### PR TITLE
Do not start the peer pool loop when discovery is disabled

### DIFF
--- a/eth/p2p.nim
+++ b/eth/p2p.nim
@@ -104,10 +104,9 @@ proc connectToNetwork*(node: EthereumNode,
   if enableDiscovery:
     node.discovery.open()
     await node.discovery.bootstrap()
+    node.peerPool.start()
   else:
     info "Discovery disabled"
-
-  node.peerPool.start()
 
   while node.peerPool.connectedNodes.len == 0:
     trace "Waiting for more peers", peers = node.peerPool.connectedNodes.len


### PR DESCRIPTION
Doesn't make sense to have that peer_pool `run` running when there will never be peers presented as discovery is disabled. 