### PR TITLE
Increase rlpx maxMsgSize *10

### DIFF
--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -24,7 +24,7 @@ type
 
 const
   devp2pVersion* = 4
-  maxMsgSize = 1024 * 1024
+  maxMsgSize = 1024 * 1024 * 10
   HandshakeTimeout = MessageTimeout
 
 include p2p_tracing


### PR DESCRIPTION
This is the same size as used by geth. (https://github.com/ethereum/go-ethereum/blob/983f92368bdd79c65082ac2c98cbc0d58b28b22b/eth/protocol.go#L46 )

The issue would occur that at certain block numbers, when fetching 128 block bodies (which we default do, and also is the max), we would fail the 1024*1024 size limit (and also disconnect the peer).

Could in this case also try to fetch less, but that is not really needed for now.