### PR TITLE
Fix for hanging protocol_handlers test

### DIFF
--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -1291,6 +1291,13 @@ proc postHelloSteps(peer: Peer, h: devp2p.hello) {.async.} =
   #
   await all(subProtocolsHandshakes)
 
+  # This is needed as a peer might have already disconnected. In this case
+  # we need to raise so that rlpxConnect/rlpxAccept fails.
+  # Disconnect is done only to run the disconnect handlers. TODO: improve this
+  # also TODO: Should we discern the type of error?
+  if messageProcessingLoop.finished:
+    await peer.disconnectAndRaise(ClientQuitting,
+                                  "messageProcessingLoop ended while connecting")
   peer.connectionState = Connected
 
 template `^`(arr): auto =


### PR DESCRIPTION
Do not merge this yet, even if tests succeed.

I will still add another commit to make the connections happening in the test more reliable/predictable.
However, I want to see test results with this change to see if it is the same underlying issue that I spotted. But, even if it is, the test might still hang (for a while?) due to incoming & outgoing connection races between the two nodes.