### PR TITLE
initial statistics collection setup

### DIFF
--- a/eth/common/eth_types.nim
+++ b/eth/common/eth_types.nim
@@ -168,6 +168,9 @@ type
     OK
     Error
 
+  NimbusStats* = object
+    num_peers*: int
+
 when BlockNumber is int64:
   ## The goal of these templates is to make it easier to switch
   ## the block number type to a different representation

--- a/eth/common/utils.nim
+++ b/eth/common/utils.nim
@@ -8,3 +8,5 @@ proc parseAddress*(hexString: string): EthAddress =
 proc `$`*(a: EthAddress): string =
   a.toHex()
 
+var nimbusStats*: NimbusStats
+

--- a/eth/p2p/peer_pool.nim
+++ b/eth/p2p/peer_pool.nim
@@ -3,7 +3,7 @@
 
 import
   os, tables, times, random, sequtils, options,
-  chronos, chronicles, eth/[rlp, keys],
+  chronos, chronicles, eth/[rlp, keys, common],
   private/p2p_types, discovery, kademlia, rlpx
 
 const
@@ -110,6 +110,7 @@ proc getRandomBootnode(p: PeerPool): Option[Node] =
 proc addPeer*(pool: PeerPool, peer: Peer) =
   doAssert(peer.remote notin pool.connectedNodes)
   pool.connectedNodes[peer.remote] = peer
+  inc(nimbusStats.num_peers)
   for o in pool.observers.values:
     if not o.onPeerConnected.isNil:
       if o.protocol.isNil or peer.supports(o.protocol):

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -787,8 +787,9 @@ proc removePeer(network: EthereumNode, peer: Peer) =
   # have been dropped already from the peers side.
   # E.g. when receiving a p2p.disconnect message from a peer, a race will happen
   # between which side disconnects first.
-  if network.peerPool != nil and not peer.remote.isNil:
+  if network.peerPool != nil and not peer.remote.isNil and peer.remote in network.peerPool.connectedNodes:
     network.peerPool.connectedNodes.del(peer.remote)
+    dec(nimbusStats.num_peers)
 
     # Note: we need to do this check as disconnect (and thus removePeer)
     # currently can get called before the dispatcher is initialized.


### PR DESCRIPTION
Example output during Nimbus sync, while logging the stats every 10 seconds:

```text
INF 2019-06-26 14:33:08+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:33:18+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:33:28+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:33:38+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:33:48+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:33:58+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:34:08+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:34:18+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:34:28+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:34:38+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:34:48+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:34:58+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:35:08+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:35:18+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:35:28+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:35:38+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:35:48+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:35:58+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:36:08+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:36:18+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:36:28+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 0)"
INF 2019-06-26 14:36:38+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 1)"
INF 2019-06-26 14:36:48+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 1)"
INF 2019-06-26 14:36:58+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 2)"
INF 2019-06-26 14:37:08+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 2)"
INF 2019-06-26 14:37:18+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 1)"
INF 2019-06-26 14:37:28+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 2)"
INF 2019-06-26 14:37:38+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 2)"
INF 2019-06-26 14:37:48+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 3)"
INF 2019-06-26 14:37:59+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 6)"
INF 2019-06-26 14:38:09+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 6)"
INF 2019-06-26 14:38:19+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 5)"
INF 2019-06-26 14:38:29+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 5)"
INF 2019-06-26 14:38:39+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 6)"
INF 2019-06-26 14:38:49+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 7)"
INF 2019-06-26 14:38:59+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 8)"
INF 2019-06-26 14:39:09+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 7)"
INF 2019-06-26 14:39:19+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 8)"
INF 2019-06-26 14:39:31+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 8)"
INF 2019-06-26 14:39:41+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 6)"
INF 2019-06-26 14:40:00+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 5)"
INF 2019-06-26 14:40:10+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 5)"
INF 2019-06-26 14:40:20+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 6)"
INF 2019-06-26 14:40:30+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 7)"
INF 2019-06-26 14:40:49+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 6)"
INF 2019-06-26 14:40:59+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 6)"
INF 2019-06-26 14:41:09+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 6)"
INF 2019-06-26 14:41:19+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 6)"
INF 2019-06-26 14:41:29+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 7)"
INF 2019-06-26 14:41:39+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 8)"
INF 2019-06-26 14:41:49+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 8)"
INF 2019-06-26 14:42:02+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 7)"
INF 2019-06-26 14:42:12+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 9)"
INF 2019-06-26 14:42:22+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 10)"
INF 2019-06-26 14:42:34+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 10)"
INF 2019-06-26 14:42:44+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 10)"
INF 2019-06-26 14:43:07+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 10)"
INF 2019-06-26 14:43:17+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 7)"
INF 2019-06-26 14:43:51+02:00 stats                                      tid=6754 file=nimbus.nim:128 nimbusStats="(num_peers: 6)"
```

After seeing negative values in there, I fixed removePeer() being called for peers not in the peer pool.