### PR TITLE
Bug/fix transport leaks #37

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -51,7 +51,7 @@ proc runP2pTests() =
       "test_enode",
       "test_shh",
       "test_shh_connect",
-      "test_failing_handler",
+      "test_protocol_handlers",
     ]:
     runTest("tests/p2p/" & filename)
 

--- a/eth/p2p.nim
+++ b/eth/p2p.nim
@@ -76,8 +76,6 @@ proc processIncoming(server: StreamServer,
         # malicious peer opens multiple connections
         debug "Disconnecting peer (incoming)", reason = AlreadyConnected
         await peer.disconnect(AlreadyConnected)
-  else:
-    remote.close()
 
 proc listeningAddress*(node: EthereumNode): ENode =
   return initENode(node.keys.pubKey, node.address)

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -511,22 +511,34 @@ proc nextMsg*(peer: Peer, MsgType: type): Future[MsgType] =
 # handled a layer lower for clarity (and consistency), as also the actual
 # message handler code as the TODO mentions already.
 proc dispatchMessages*(peer: Peer) {.async.} =
-  while true:
+  while peer.connectionState notin {Disconnecting, Disconnected}:
     var msgId: int
     var msgData: Rlp
     try:
       (msgId, msgData) = await peer.recvMsg()
     except TransportIncompleteError:
-      trace "Connection dropped, ending dispatchMessages loop", peer
-      # This can happen during the rlpx connection setup or at any point after.
-      # Because this code does not know, a disconnect needs to be done.
-      await peer.disconnect(ClientQuitting)
+      # Note: Could also "Transport is already closed!" error occur? Might have
+      # to change here to the general TransportError.
+      case peer.connectionState
+      of Connected:
+        # Dropped connection, still need to cleanup the peer.
+        # This could be seen as bad behaving peer.
+        trace "Dropped connection", peer
+        await peer.disconnect(ClientQuitting, false)
+        return
+      of Disconnecting, Disconnected:
+        # Graceful disconnect, can still cause TransportIncompleteError as it
+        # could be that this loop was waiting at recvMsg().
+        return
+      else:
+        # Connection dropped while `Connecting` (in rlpxConnect/rlpxAccept).
+        return
+    except PeerDisconnected:
       return
 
     if msgId == 1: # p2p.disconnect
-      await peer.transport.closeWait()
       let reason = msgData.listElem(0).toInt(uint32).DisconnectionReason
-      await peer.disconnect(reason)
+      await peer.disconnect(reason, false)
       break
 
     try:
@@ -1176,17 +1188,28 @@ macro handshake*(peer: Peer, timeout: untyped, sendCall: untyped): untyped =
 proc disconnect*(peer: Peer, reason: DisconnectionReason, notifyOtherPeer = false) {.async.} =
   if peer.connectionState notin {Disconnecting, Disconnected}:
     peer.connectionState = Disconnecting
-    if notifyOtherPeer and not peer.transport.closed:
-      var fut = peer.sendDisconnectMsg(reason)
-      yield fut
-      if fut.failed:
-        debug "Failed to delived disconnect message", peer
-
+    # Do this first so sub-protocols have time to clean up and stop sending
+    # before this node closes transport to remote peer
     if not peer.dispatcher.isNil:
       # In case of `CatchableError` in any of the handlers, this will be logged.
       # Other handlers will still execute.
       # In case of `Defect` in any of the handlers, program will quit.
       traceAwaitErrors callDisconnectHandlers(peer, reason)
+
+    if notifyOtherPeer and not peer.transport.closed:
+      var fut = peer.sendDisconnectMsg(reason)
+      yield fut
+      if fut.failed:
+        debug "Failed to deliver disconnect message", peer
+
+      proc waitAndClose(peer: Peer, time: Duration) {.async.} =
+        await sleepAsync(time)
+        await peer.transport.closeWait()
+
+      # Give the peer a chance to disconnect
+      await peer.waitAndClose(2.seconds)
+    elif not peer.transport.closed:
+      await peer.transport.closeWait()
 
     logDisconnectedPeer peer
     peer.connectionState = Disconnected

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -1207,9 +1207,9 @@ proc disconnect*(peer: Peer, reason: DisconnectionReason, notifyOtherPeer = fals
         await peer.transport.closeWait()
 
       # Give the peer a chance to disconnect
-      await peer.waitAndClose(2.seconds)
+      traceAsyncErrors peer.waitAndClose(2.seconds)
     elif not peer.transport.closed:
-      await peer.transport.closeWait()
+      peer.transport.close()
 
     logDisconnectedPeer peer
     peer.connectionState = Disconnected


### PR DESCRIPTION
Proposal PR for fixing #37 

Transport close is now done either in:
- `disconnect()`: in case in Connected state
- `rlpxConnect` or `rlpxAccept`: in case of failure before Connected state 

`dispatchMessages` loop needed some logic to differentiate these situations. Including the one where a connection is dropped from the other side.

I decided not to use an `AsycEvent` in the end (was one of the suggestions) because:
1. It is not necessary, we can check `connectionState`
2. I feel that then we should use more Events to be consitent. E.g. also when `Connecting` fails, or when sending of messages could fail due to a `disconnect` or dropped connect.

It does have as drawback that now the `await peer.recvMsg()` will have to wait until `TransportIncompleteError` in case it happens to be at that point in the loop when a `disconnect` is done. 

It could be that we now see "broken pipe" or "Transport is already closed" errors again, e.g. when a send would be done after transport closure (this was before also possible, it is just that transport were not getting closed :) ). To be monitored...