### PR TITLE
Fix unhandled exceptions #3

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -49,6 +49,7 @@ proc runP2pTests() =
       "test_enode",
       "test_shh",
       "test_shh_connect",
+      "test_failing_handler",
     ]:
     runTest("tests/p2p/" & filename)
 

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -1170,6 +1170,9 @@ proc disconnect*(peer: Peer, reason: DisconnectionReason, notifyOtherPeer = fals
     try:
       if not peer.dispatcher.isNil:
         await callDisconnectHandlers(peer, reason)
+    except:
+      error "Exception in callDisconnectHandlers()",
+            err = getCurrentExceptionMsg()
     finally:
       logDisconnectedPeer peer
       peer.connectionState = Disconnected

--- a/tests/p2p/p2p_test_helper.nim
+++ b/tests/p2p/p2p_test_helper.nim
@@ -1,0 +1,34 @@
+import
+  unittest, chronos, eth/[keys, p2p], eth/p2p/[discovery, enode]
+
+var nextPort = 30303
+
+proc localAddress(port: int): Address =
+  let port = Port(port)
+  result = Address(udpPort: port, tcpPort: port, ip: parseIpAddress("127.0.0.1"))
+
+proc startDiscoveryNode(privKey: PrivateKey, address: Address,
+                        bootnodes: seq[ENode]): Future[DiscoveryProtocol] {.async.} =
+  result = newDiscoveryProtocol(privKey, address, bootnodes)
+  result.open()
+  await result.bootstrap()
+
+proc setupBootNode*(): Future[ENode] {.async.} =
+  let
+    bootNodeKey = newPrivateKey()
+    bootNodeAddr = localAddress(30301)
+    bootNode = await startDiscoveryNode(bootNodeKey, bootNodeAddr, @[])
+  result = initENode(bootNodeKey.getPublicKey, bootNodeAddr)
+
+proc setupTestNode*(capabilities: varargs[ProtocolInfo, `protocolInfo`]): EthereumNode =
+  let keys1 = newKeyPair()
+  result = newEthereumNode(keys1, localAddress(nextPort), 1, nil,
+                           addAllCapabilities = false)
+  nextPort.inc
+  for capability in capabilities:
+    result.addCapability capability
+
+template asyncTest*(name, body: untyped) =
+  test name:
+    proc scenario {.async.} = body
+    waitFor scenario()

--- a/tests/p2p/test_failing_handler.nim
+++ b/tests/p2p/test_failing_handler.nim
@@ -8,31 +8,8 @@
 #            MIT license (LICENSE-MIT)
 
 import
-  unittest, tables, chronos, eth/[keys, p2p], eth/p2p/[discovery, enode]
-
-var nextPort = 30303
-
-proc localAddress(port: int): Address =
-  let port = Port(port)
-  result = Address(udpPort: port, tcpPort: port, ip: parseIpAddress("127.0.0.1"))
-
-proc startDiscoveryNode(privKey: PrivateKey, address: Address,
-                        bootnodes: seq[ENode]): Future[DiscoveryProtocol] {.async.} =
-  result = newDiscoveryProtocol(privKey, address, bootnodes)
-  result.open()
-  await result.bootstrap()
-
-proc setupBootNode(): Future[ENode] {.async.} =
-  let
-    bootNodeKey = newPrivateKey()
-    bootNodeAddr = localAddress(30301)
-    bootNode = await startDiscoveryNode(bootNodeKey, bootNodeAddr, @[])
-  result = initENode(bootNodeKey.getPublicKey, bootNodeAddr)
-
-template asyncTest(name, body: untyped) =
-  test name:
-    proc scenario {.async.} = body
-    waitFor scenario()
+  unittest, tables, chronos, eth/p2p,
+  ./p2p_test_helper
 
 type
   network = ref object
@@ -48,7 +25,7 @@ p2pProtocol abc(version = 1,
   onPeerDisconnected do (peer: Peer, reason: DisconnectionReason) {.gcsafe.}:
     peer.networkState.count -= 1
     if true:
-      raise newException(UnsupportedProtocol, "Fake abc exception")
+      raise newException(CatchableError, "Fake abc exception")
 
 p2pProtocol xyz(version = 1,
                 shortName = "xyz",
@@ -60,21 +37,13 @@ p2pProtocol xyz(version = 1,
   onPeerDisconnected do (peer: Peer, reason: DisconnectionReason) {.gcsafe.}:
     peer.networkState.count -= 1
     if true:
-      raise newException(UnsupportedProtocol, "Fake xyz exception")
+      raise newException(CatchableError, "Fake xyz exception")
 
-proc prepTestNode(): EthereumNode =
-  let keys1 = newKeyPair()
-  result = newEthereumNode(keys1, localAddress(nextPort), 1, nil,
-                           addAllCapabilities = false)
-  nextPort.inc
-  result.addCapability abc
-  result.addCapability xyz
-
-suite "Failing handlers":
+suite "Testing protocol handlers":
   asyncTest "Failing disconnect handler":
     let bootENode = waitFor setupBootNode()
-    var node1 = prepTestNode()
-    var node2 = prepTestNode()
+    var node1 = setupTestNode(abc, xyz)
+    var node2 = setupTestNode(abc, xyz)
     # node2 listening and node1 not, to avoid many incoming vs outgoing
     var node1Connected = node1.connectToNetwork(@[bootENode], false, true)
     var node2Connected = node2.connectToNetwork(@[bootENode], true, true)

--- a/tests/p2p/test_failing_handler.nim
+++ b/tests/p2p/test_failing_handler.nim
@@ -1,0 +1,93 @@
+#
+#                 Ethereum P2P
+#              (c) Copyright 2018
+#       Status Research & Development GmbH
+#
+#            Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#            MIT license (LICENSE-MIT)
+
+import
+  unittest, tables, chronos, eth/[keys, p2p], eth/p2p/[discovery, enode]
+
+var nextPort = 30303
+
+proc localAddress(port: int): Address =
+  let port = Port(port)
+  result = Address(udpPort: port, tcpPort: port, ip: parseIpAddress("127.0.0.1"))
+
+proc startDiscoveryNode(privKey: PrivateKey, address: Address,
+                        bootnodes: seq[ENode]): Future[DiscoveryProtocol] {.async.} =
+  result = newDiscoveryProtocol(privKey, address, bootnodes)
+  result.open()
+  await result.bootstrap()
+
+proc setupBootNode(): Future[ENode] {.async.} =
+  let
+    bootNodeKey = newPrivateKey()
+    bootNodeAddr = localAddress(30301)
+    bootNode = await startDiscoveryNode(bootNodeKey, bootNodeAddr, @[])
+  result = initENode(bootNodeKey.getPublicKey, bootNodeAddr)
+
+template asyncTest(name, body: untyped) =
+  test name:
+    proc scenario {.async.} = body
+    waitFor scenario()
+
+type
+  network = ref object
+    count*: int
+
+p2pProtocol abc(version = 1,
+                shortName = "abc",
+                networkState = network):
+
+  onPeerConnected do (peer: Peer):
+    peer.networkState.count += 1
+
+  onPeerDisconnected do (peer: Peer, reason: DisconnectionReason) {.gcsafe.}:
+    peer.networkState.count -= 1
+    if true:
+      raise newException(UnsupportedProtocol, "Fake abc exception")
+
+p2pProtocol xyz(version = 1,
+                shortName = "xyz",
+                networkState = network):
+
+  onPeerConnected do (peer: Peer):
+    peer.networkState.count += 1
+
+  onPeerDisconnected do (peer: Peer, reason: DisconnectionReason) {.gcsafe.}:
+    peer.networkState.count -= 1
+    if true:
+      raise newException(UnsupportedProtocol, "Fake xyz exception")
+
+proc prepTestNode(): EthereumNode =
+  let keys1 = newKeyPair()
+  result = newEthereumNode(keys1, localAddress(nextPort), 1, nil,
+                           addAllCapabilities = false)
+  nextPort.inc
+  result.addCapability abc
+  result.addCapability xyz
+
+suite "Failing handlers":
+  asyncTest "Failing disconnect handler":
+    let bootENode = waitFor setupBootNode()
+    var node1 = prepTestNode()
+    var node2 = prepTestNode()
+    # node2 listening and node1 not, to avoid many incoming vs outgoing
+    var node1Connected = node1.connectToNetwork(@[bootENode], false, true)
+    var node2Connected = node2.connectToNetwork(@[bootENode], true, true)
+    waitFor node1Connected
+    waitFor node2Connected
+    check:
+      node1.peerPool.connectedNodes.len() == 1
+      node2.peerPool.connectedNodes.len() == 1
+
+    for peer in node1.peers():
+      waitFor peer.disconnect(SubprotocolReason, true)
+    check:
+      # we want to check that even though the exceptions in the disconnect
+      # handlers, each handler still ran
+      node1.protocolState(abc).count == 0
+      node1.protocolState(xyz).count == 0


### PR DESCRIPTION
Fixes the two issues mentioned in #3 .

The reason as to why the message `dispatchMessages failed` would not always occur is because it happens in the last test and sometimes that code simply did not run before the test finished. Adding an `asyncSleep` of several ms to the test will make it happen always.

I'm also thinking of reworking the `rlpxConnect` and `rlpxAccept` to make them both behave the same in terms of returning a "failing" Future. But I didn't want to do those changes in this PR as impact will be a little bit bigger.



