### PR TITLE
Quick fix for overflow on 32bit systems

### DIFF
--- a/eth/p2p/rlpx_protocols/les/flow_control.nim
+++ b/eth/p2p/rlpx_protocols/les/flow_control.nim
@@ -175,9 +175,8 @@ proc updateRechargingParams(peer: LesPeer, network: LesNetwork) =
     peer.reqCostGradient = rechargingScale / network.reqCount
 
   if peer.isRecharging:
-    peer.reqCostGradient = (network.rechargingRate * peer.rechargingPower /
-                                    network.totalRechargingPower          )
-
+    peer.reqCostGradient = (network.rechargingRate * (peer.rechargingPower /
+                                    network.totalRechargingPower).int64).int
     peer.rechargingEndsAt = peer.lastRechargeTime +
                             LesTime(peer.reqCostVal * rechargingScale /
                                          -peer.reqCostGradient        )
@@ -263,8 +262,8 @@ proc delistFromFlowControl*(network: LesNetwork, peer: LesPeer) =
 proc initFlowControl*(network: LesNetwork, les: ProtocolInfo,
                       maxReqCount, maxReqCostSum, reqCostTarget: int,
                       db: AbstractChainDB = nil) =
-  network.rechargingRate = (rechargingScale * rechargingScale) /
-                           (100 * rechargingScale / reqCostTarget - rechargingScale)
+  network.rechargingRate = rechargingScale * (rechargingScale /
+                           (100 * rechargingScale / reqCostTarget - rechargingScale))
   network.maxReqCount = maxReqCount
   network.maxReqCostSum = maxReqCostSum
 

--- a/eth/p2p/rlpx_protocols/les/private/les_types.nim
+++ b/eth/p2p/rlpx_protocols/les/private/les_types.nim
@@ -85,7 +85,7 @@ type
     reqCount*, maxReqCount*: int
     sumWeigth*: int
 
-    rechargingRate*: int
+    rechargingRate*: int64
     totalRechargedUnits*: int
     totalRechargingPower*: int
 


### PR DESCRIPTION
As said quick fix, might still get `RangeError` on that int cast with certain selected values I'd guess.

Better would be to properly min/max/etc. the calculus to sane values. Problem is that I don't know what sane is in this flow control algorithm. There are e.g. also several div by 0 possible with certain values.