### PR TITLE
Fix possible overflows in rlp

### DIFF
--- a/tests/rlp/cases/invalidRLPTest.json
+++ b/tests/rlp/cases/invalidRLPTest.json
@@ -42,5 +42,46 @@
 	"bytesShouldBeSingleByte7F": {
 		"in": "INVALID",
 		"out": "817F"
+	},
+
+	"fakelonglist": {
+		"in": "INVALID",
+		"out": "ff7fffffffffffffffff"
+	},
+
+	"fakelonglist2": {
+		"in": "INVALID",
+		"out": "ff800000000000000000"
+	},
+
+	"fakelongblob": {
+		"in": "INVALID",
+		"out": "bf7fffffffffffffffff"
+	},
+
+	"fakelongblob2": {
+		"in": "INVALID",
+		"out": "bf800000000000000000"
+	},
+
+	"fakelongblobinlist": {
+		"in": "INVALID",
+		"out": "f2bf7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	},
+
+	"fakelongblobinlist2": {
+		"in": "INVALID",
+		"out": "f2bf80000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	},
+
+	"fakelonglistinlist": {
+		"in": "INVALID",
+		"out": "f2ff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	},
+
+	"fakelonglistinlist2": {
+		"in": "INVALID",
+		"out": "f2ff80000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 	}
+
 }

--- a/tests/rlp/test_json_suite.nim
+++ b/tests/rlp/test_json_suite.nim
@@ -1,8 +1,12 @@
 import
-  os, strutils,
+  os, strutils, strformat,
   util/json_testing
 
-for file in walkDirRec("tests/cases"):
+template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
+
+const casesDir = &"{sourceDir}{DirSep}cases{DirSep}"
+
+for file in walkDirRec(casesDir):
   if file.endsWith("json"):
     runTests(file)
 

--- a/tests/rlp/util/json_testing.nim
+++ b/tests/rlp/util/json_testing.nim
@@ -48,7 +48,7 @@ proc runTests*(filename: string) =
         inspectOutput = rlp.inspect(1)
         discard rlp.getType
         while rlp.hasData: discard rlp.toNodes
-      except MalformedRlpError, ValueError:
+      except MalformedRlpError, UnsupportedRlpError, ValueError:
         success = true
       if not success:
         testStatus "FAILED"


### PR DESCRIPTION
- Fix a potential overflow (actual overflow exception)
- Fix case where a signed int could "overflow"

+ add tests for these cases
+ activate all tests as now they were not running due to wrong folder path