### PR TITLE
Make the APIs compatible with libp2p

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -13,7 +13,8 @@ requires "nim >= 0.19.0",
          "rocksdb",
          "package_visible_types",
          "chronos",
-         "chronicles"
+         "chronicles",
+         "std_shims"
 
 import strutils
 import oswalkdir, ospaths # In newer nim these are merged to os

--- a/eth/p2p/p2p_backends_helpers.nim
+++ b/eth/p2p/p2p_backends_helpers.nim
@@ -1,0 +1,66 @@
+proc getState(peer: Peer, proto: ProtocolInfo): RootRef =
+  peer.protocolStates[proto.index]
+
+template state*(peer: Peer, Protocol: type): untyped =
+  ## Returns the state object of a particular protocol for a
+  ## particular connection.
+  mixin State
+  bind getState
+  cast[Protocol.State](getState(peer, Protocol.protocolInfo))
+
+proc getNetworkState(node: EthereumNode, proto: ProtocolInfo): RootRef =
+  node.protocolStates[proto.index]
+
+template protocolState*(node: EthereumNode, Protocol: type): untyped =
+  mixin NetworkState
+  bind getNetworkState
+  cast[Protocol.NetworkState](getNetworkState(node, Protocol.protocolInfo))
+
+template networkState*(connection: Peer, Protocol: type): untyped =
+  ## Returns the network state object of a particular protocol for a
+  ## particular connection.
+  protocolState(connection.network, Protocol)
+
+proc initProtocolState*[T](state: T, x: Peer|EthereumNode) {.gcsafe.} = discard
+
+proc createPeerState[ProtocolState](peer: Peer): RootRef =
+  var res = new ProtocolState
+  mixin initProtocolState
+  initProtocolState(res, peer)
+  return cast[RootRef](res)
+
+proc createNetworkState[NetworkState](network: EthereumNode): RootRef {.gcsafe.} =
+  var res = new NetworkState
+  mixin initProtocolState
+  initProtocolState(res, network)
+  return cast[RootRef](res)
+
+proc chooseFieldType(n: NimNode): NimNode =
+  ## Examines the parameter types used in the message signature
+  ## and selects the corresponding field type for use in the
+  ## message object type (i.e. `p2p.hello`).
+  ##
+  ## For now, only openarray types are remapped to sequences.
+  result = n
+  if n.kind == nnkBracketExpr and eqIdent(n[0], "openarray"):
+    result = n.copyNimTree
+    result[0] = ident("seq")
+
+proc popTimeoutParam(n: NimNode): NimNode =
+  var lastParam = n.params[^1]
+  if eqIdent(lastParam[0], "timeout"):
+    if lastParam[2].kind == nnkEmpty:
+      macros.error "You must specify a default value for the `timeout` parameter", lastParam
+    result = lastParam
+    n.params.del(n.params.len - 1)
+
+proc verifyStateType(t: NimNode): NimNode =
+  result = t[1]
+  if result.kind == nnkSym and $result == "nil":
+    return nil
+  if result.kind != nnkBracketExpr or $result[0] != "ref":
+    macros.error($result & " must be a ref type")
+
+proc newFuture[T](location: var Future[T]) =
+  location = newFuture[T]()
+

--- a/eth/p2p/private/p2p_types.nim
+++ b/eth/p2p/private/p2p_types.nim
@@ -170,3 +170,9 @@ type
     MessageTimeout,
     SubprotocolReason = 0x10
 
+  ResponseWithId*[MsgType] = object
+    peer*: Peer
+    id*: int
+
+  Response*[MsgType] = distinct Peer
+

