### PR TITLE
Add remaining bytes check in toBytes

### DIFF
--- a/eth/rlp.nim
+++ b/eth/rlp.nim
@@ -227,7 +227,14 @@ proc toBytes*(self: Rlp): BytesRange =
     raise newException(RlpTypeMismatch,
                        "Bytes expected, but the source RLP in not a blob")
 
-  let payloadLen = payloadBytesCount()
+  let
+    payloadLen = payloadBytesCount()
+    payloadOffset = payloadOffset()
+    remainingBytes = bytes.len - position - payloadOffset
+
+  if payloadLen > remainingBytes:
+    eosError()
+
   if payloadLen > 0:
     let
       payloadOffset = payloadOffset()

--- a/eth/rlp.nim
+++ b/eth/rlp.nim
@@ -109,7 +109,7 @@ proc payloadOffset(self: Rlp): int =
 template readAheadCheck(numberOfBytes) =
   # important to add nothing to the left side of the equation as `numberOfBytes`
   # can in theory be at max size of its type already
-  if numberOfBytes >= bytes.len - position: eosError()
+  if numberOfBytes > bytes.len - position - payloadOffset(): eosError()
 
 template nonCanonicalNumberError =
   raise newException(MalformedRlpError, "Small number encoded in a non-canonical way")
@@ -212,10 +212,6 @@ proc toString*(self: Rlp): string =
   let
     payloadOffset = payloadOffset()
     payloadLen = payloadBytesCount()
-    remainingBytes = bytes.len - position - payloadOffset
-
-  if payloadLen > remainingBytes:
-    eosError()
 
   result = newString(payloadLen)
   for i in 0 ..< payloadLen:
@@ -227,13 +223,7 @@ proc toBytes*(self: Rlp): BytesRange =
     raise newException(RlpTypeMismatch,
                        "Bytes expected, but the source RLP in not a blob")
 
-  let
-    payloadLen = payloadBytesCount()
-    payloadOffset = payloadOffset()
-    remainingBytes = bytes.len - position - payloadOffset
-
-  if payloadLen > remainingBytes:
-    eosError()
+  let payloadLen = payloadBytesCount()
 
   if payloadLen > 0:
     let

--- a/tests/rlp/cases/invalidRLPTest.json
+++ b/tests/rlp/cases/invalidRLPTest.json
@@ -36,7 +36,7 @@
 
 	"bytesShouldBeSingleByte01": {
 		"in": "INVALID",
-		"out": "8100"
+		"out": "8101"
 	},
 
 	"bytesShouldBeSingleByte7F": {
@@ -82,6 +82,15 @@
 	"fakelonglistinlist2": {
 		"in": "INVALID",
 		"out": "f2ff80000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-	}
+	},
 
+	"smallblob1byteshort": {
+		"in": "INVALID",
+		"out": "82ff"
+	},
+
+	"longblob1byteshort": {
+		"in": "INVALID",
+		"out": "b840ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	}
 }


### PR DESCRIPTION
Without this check, `toBytes` on a Blob where the actual `len` is e.g. 1 byte less (basically the offset less) than the length provided in the RLP encoding itself would give an `AssertionError` in `ByteRange` `slice`. Doing `toString` was fine as an extra check is done there.

Fixed the `readAheadCheck` instead and removed extra check in `toString`