### PR TITLE
Rlpx unittest

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -48,6 +48,7 @@ proc runP2pTests() =
       "test_discovery",
       "test_ecies",
       "test_enode",
+      "test_rlpx_thunk",
       "test_shh",
       "test_shh_connect",
       "test_protocol_handlers",

--- a/eth/common/eth_types.nim
+++ b/eth/common/eth_types.nim
@@ -1,5 +1,5 @@
 import
-  endians, options, times,
+  endians, options, times, chronicles,
   stint, nimcrypto, eth/rlp, eth/trie/[trie_defs, db]
 
 export
@@ -329,10 +329,7 @@ proc rlpHash*[T](v: T): Hash256 =
 func blockHash*(h: BlockHeader): KeccakHash {.inline.} = rlpHash(h)
 
 proc notImplemented =
-  when defined(afl) or defined(libFuzzer):
-    discard
-  else:
-    doAssert false, "Method not implemented"
+  debug "Method not implemented"
 
 template hasData*(b: Blob): bool = b.len > 0
 template hasData*(r: EthResourceRefs): bool = r != nil

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -429,8 +429,9 @@ proc recvMsg*(peer: Peer): Future[tuple[msgId: int, msgData: Rlp]] {.async.} =
   var rlp = rlpFromBytes(decryptedBytes.toRange)
 
   try:
-    let msgid = rlp.read(int)
-    return (msgId, rlp)
+    # int32 as this seems more than big enough for the amount of msgIds
+    let msgId = rlp.read(int32)
+    return (msgId.int, rlp)
   except RlpError:
     await peer.disconnectAndRaise(BreachOfProtocol,
                                   "Cannot read RLPx message id")

--- a/tests/fuzzing/rlpx/thunk.nim
+++ b/tests/fuzzing/rlpx/thunk.nim
@@ -3,12 +3,6 @@ import
   eth/p2p/rlpx_protocols/[whisper_protocol, eth_protocol],
   ../fuzztest, ../p2p/p2p_test_helper
 
-proc recvMsgMock(msg: openArray[byte]): tuple[msgId: int, msgData: Rlp] =
-  var rlp = rlpFromBytes(@msg.toRange)
-
-  let msgid = rlp.read(int)
-  return (msgId, rlp)
-
 var
   node1: EthereumNode
   node2: EthereumNode

--- a/tests/p2p/p2p_test_helper.nim
+++ b/tests/p2p/p2p_test_helper.nim
@@ -1,5 +1,6 @@
 import
-  unittest, chronos, nimcrypto, eth/[keys, p2p], eth/p2p/[discovery, enode]
+  unittest, chronos, nimcrypto, strutils,
+  eth/[keys, p2p], eth/p2p/[discovery, enode]
 
 var nextPort = 30303
 
@@ -39,3 +40,11 @@ proc packData*(payload: openArray[byte], pk: PrivateKey): seq[byte] =
     signature = @(pk.signMessage(payload).getRaw())
     msgHash = keccak256.digest(signature & payloadSeq)
   result = @(msgHash.data) & signature & payloadSeq
+
+template sourceDir*: string = currentSourcePath.rsplit(DirSep, 1)[0]
+
+proc recvMsgMock*(msg: openArray[byte]): tuple[msgId: int, msgData: Rlp] =
+  var rlp = rlpFromBytes(@msg.toRange)
+
+  let msgid = rlp.read(int)
+  return (msgId, rlp)

--- a/tests/p2p/p2p_test_helper.nim
+++ b/tests/p2p/p2p_test_helper.nim
@@ -46,5 +46,5 @@ template sourceDir*: string = currentSourcePath.rsplit(DirSep, 1)[0]
 proc recvMsgMock*(msg: openArray[byte]): tuple[msgId: int, msgData: Rlp] =
   var rlp = rlpFromBytes(@msg.toRange)
 
-  let msgid = rlp.read(int)
-  return (msgId, rlp)
+  let msgId = rlp.read(int32)
+  return (msgId.int, rlp)

--- a/tests/p2p/test_rlpx_thunk.json
+++ b/tests/p2p/test_rlpx_thunk.json
@@ -9,8 +9,13 @@
     "error": "UnsupportedMessageError",
     "description": "This is a message id not used by devp2p, eth or whisper"
   },
