### PR TITLE
Parity compatibility

### DIFF
--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -20,6 +20,8 @@ type
 
   ResponderWithoutId*[MsgType] = distinct Peer
 
+  EmptyList = object
+
 const
   devp2pVersion* = 4
   maxMsgSize = 1024 * 1024
@@ -777,10 +779,13 @@ p2pProtocol devp2p(version = 0, shortName = "p2p"):
 
   proc sendDisconnectMsg(peer: Peer, reason: DisconnectionReason)
 
-  proc ping(peer: Peer) =
-    discard peer.pong()
+  # Adding an empty RLP list as the spec defines.
+  # The parity client specifically checks if there is rlp data.
+  # TODO: can we do this in the macro instead?
+  proc ping(peer: Peer, emptyList: EmptyList) =
+    discard peer.pong(EmptyList())
 
-  proc pong(peer: Peer) =
+  proc pong(peer: Peer, emptyList: EmptyList) =
     discard
 
 proc removePeer(network: EthereumNode, peer: Peer) =

--- a/eth/p2p/rlpxcrypt.nim
+++ b/eth/p2p/rlpxcrypt.nim
@@ -141,6 +141,13 @@ proc encryptMsg*(msg: openarray[byte], secrets: var SecretState): seq[byte] =
   header[1] = byte((msg.len shr 8) and 0xFF)
   header[2] = byte(msg.len and 0xFF)
 
+  # This is the  [capability-id, context-id] in header-data
+  # While not really used, this is checked in the Parity client.
+  # Same as rlp.encode((0, 0))
+  header[3] = 0xc2
+  header[4] = 0x80
+  header[5] = 0x80
+
   # XXX:
   # This would be safer if we use a thread-local sequ for the temporary buffer
   result = newSeq[byte](encryptedLength(msg.len))


### PR DESCRIPTION
2 commits to be able to connect with a Parity client, 1 commit with some updated debug information.

Tested with Nimbus. Nimbus now connects to geth and parity nodes.

Specific code that in Parity that required these changes:
- https://github.com/paritytech/parity-ethereum/blob/v2.5.4/util/network-devp2p/src/connection.rs#L399
- https://github.com/paritytech/parity-ethereum/blob/v2.5.4/util/network-devp2p/src/session.rs#L332

Based myself on this spec: https://github.com/ethereum/devp2p/blob/master/rlpx.md#framing & https://github.com/ethereum/devp2p/blob/master/rlpx.md#ping-0x02