### PR TITLE
Fix to only allow sync for peer with eth support

### DIFF
--- a/eth/p2p/blockchain_sync.nim
+++ b/eth/p2p/blockchain_sync.nim
@@ -331,10 +331,12 @@ proc onPeerDisconnected(ctx: SyncContext, p: Peer) =
 proc startSync(ctx: SyncContext) =
   var po: PeerObserver
   po.onPeerConnected = proc(p: Peer) {.gcsafe.} =
-    ctx.onPeerConnected(p)
+    if p.supports(eth):
+      ctx.onPeerConnected(p)
 
   po.onPeerDisconnected = proc(p: Peer) {.gcsafe.} =
-    ctx.onPeerDisconnected(p)
+    if p.supports(eth):
+      ctx.onPeerDisconnected(p)
 
   ctx.peerPool.addObserver(ctx, po)
 

--- a/eth/p2p/blockchain_sync.nim
+++ b/eth/p2p/blockchain_sync.nim
@@ -331,13 +331,12 @@ proc onPeerDisconnected(ctx: SyncContext, p: Peer) =
 proc startSync(ctx: SyncContext) =
   var po: PeerObserver
   po.onPeerConnected = proc(p: Peer) {.gcsafe.} =
-    if p.supports(eth):
-      ctx.onPeerConnected(p)
+    ctx.onPeerConnected(p)
 
   po.onPeerDisconnected = proc(p: Peer) {.gcsafe.} =
-    if p.supports(eth):
-      ctx.onPeerDisconnected(p)
+    ctx.onPeerDisconnected(p)
 
+  po.setProtocol eth
   ctx.peerPool.addObserver(ctx, po)
 
 proc findBestPeer(node: EthereumNode): (Peer, DifficultyInt) =

--- a/eth/p2p/private/p2p_types.nim
+++ b/eth/p2p/private/p2p_types.nim
@@ -59,6 +59,7 @@ type
   PeerObserver* = object
     onPeerConnected*: proc(p: Peer) {.gcsafe.}
     onPeerDisconnected*: proc(p: Peer) {.gcsafe.}
+    protocol*: ProtocolInfo
 
   Capability* = object
     name*: string


### PR DESCRIPTION
This is to fix a crash that occurs when connecting to a node that does not support the eth sub-protocol. E.g. a node that only supports whisper.

Following stacktrace would occur:
```
Traceback (most recent call last)
nimbus.nim(147)          nimbus
nimbus.nim(126)          process
asyncloop.nim(266)       poll
asyncmacro2.nim(36)      connectToNode_continue
peer_pool.nim(119)       connectToNodeIter
peer_pool.nim(111)       addPeer
blockchain_sync.nim(334) :anonymous
blockchain_sync.nim(317) onPeerConnected
asyncmacro2.nim(306)     startSyncWithPeer
asyncmacro2.nim(36)      startSyncWithPeer_continue
blockchain_sync.nim(293) startSyncWithPeerIter
asyncmacro2.nim(306)     peersAgreeOnChain
asyncmacro2.nim(36)      peersAgreeOnChain_continue
p2p_backends_helpers.nim(9) peersAgreeOnChainIter
uint_public.nim(56)      <
uint_comparison.nim(20)  <
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```
This is because the `eth.state` is being accessed when doing the sync.
