### PR TITLE
Add powTarget and other changes for Whisper RPC implementation

### DIFF
--- a/eth/p2p/rlpx_protocols/whisper_protocol.nim
+++ b/eth/p2p/rlpx_protocols/whisper_protocol.nim
@@ -24,7 +24,7 @@ const
   defaultFilterQueueCapacity = 64
   whisperVersion* = 6
   whisperVersionStr* = "6.0"
-  defaultMinPow* = 0.001'f64
+  defaultMinPow* = 0.2'f64
   defaultMaxMsgSize* = 1024'u32 * 1024'u32 # * 10 # should be no higher than max RLPx size
   messageInterval* = 300 ## Interval at which messages are send to peers, in ms
   pruneInterval* = 1000 ## Interval at which message queue is pruned, in ms

--- a/eth/p2p/rlpx_protocols/whisper_protocol.nim
+++ b/eth/p2p/rlpx_protocols/whisper_protocol.nim
@@ -607,6 +607,8 @@ proc notify*(filters: var Filters, msg: Message) {.gcsafe.} =
    if decoded.isNone():
      decoded = decode(msg.env.data, dst = filter.privateKey,
                       symKey = filter.symKey)
+     if decoded.isNone():
+       continue
      if filter.privateKey.isSome():
        keyHash = keccak256.digest(filter.privateKey.get().data)
        # TODO: Get rid of the hash and just use pubkey to compare?
@@ -615,8 +617,6 @@ proc notify*(filters: var Filters, msg: Message) {.gcsafe.} =
        keyHash = keccak256.digest(filter.symKey.get())
      # else:
        # NOTE: should we error on messages without encryption?
-     if decoded.isNone():
-       continue
    else:
      if filter.privateKey.isSome():
        if keyHash != keccak256.digest(filter.privateKey.get().data):

--- a/tests/p2p/test_shh.nim
+++ b/tests/p2p/test_shh.nim
@@ -22,6 +22,7 @@ suite "Whisper payload":
     check:
       decoded.isSome()
       payload.payload == decoded.get().payload
+      decoded.get().src.isNone()
       decoded.get().padding.get().len == 251 # 256 -1 -1 -3
 
   test "should roundtrip with symmetric encryption":
@@ -33,6 +34,7 @@ suite "Whisper payload":
     check:
       decoded.isSome()
       payload.payload == decoded.get().payload
+      decoded.get().src.isNone()
       decoded.get().padding.get().len == 251 # 256 -1 -1 -3
 
   test "should roundtrip with signature":
@@ -59,6 +61,7 @@ suite "Whisper payload":
     check:
       decoded.isSome()
       payload.payload == decoded.get().payload
+      decoded.get().src.isNone()
       decoded.get().padding.get().len == 251 # 256 -1 -1 -3
 
   test "should return specified bloom":
@@ -299,7 +302,10 @@ suite "Whisper filter":
     notify(filters, msg)
 
     let messages = filters.getFilterMessages(filterId)
-    check messages.len == 1
+    check:
+      messages.len == 1
+      messages[0].decoded.src.isNone()
+      messages[0].dst.isNone()
 
   test "should notify filter on message with asymmetric encryption":
     let privKey = keys.newPrivateKey()
@@ -314,7 +320,10 @@ suite "Whisper filter":
     notify(filters, msg)
 
     let messages = filters.getFilterMessages(filterId)
-    check messages.len == 1
+    check:
+      messages.len == 1
+      messages[0].decoded.src.isNone()
+      messages[0].dst.isSome()
 
   test "should notify filter on message with signature":
     let privKey = keys.newPrivateKey()
@@ -329,7 +338,10 @@ suite "Whisper filter":
     notify(filters, msg)
 
     let messages = filters.getFilterMessages(filterId)
-    check messages.len == 1
+    check:
+      messages.len == 1
+      messages[0].decoded.src.isSome()
+      messages[0].dst.isNone()
 
   test "test notify of filter against PoW requirement":
     let topic = [byte 0, 0, 0, 0]

--- a/tests/p2p/test_shh.nim
+++ b/tests/p2p/test_shh.nim
@@ -336,14 +336,16 @@ suite "Whisper filter":
     let padding = some(repeat(byte 0, 251))
     # this message has a PoW of 0.02962962962962963, number should be updated
     # in case PoW algorithm changes or contents of padding, payload, topic, etc.
+    # update: now with NON rlp encoded envelope size the PoW of this message is
+    # 0.02898550724637681
     let msg = prepFilterTestMsg(topic = topic, padding = padding)
 
     var filters = initTable[string, Filter]()
     let
       filterId1 = filters.subscribeFilter(
-                    newFilter(topics = @[topic], powReq = 0.02962962962962963))
+                    newFilter(topics = @[topic], powReq = 0.02898550724637681))
       filterId2 = filters.subscribeFilter(
-                    newFilter(topics = @[topic], powReq = 0.02962962962962964))
+                    newFilter(topics = @[topic], powReq = 0.02898550724637682))
 
     notify(filters, msg)
 

