### PR TITLE
Beginning of bzz protocol + simple handshake tester

### DIFF
--- a/eth/p2p/rlpx_protocols/bzz_protocol.nim
+++ b/eth/p2p/rlpx_protocols/bzz_protocol.nim
@@ -1,0 +1,85 @@
+import
+  chronos, chronicles, eth/p2p
+
+# Limited bzz protocol that allows for doing a handshake with a peer running
+# ethersphere/swarm client rev. c535b271536d0dee5bd97c2541ca32a42f272d4f
+
+const
+  bzzVersion = 12
+  hiveVersion = 10
+  swarmNetworkId* = 4
+  # Faking our capabilities to make handshake work, "bit" 0, 1, 4, 5, 15.
+  supportedCapabilities = [1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+
+type
+  # Need object (or extra seq) here as swarm expects list(list(Capability))
+  Capabilities = object
+    caps: seq[Capability]
+
+  Capability = object
+    id: uint
+    # Swarm expects here list(bool), thus bool or int (values <= 1 byte, as rlp
+    # writer has currently no int8 support). Guess this could be a bitvector.
+    # Also looks like per id the list can have a different size, so lets stick
+    # with seq instead of array.
+    value: seq[int]
+
+  OverlayAddress = array[32, byte]
+
+  AddressData = object
+    oaddr: OverlayAddress
+    uaddr: string
+
+  Handshake = object
+    version: uint
+    networkId: uint
+    addressData: AddressData
+    capabilities: Capabilities
+
+  BzzNetwork = ref object
+    thisENode*: ENode
+
+p2pProtocol Hive(version = hiveVersion,
+                 rlpxName = "hive"):
+
+  proc peersMsg(peer: Peer)
+  proc subPeersMsg(peer:Peer)
+
+  onPeerConnected do (peer: Peer):
+    debug "Hive peer connected"
+
+proc initProtocolState*(network: BzzNetwork, node: EthereumNode) {.gcsafe.} =
+  network.thisENode = initENode(node.keys.pubkey, node.address)
+
+p2pProtocol Bzz(version = bzzVersion,
+                rlpxName = "bzz",
+                networkState = BzzNetwork):
+
+  handshake:
+    proc hs(peer: Peer, hs: Handshake) =
+      trace "Incoming bzz handshake", version = hs.version,
+                                      addressData = hs.addressData
+
+  onPeerConnected do (peer: Peer):
+    debug "Bzz peer connected"
+
+    # Now all zeroes, this needs to be the Hash of the ECDSA Public Key
+    # of the used Ethereum account
+    var oaddr: OverlayAddress
+    let
+      # TODO: could do ENode RLP serialisation
+      # Why do we need to send the ENode? Doesn't the peer already have this?
+      # Or should it be a different one?
+      uaddr = $peer.networkState.thisENode
+      addressData = AddressData(oaddr: oaddr,
+                                uaddr: uaddr)
+
+      caps = Capabilities(caps: @[Capability(id: 0,
+                                             value: @supportedCapabilities)])
+      handshake = Handshake(version: bzzVersion,
+                            networkId: swarmNetworkId,
+                            addressData: addressData,
+                            capabilities: caps)
+
+      m = await peer.hs(handshake, timeout = chronos.seconds(10))
+      # TODO: validate the handshake...

--- a/tests/p2p/bzz_basic_client.nim
+++ b/tests/p2p/bzz_basic_client.nim
@@ -1,0 +1,18 @@
+import
+  tables, chronos, eth/p2p, eth/p2p/peer_pool,
+  eth/p2p/rlpx_protocols/bzz_protocol, ./p2p_test_helper
+
+# Basic bzz test to test handshake with ethersphere/swarm node
+# Fixed enode string for now
+
+var node = setupTestNode(Bzz, Hive)
+
+var bzzENode: ENode
+let nodeId = "enode://10420addaa648ffcf09c4ba9df7ce876f276f77aae015bc9346487780c9c04862dc47cec17c86be10d4fb7d93f2cae3f8e702f94cb6dea5807bfedad218a53df@127.0.0.1:30399"
+discard initENode(nodeId, bzzENode)
+waitFor node.peerPool.connectToNode(newNode(bzzENode))
+
+doAssert node.peerPool.connectedNodes.len() == 1
+
+while true:
+  poll()


### PR DESCRIPTION
I've tried to take the important parts from https://github.com/oskarth/nim-eth/pull/2 and did some rework/clean-up on it.

Basically, it will allow for a bzz handshake on a node running ethersphere/swarm client to complete.
```
DEBUG[10-04|14:46:58.575|p2p/server.go:733]                                         Adding p2p peer                          name=nim-eth-p2p/0.2.0       addr=172.17.0.1:34150    peers=5
DEBUG[10-04|14:46:58.616|github.com/ethersphere/swarm/network/protocol.go:256]      peer created                             addr="0000000000000000000000000000000000000000000000000000000000000000 <enode://1dfcee808c95deecba3ef94d933e1776592d2cfd78ee6a9fc3b82af4147462816ad574fd11dcb6259226955fea61cca7a697682933d0a4f751644c5dec2fed3f@127.0.0.1:30303>"
```
Of course on our side it needs a whole lot of more implementation.