### PR TITLE
Add max open files limit of 512 to rocksdb init

### DIFF
--- a/eth/trie/backends/rocksdb_backend.nim
+++ b/eth/trie/backends/rocksdb_backend.nim
@@ -7,6 +7,10 @@ type
 
   ChainDB* = RocksChainDB
 
+# Maximum open files for rocksdb, set to 512 to be safe for usual 1024 Linux
+# limit per application
+const maxOpenFiles = 512
+
 proc get*(db: ChainDB, key: openarray[byte]): seq[byte] =
   let s = db.store.getBytes(key)
   if s.ok:
@@ -44,7 +48,8 @@ proc newChainDB*(basePath: string, readOnly = false): ChainDB =
   createDir(dataDir)
   createDir(backupsDir)
 
-  let s = result.store.init(dataDir, backupsDir, readOnly)
+  let s = result.store.init(dataDir, backupsDir, readOnly,
+                            maxOpenFiles = maxOpenFiles)
   if not s.ok: raiseStorageInitError()
 
   if not readOnly:


### PR DESCRIPTION
Requires https://github.com/status-im/nim-rocksdb/pull/20

Change rocksdb default of -1 to 512, as we reach the 1024 usual (?) open files limit in Linux when running Nimbus at around block ~1.300.000.
I could not immediately find what the default limit is in Windows, so perhaps I just have to test it.

Setting of 512 is somewhat based on value used in parity client: https://github.com/paritytech/parity-common/blob/master/kvdb-rocksdb/src/lib.rs#L197
Should be quite safe, and if needed can probably be increased safely to somewhere between 700-800. Will need incoming connection limitations for that, but that is another issue.

Could also forward this setting to Nimbus + Nimbus config but decided to not yet do this until it is proven to have an practical impact. 
I'll create an issue to benchmark + (if needed) tune rocksdb at later moment.