-  "Message id that is negative": {
+  "Message id that is bigger than int32": {
     "payload": "888888888888888888",
+    "error": "RlpTypeMismatch",
+    "description": "This payload will result in too large int for a message id"
+  },
+  "Message id that is negative": {
+    "payload": "8488888888",
     "error": "UnsupportedMessageError",
     "description": "This payload will result in a negative number as message id"
   },

--- a/tests/p2p/test_rlpx_thunk.json
+++ b/tests/p2p/test_rlpx_thunk.json
@@ -1,0 +1,52 @@
+{
+  "Invalid list when decoding for object": {
+    "payload": "03",
+    "error": "RlpTypeMismatch",
+    "description": "Object parameters are expected to be encoded in an RLP list"
+  },
+  "Message id that is not supported": {
+    "payload": "08",
+    "error": "UnsupportedMessageError",
+    "description": "This is a message id not used by devp2p, eth or whisper"
+  },
+  "Message id that is negative": {
+    "payload": "888888888888888888",
+    "error": "UnsupportedMessageError",
+    "description": "This payload will result in a negative number as message id"
+  },
+  "No Hash nor Status, but empty list": {
+    "payload": "20c1c0",
+    "error": "RlpTypeMismatch",
+    "description": "Decoding to HashOrStatus expects blob of size 1 or 32"
+  },
+  "No Hash nor Status, list instead of blob": {
+    "payload": "20c2c1c0",
+    "error": "RlpTypeMismatch",
+    "description": "Decoding to HashOrStatus expects blob of size 1 or 32"
+  },
+  "No Hash nor Status, blob of 2 bytes": {
+    "payload": "20c4c3820011",
+    "error": "RlpTypeMismatch",
+    "description": "Decoding to HashOrStatus expects blob of size 1 or 32"
+  },
+  "No Hash nor Status, blob of 33 bytes": {
+    "payload": "20e3e2a100112233445566778899aabbccddeeff00112233445566778899aabbcceeddff33",
+    "error": "RlpTypeMismatch",
+    "description": "Decoding to HashOrStatus expects blob of size 1 or 32"
+  },
+  "Listing elements when no data": {
+    "payload": "01e1",
+    "error": "MalformedRlpError",
+    "description": "listElem to error on empty list"
+  },
+  "Listing elements when invalid length": {
+    "payload": "01ffdada",
+    "error": "MalformedRlpError",
+    "description": "listElem to error on invalid size encoding"
+  },
+  "Listing elements when not a list": {
+    "payload": "010a",
+    "error": "RlpTypeMismatch",
+    "description": "listElem to assert on not a list"
+  }
+}

--- a/tests/p2p/test_rlpx_thunk.json
+++ b/tests/p2p/test_rlpx_thunk.json
@@ -48,5 +48,8 @@
     "payload": "010a",
     "error": "RlpTypeMismatch",
     "description": "listElem to assert on not a list"
+  },
+  "devp2p hello packet version 22 + additional list elements for EIP-8": {
+    "payload": "00f87137916b6e6574682f76302e39312f706c616e39cdc5836574683dc6846d6f726b1682270fb840fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877c883666f6f836261720304"
   }
 }

--- a/tests/p2p/test_rlpx_thunk.nim
+++ b/tests/p2p/test_rlpx_thunk.nim
@@ -1,0 +1,46 @@
+import
+  json, os, stew/byteutils, unittest, chronos,
+  eth/p2p, eth/p2p/rlpx_protocols/[whisper_protocol, eth_protocol],
+  ../p2p/p2p_test_helper
+
+var
+  node1: EthereumNode
+  node2: EthereumNode
+  peer: Peer
+
+
+node1 = setupTestNode(eth, Whisper)
+node2 = setupTestNode(eth, Whisper)
+
+node2.startListening()
+peer = waitFor node1.rlpxConnect(newNode(initENode(node2.keys.pubKey,
+                                                   node2.address)))
+
+proc testPayloads(filename: string) =
+  let js = json.parseFile(filename)
+
+  suite extractFilename(filename):
+    for testname, testdata in js:
+      test testname:
+        let
+          payloadHex = testdata{"payload"}
+          error = testdata{"error"}
+
+        if payloadHex.isNil or payloadHex.kind != JString:
+          skip()
+          continue
+        if error.isNil or error.kind != JString:
+          skip()
+          continue
+
+        let payload = hexToSeqByte(payloadHex.str)
+        # TODO: can I convert the error string to an Exception type at runtime?
+        expect CatchableError:
+          try:
+            var (msgId, msgData) = recvMsgMock(payload)
+            waitFor peer.invokeThunk(msgId.int, msgData)
+          except CatchableError as e:
+            check: e.name == error.str
+            raise
+
+testPayloads(sourceDir / "test_rlpx_thunk.json")


### PR DESCRIPTION
Basic rlpx thunk unittests, currently containing payloads of previously triggered crashes + the EIP-8 payload (for https://github.com/status-im/nim-eth/issues/109).



