### PR TITLE
Add several checks for currently unhandled errors

### DIFF
--- a/eth/p2p/discovery.nim
+++ b/eth/p2p/discovery.nim
@@ -229,13 +229,13 @@ proc recvFindNode(d: DiscoveryProtocol, node: Node, payload: Bytes) {.inline, gc
 proc expirationValid(cmdId: CommandId, rlpEncodedPayload: seq[byte]):
     bool {.inline, raises:[DiscProtocolError, RlpError].} =
   ## Can only raise `DiscProtocolError` and all of `RlpError`
-  # Check if there is a payload, TODO: perhaps this should be an RLP error?
+  # Check if there is a payload
   if rlpEncodedPayload.len <= 0:
     raise newException(DiscProtocolError, "RLP stream is empty")
   let rlp = rlpFromBytes(rlpEncodedPayload.toRange)
   # Check payload is an RLP list and if the list has the minimum items required
   # for this packet type
-  if rlp.listLen >= MinListLen[cmdId]:
+  if rlp.isList and rlp.listLen >= MinListLen[cmdId]:
     # Expiration is always the last mandatory item of the list
     let expiration = rlp.listElem(MinListLen[cmdId] - 1).toInt(uint32)
     result = epochTime() <= expiration.float

--- a/eth/rlp.nim
+++ b/eth/rlp.nim
@@ -275,7 +275,7 @@ proc listElem*(self: Rlp, i: int): Rlp =
 
 proc listLen*(self: Rlp): int =
   if not isList():
-    raise newException(RlpTypeMismatch, "List expected, but the source RLP is not a list.")
+    return 0
 
   var rlp = self
   for elem in rlp:

--- a/eth/rlp.nim
+++ b/eth/rlp.nim
@@ -26,7 +26,7 @@ type
     of rlpList:
       elems*: seq[RlpNode]
 
-  RlpError* = object of Exception
+  RlpError* = object of CatchableError
   MalformedRlpError* = object of RlpError
   UnsupportedRlpError* = object of RlpError
   RlpTypeMismatch* = object of RlpError
@@ -275,7 +275,7 @@ proc listElem*(self: Rlp, i: int): Rlp =
 
 proc listLen*(self: Rlp): int =
   if not isList():
-    return 0
+    raise newException(RlpTypeMismatch, "List expected, but the source RLP is not a list.")
 
   var rlp = self
   for elem in rlp:


### PR DESCRIPTION
Checks needed against possible `AssertionError`s being raised in discovery protocol:
- need check if there is packet-data (rlp payload)
- need check if packet-data is rlp list
- depending on packet id, need to check if minimum size of list.
- specifically for FindNode Packet, need to check if the size of target public key

Need also to check on packet id range, else `RangeError` is possible (the code would actually work correct in `-d:release`, but that is to tricky)

And need to catch all types of `RlpError`.

Don't merge yet, will still add the error cases in a test. And might rework the code somewhat also.
