### PR TITLE
Cleanup unneeded check in getBlockHeaders

### DIFF
--- a/eth/p2p/blockchain_utils.nim
+++ b/eth/p2p/blockchain_utils.nim
@@ -10,16 +10,15 @@ proc getBlockHeaders*(db: AbstractChainDB,
   var foundBlock: BlockHeader
   if db.getBlockHeader(req.startBlock, foundBlock):
     result.add foundBlock
-    # Quick sanity check for lower bounds, code should be safe though without.
-    if not req.reverse or (foundBlock.blockNumber >= (req.skip + 1).toBlockNumber):
-      while uint64(result.len) < req.maxResults:
-        if not req.reverse:
-          if not db.getSuccessorHeader(foundBlock, foundBlock, req.skip):
-            break
-        else:
-          if not db.getAncestorHeader(foundBlock, foundBlock, req.skip):
-            break
-        result.add foundBlock
+
+    while uint64(result.len) < req.maxResults:
+      if not req.reverse:
+        if not db.getSuccessorHeader(foundBlock, foundBlock, req.skip):
+          break
+      else:
+        if not db.getAncestorHeader(foundBlock, foundBlock, req.skip):
+          break
+      result.add foundBlock
 
 
 template fetcher*(fetcherName, fetchingFunc, InputType, ResultType: untyped) =


### PR DESCRIPTION
Became really redundant with latest changes in https://github.com/status-im/nimbus/pull/346

