### PR TITLE
Support skip and reverse in the GetBlockHeaders request 

### DIFF
--- a/eth/common/eth_types.nim
+++ b/eth/common/eth_types.nim
@@ -345,7 +345,10 @@ proc getBlockHeader*(db: AbstractChainDB, b: BlockNumber): BlockHeaderRef {.gcsa
 method getBestBlockHeader*(self: AbstractChainDB): BlockHeader {.base, gcsafe.} =
   notImplemented()
 
-method getSuccessorHeader*(db: AbstractChainDB, h: BlockHeader, output: var BlockHeader): bool {.base, gcsafe.} =
+method getSuccessorHeader*(db: AbstractChainDB, h: BlockHeader, output: var BlockHeader, skip = 0'u): bool {.base, gcsafe.} =
+  notImplemented()
+
+method getAncestorHeader*(db: AbstractChainDB, h: BlockHeader, output: var BlockHeader, skip = 0'u): bool {.base, gcsafe.} =
   notImplemented()
 
 method getBlockBody*(db: AbstractChainDB, blockHash: KeccakHash): BlockBodyRef {.base, gcsafe.} =

--- a/eth/p2p/blockchain_utils.nim
+++ b/eth/p2p/blockchain_utils.nim
@@ -12,8 +12,12 @@ proc getBlockHeaders*(db: AbstractChainDB,
     result.add foundBlock
 
     while uint64(result.len) < req.maxResults:
-      if not db.getSuccessorHeader(foundBlock, foundBlock):
-        break
+      if not req.reverse:
+        if not db.getSuccessorHeader(foundBlock, foundBlock, req.skip):
+          break
+      else:
+        if not db.getAncestorHeader(foundBlock, foundBlock, req.skip):
+          break
       result.add foundBlock
 
 template fetcher*(fetcherName, fetchingFunc, InputType, ResultType: untyped) =

--- a/eth/p2p/blockchain_utils.nim
+++ b/eth/p2p/blockchain_utils.nim
@@ -10,15 +10,17 @@ proc getBlockHeaders*(db: AbstractChainDB,
   var foundBlock: BlockHeader
   if db.getBlockHeader(req.startBlock, foundBlock):
     result.add foundBlock
+    # Quick sanity check for lower bounds, code should be safe though without.
+    if not req.reverse or (foundBlock.blockNumber >= (req.skip + 1).toBlockNumber):
+      while uint64(result.len) < req.maxResults:
+        if not req.reverse:
+          if not db.getSuccessorHeader(foundBlock, foundBlock, req.skip):
+            break
+        else:
+          if not db.getAncestorHeader(foundBlock, foundBlock, req.skip):
+            break
+        result.add foundBlock
 
-    while uint64(result.len) < req.maxResults:
-      if not req.reverse:
-        if not db.getSuccessorHeader(foundBlock, foundBlock, req.skip):
-          break
-      else:
-        if not db.getAncestorHeader(foundBlock, foundBlock, req.skip):
-          break
-      result.add foundBlock
 
 template fetcher*(fetcherName, fetchingFunc, InputType, ResultType: untyped) =
   proc fetcherName*(db: AbstractChainDB,

--- a/eth/p2p/rlpx_protocols/eth_protocol.nim
+++ b/eth/p2p/rlpx_protocols/eth_protocol.nim
@@ -91,8 +91,7 @@ p2pProtocol eth(version = protocolVersion,
         await peer.disconnect(BreachOfProtocol)
         return
 
-      # TODO: implement `getBlockBodies` and reactivate this code
-      # await response.send(peer.network.chain.getBlockBodies(hashes))
+      await response.send(peer.network.chain.getBlockBodies(hashes))
 
     proc blockBodies(peer: Peer, blocks: openarray[BlockBody])
 


### PR DESCRIPTION
Without this other clients (at least geth) will disconnect when requesting headers with "skip" but receiving the wrong ones (as none get skipped).

Also activate the getBlockBodies again as this is actually implemented in Nimbus.

Don't merge quite yet, still need to add this on Nimbus side + probably need to do some bound checking here or there.