--- a/tests/p2p/test_shh_connect.nim
+++ b/tests/p2p/test_shh_connect.nim
@@ -18,6 +18,7 @@ proc resetMessageQueues(nodes: varargs[EthereumNode]) =
 
 let bootENode = waitFor setupBootNode()
 let safeTTL = 5'u32
+let waitInterval = messageInterval + 150
 
 var node1 = setupTestNode(Whisper)
 var node2 = setupTestNode(Whisper)
@@ -97,7 +98,7 @@ suite "Whisper connections":
       node2.protocolState(Whisper).queue.items.len == 4
 
     var f = all(futures)
-    await f or sleepAsync(messageInterval)
+    await f or sleepAsync(waitInterval)
     check:
       f.finished == true
       node1.protocolState(Whisper).queue.items.len == 4
@@ -130,7 +131,7 @@ suite "Whisper connections":
       node2.protocolState(Whisper).queue.items.len == 2
 
     var f = all(futures)
-    await f or sleepAsync(messageInterval)
+    await f or sleepAsync(waitInterval)
     check:
       f.finished == true
       node1.protocolState(Whisper).queue.items.len == 2
@@ -159,8 +160,8 @@ suite "Whisper connections":
     check:
       node2.postMessage(ttl = safeTTL, topic = topic, payload = payload) == true
 
-    await futures[0] or sleepAsync(messageInterval)
-    await futures[1] or sleepAsync(messageInterval)
+    await futures[0] or sleepAsync(waitInterval)
+    await futures[1] or sleepAsync(waitInterval)
     check:
       futures[0].finished == true
       futures[1].finished == false
@@ -180,7 +181,7 @@ suite "Whisper connections":
       check node2.postMessage(ttl = safeTTL, topic = topic,
                               payload = payload) == true
 
-    await sleepAsync(messageInterval)
+    await sleepAsync(waitInterval)
     check:
       node1.getFilterMessages(filter).len() == 10
       node1.getFilterMessages(filter).len() == 0
@@ -198,7 +199,7 @@ suite "Whisper connections":
       node1.getFilterMessages(filter).len() == 1
       node1.unsubscribeFilter(filter) == true
 
-    await sleepAsync(messageInterval)
+    await sleepAsync(waitInterval)
     resetMessageQueues(node1, node2)
 
   asyncTest "Bloomfilter blocking":
@@ -218,7 +219,7 @@ suite "Whisper connections":
                         payload = payload) == true
       node2.protocolState(Whisper).queue.items.len == 1
 
-    await f or sleepAsync(messageInterval)
+    await f or sleepAsync(waitInterval)
     check:
       f.finished == false
       node1.protocolState(Whisper).queue.items.len == 0
@@ -232,7 +233,7 @@ suite "Whisper connections":
                         payload = payload) == true
       node2.protocolState(Whisper).queue.items.len == 1
 
-    await f or sleepAsync(messageInterval)
+    await f or sleepAsync(waitInterval)
     check:
       f.finished == true
       f.read() == 1
@@ -252,7 +253,7 @@ suite "Whisper connections":
     check:
       node2.postMessage(ttl = safeTTL, topic = topic, payload = payload) == true
       node2.protocolState(Whisper).queue.items.len == 1
-    await sleepAsync(messageInterval)
+    await sleepAsync(waitInterval)
     check:
       node1.protocolState(Whisper).queue.items.len == 0
 
@@ -262,7 +263,7 @@ suite "Whisper connections":
     check:
       node2.postMessage(ttl = safeTTL, topic = topic, payload = payload) == true
       node2.protocolState(Whisper).queue.items.len == 1
-    await sleepAsync(messageInterval)
+    await sleepAsync(waitInterval)
     check:
       node1.protocolState(Whisper).queue.items.len == 1
 
@@ -279,7 +280,7 @@ suite "Whisper connections":
       check node2.postMessage(ttl = lowerTTL, topic = topic, payload = payload) == true
     check node2.protocolState(Whisper).queue.items.len == 10
 
-    await sleepAsync(messageInterval)
+    await sleepAsync(waitInterval)
     check node1.protocolState(Whisper).queue.items.len == 10
 
     await sleepAsync(int((lowerTTL+1)*1000))
@@ -303,7 +304,7 @@ suite "Whisper connections":
                         payload = repeat(byte 4, 10),
                         targetPeer = some(toNodeId(node1.keys.pubkey))) == true
 
-    await f or sleepAsync(messageInterval)
+    await f or sleepAsync(waitInterval)
     check:
       f.finished == true
       f.read() == 1


### PR DESCRIPTION
PR with some changes for upcoming Whisper RPC PR.

Biggest change is adding the option of `powTarget` so that you don't always need to wait for `powTime`. This is an option in the `shh_post` RPC call.

Annoyingly, this does violate the Whisper EIP in its current implementation (so does geth by the way, I understand now why). I think in general it would be better if Whisper is not RLP depended. However the PoW hash is still RLP depended so this does not really resolve that...

Nice side effect is that testing time of test_shh_connect.nim dropped ~30 seconds.

By the way, I would perhaps move `generateRandomID ` to somewhere more "common", e.g.  `nim-eth/eth/common/utils.nim`?