--- a/eth/p2p/rlpx_protocols/eth_protocol.nim
+++ b/eth/p2p/rlpx_protocols/eth_protocol.nim
@@ -80,7 +80,7 @@ p2pProtocol eth(version = protocolVersion,
         await peer.disconnect(BreachOfProtocol)
         return
 
-      await peer.blockHeaders(peer.network.chain.getBlockHeaders(request))
+      await response.send(peer.network.chain.getBlockHeaders(request))
 
     proc blockHeaders(p: Peer, headers: openarray[BlockHeader])
 
@@ -90,7 +90,7 @@ p2pProtocol eth(version = protocolVersion,
         await peer.disconnect(BreachOfProtocol)
         return
 
-      await peer.blockBodies(peer.network.chain.getBlockBodies(hashes))
+      await response.send(peer.network.chain.getBlockBodies(hashes))
 
     proc blockBodies(peer: Peer, blocks: openarray[BlockBody])
 
@@ -101,13 +101,13 @@ p2pProtocol eth(version = protocolVersion,
 
   requestResponse:
     proc getNodeData(peer: Peer, hashes: openarray[KeccakHash]) =
-      await peer.nodeData(peer.network.chain.getStorageNodes(hashes))
+      await response.send(peer.network.chain.getStorageNodes(hashes))
 
     proc nodeData(peer: Peer, data: openarray[Blob])
 
   requestResponse:
     proc getReceipts(peer: Peer, hashes: openarray[KeccakHash]) =
-      await peer.receipts(peer.network.chain.getReceipts(hashes))
+      await response.send(peer.network.chain.getReceipts(hashes))
 
     proc receipts(peer: Peer, receipts: openarray[Receipt])
 

--- a/eth/p2p/rlpx_protocols/les_protocol.nim
+++ b/eth/p2p/rlpx_protocols/les_protocol.nim
@@ -287,7 +287,7 @@ p2pProtocol les(version = lesVersion,
            costQuantity(req.maxResults.int, max = maxHeadersFetch).} =
 
       let headers = peer.network.chain.getBlockHeaders(req)
-      await peer.blockHeaders(reqId, updateBV(), headers)
+      await response.send(updateBV(), headers)
 
     proc blockHeaders(
            peer: Peer,
@@ -304,7 +304,7 @@ p2pProtocol les(version = lesVersion,
            costQuantity(blocks.len, max = maxBodiesFetch), gcsafe.} =
 
       let blocks = peer.network.chain.getBlockBodies(blocks)
-      await peer.blockBodies(reqId, updateBV(), blocks)
+      await response.send(updateBV(), blocks)
 
     proc blockBodies(
            peer: Peer,
@@ -318,7 +318,7 @@ p2pProtocol les(version = lesVersion,
            {.costQuantity(hashes.len, max = maxReceiptsFetch).} =
 
       let receipts = peer.network.chain.getReceipts(hashes)
-      await peer.receipts(reqId, updateBV(), receipts)
+      await response.send(updateBV(), receipts)
 
     proc receipts(
            peer: Peer,
@@ -332,7 +332,7 @@ p2pProtocol les(version = lesVersion,
            costQuantity(proofs.len, max = maxProofsFetch).} =
 
       let proofs = peer.network.chain.getProofs(proofs)
-      await peer.proofs(reqId, updateBV(), proofs)
+      await response.send(updateBV(), proofs)
 
     proc proofs(
            peer: Peer,
@@ -346,7 +346,7 @@ p2pProtocol les(version = lesVersion,
            costQuantity(reqs.len, max = maxCodeFetch).} =
 
       let results = peer.network.chain.getContractCodes(reqs)
-      await peer.contractCodes(reqId, updateBV(), results)
+      await response.send(updateBV(), results)
 
     proc contractCodes(
            peer: Peer,
@@ -362,7 +362,7 @@ p2pProtocol les(version = lesVersion,
            costQuantity(reqs.len, max = maxHeaderProofsFetch).} =
 
       let proofs = peer.network.chain.getHeaderProofs(reqs)
-      await peer.headerProofs(reqId, updateBV(), proofs)
+      await response.send(updateBV(), proofs)
 
     proc headerProofs(
            peer: Peer,
@@ -377,7 +377,7 @@ p2pProtocol les(version = lesVersion,
 
       var nodes, auxData: seq[Blob]
       peer.network.chain.getHelperTrieProofs(reqs, nodes, auxData)
-      await peer.helperTrieProofs(reqId, updateBV(), nodes, auxData)
+      await response.send(updateBV(), nodes, auxData)
 
     proc helperTrieProofs(
            peer: Peer,
@@ -409,7 +409,7 @@ p2pProtocol les(version = lesVersion,
 
         results.add s
 
-      await peer.txStatus(reqId, updateBV(), results)
+      await response.send(updateBV(), results)
 
     proc getTxStatus(
            peer: Peer,
@@ -421,7 +421,7 @@ p2pProtocol les(version = lesVersion,
       var results: seq[TransactionStatusMsg]
       for t in transactions:
         results.add chain.getTransactionStatus(t.rlpHash)
-      await peer.txStatus(reqId, updateBV(), results)
+      await response.send(updateBV(), results)
 
     proc txStatus(
            peer: Peer,


### PR DESCRIPTION
Lib2P2 handles RPC requests and responses with separate streams
while DEV2P2 is relying on tagged messages transmitted over a
single stream. To cover both models through the same application
code, we introduce a new `response` variable in the request handlers.
The user is supposed to issue a call to `response.send` in order to
reply to the request. Please note that the `response.send` signature
is strongly typed and depends on the current message.