### PR TITLE
WIP Add rlpx unit test concept

### DIFF
--- a/tests/fuzzing/rlpx/test_thunk.json
+++ b/tests/fuzzing/rlpx/test_thunk.json
@@ -1,0 +1,52 @@
+{
+  "Invalid list when decoding for object": {
+    "payload": "03",
+    "result": "RlpTypeMismatch",
+    "description": "Object parameters are expected to be encoded in an RLP list"
+  },
+  "Message id that is not supported": {
+    "payload": "08",
+    "result": "UnsupportedMessageError",
+    "description": "This is a message id not used by devp2p, eth or whisper"
+  },
+  "Message id that is negative": {
+    "payload": "888888888888888888",
+    "result": "UnsupportedMessageError",
+    "description": "This payload will result in a negative number as message id"
+  },
+  "No Hash nor Status, but empty list": {
+    "payload": "20c1c0",
+    "result": "RlpTypeMismatch",
+    "description": "Decoding to HashOrStatus expects blob of size 1 or 32"
+  },
+  "No Hash nor Status, list instead of blob": {
+    "payload": "20c1c0",
+    "result": "RlpTypeMismatch",
+    "description": "Decoding to HashOrStatus expects blob of size 1 or 32"
+  },
+  "No Hash nor Status, blob of 2 bytes": {
+    "payload": "20c4c3820011",
+    "result": "RlpTypeMismatch",
+    "description": "Decoding to HashOrStatus expects blob of size 1 or 32"
+  },
+  "No Hash nor Status, blob of 33 bytes": {
+    "payload": "20e3e2a100112233445566778899aabbccddeeff00112233445566778899aabbcceeddff33",
+    "result": "RlpTypeMismatch",
+    "description": "Decoding to HashOrStatus expects blob of size 1 or 32"
+  },
+  "Listing elements when no data": {
+    "payload": "01e1",
+    "result": "MalformedRlpError",
+    "description": "listElem to error on empty list"
+  },
+  "Listing elements when invalid length": {
+    "payload": "01ffdada",
+    "result": "MalformedRlpError",
+    "description": "listElem to error on invalid size encoding"
+  },
+  "Listing elements when not a list": {
+    "payload": "010a",
+    "result": "RlpTypeMismatch",
+    "description": "listElem to assert on not a list"
+  }
+}

--- a/tests/fuzzing/rlpx/test_thunk.nim
+++ b/tests/fuzzing/rlpx/test_thunk.nim
@@ -1,0 +1,71 @@
+import
+  json, os, stew/byteutils, unittest, chronos,
+  eth/p2p, eth/p2p/rlpx_protocols/[whisper_protocol, eth_protocol],
+  ../p2p/p2p_test_helper
+
+template init(body: untyped) =
+  proc fuzzerInit() =
+    `body`
+
+template test(body: untyped) =
+  proc fuzzerTest(data: openArray[byte]) =
+    template payload(): auto =
+      data
+    `body`
+
+# TODO: make it reuse the code from the fuzzing test. This would mean a bit of
+# reworking the exception part for the fuzzing test template.
+proc recvMsgMock(msg: openArray[byte]): tuple[msgId: int, msgData: Rlp] =
+  var rlp = rlpFromBytes(@msg.toRange)
+
+  let msgid = rlp.read(int)
+  return (msgId, rlp)
+
+var
+  node1: EthereumNode
+  node2: EthereumNode
+  peer: Peer
+
+init:
+  node1 = setupTestNode(eth, Whisper)
+  node2 = setupTestNode(eth, Whisper)
+
+  node2.startListening()
+  peer = waitFor node1.rlpxConnect(newNode(initENode(node2.keys.pubKey,
+                                                     node2.address)))
+
+test:
+  var (msgId, msgData) = recvMsgMock(payload)
+  waitFor peer.invokeThunk(msgId.int, msgData)
+
+proc testPayloads(filename: string) =
+  let js = json.parseFile(filename)
+
+  fuzzerInit()
+
+  suite filename:
+
+    for testname, testdata in js:
+      let
+        payloadHex = testdata{"payload"}
+        result = testdata{"result"}
+        # description = testdata{"description"}
+
+      if payloadHex.isNil or payloadHex.kind != JString:
+        continue
+      if result.isNil or result.kind != JString:
+        continue
+
+      let payload = hexToSeqByte(payloadHex.str)
+
+      # TODO: can I convert the result string to an Exception type at runtime?
+      test testname:
+        expect CatchableError:
+          try:
+            fuzzerTest(payload)
+          except CatchableError as e:
+            debug "Test input created exception", exception=e.name, msg=e.msg
+            check: e.name == result.str
+            raise
+
+testPayloads(changeFileExt(currentSourcePath, "json"))


### PR DESCRIPTION
Sort of a PoC. The idea would be to change the templates so that we can reuse the code in thunk.nim currently used for fuzzing. 
Either by doing an include of the fuzzing application,or perhaps better, by running the same fuzzing application, but with another define which will then read and test the json file input.