### PR TITLE
Replace getCurrentException and getCurrentExceptionMsg

### DIFF
--- a/eth/net/nat.nim
+++ b/eth/net/nat.nim
@@ -71,8 +71,8 @@ proc getExternalIP*(natStrategy: NatStrategy, quiet = false): Option[IpAddress] 
             externalIP = parseIpAddress(ires.value)
             strategy = NatUpnp
             return some(externalIP)
-          except:
-            error "parseIpAddress() exception", err = getCurrentExceptionMsg()
+          except ValueError as e:
+            error "parseIpAddress() exception", err = e.msg
             return
 
   if natStrategy == NatAny or natStrategy == NatPmp:
@@ -89,8 +89,8 @@ proc getExternalIP*(natStrategy: NatStrategy, quiet = false): Option[IpAddress] 
           externalIP = parseIpAddress($(nires.value))
           strategy = NatPmp
           return some(externalIP)
-        except:
-          error "parseIpAddress() exception", err = getCurrentExceptionMsg()
+        except ValueError as e:
+          error "parseIpAddress() exception", err = e.msg
           return
 
 proc doPortMapping(tcpPort, udpPort: Port, description: string): Option[(Port, Port)] {.gcsafe.} =

--- a/eth/p2p/blockchain_sync.nim
+++ b/eth/p2p/blockchain_sync.nim
@@ -198,10 +198,8 @@ proc obtainBlocksFromPeer(syncCtx: SyncContext, peer: Peer) {.async.} =
       syncCtx.endBlockNumber = bestBlockNumber
   except TransportError:
     debug "Transport got closed during obtainBlocksFromPeer"
-  except CatchableError:
-    debug "Exception in getBestBlockNumber()",
-      exc = getCurrentException().name,
-      err = getCurrentExceptionMsg()
+  except CatchableError as e:
+    debug "Exception in getBestBlockNumber()", exc = e.name, err = e.msg
     # no need to exit here, because the context might still have blocks to fetch
     # from this peer
 
@@ -252,13 +250,11 @@ proc obtainBlocksFromPeer(syncCtx: SyncContext, peer: Peer) {.async.} =
           warn "Bodies len != headers.len", bodies = bodies.len, headers = workItem.headers.len
     except TransportError:
       debug "Transport got closed during obtainBlocksFromPeer"
-    except CatchableError:
+    except CatchableError as e:
       # the success case sets `dataReceived`, so we can just fall back to the
       # failure path below. If we signal time-outs with exceptions such
       # failures will be easier to handle.
-      debug "Exception in obtainBlocksFromPeer()",
-            exc = getCurrentException().name,
-            err = getCurrentExceptionMsg()
+      debug "Exception in obtainBlocksFromPeer()", exc = e.name, err = e.msg
 
     var giveUpOnPeer = false
 
@@ -365,10 +361,8 @@ proc onPeerConnected(ctx: SyncContext, peer: Peer) =
           error "startSyncWithPeer failed", msg = f.readError.msg, peer
   except TransportError:
     debug "Transport got closed during startSyncWithPeer"
-  except CatchableError:
-    debug "Exception in startSyncWithPeer()",
-      exc = getCurrentException().name,
-      err = getCurrentExceptionMsg()
+  except CatchableError as e:
+    debug "Exception in startSyncWithPeer()", exc = e.name, err = e.msg
 
 
 proc onPeerDisconnected(ctx: SyncContext, p: Peer) =

--- a/eth/p2p/discovery.nim
+++ b/eth/p2p/discovery.nim
@@ -263,10 +263,12 @@ proc processClient(transp: DatagramTransport,
     var buf = transp.getMessage()
     let a = Address(ip: raddr.address, udpPort: raddr.port, tcpPort: raddr.port)
     proto.receive(a, buf)
-  except RlpError, DiscProtocolError:
-    debug "Receive failed", err = getCurrentExceptionMsg()
-  except:
-    debug "Receive failed", err = getCurrentExceptionMsg()
+  except RlpError as e:
+    debug "Receive failed", exc = e.name, err = e.msg
+  except DiscProtocolError as e:
+    debug "Receive failed", exc = e.name, err = e.msg
+  except Exception as e:
+    debug "Receive failed", exc = e.name, err = e.msg
     raise
 
 proc open*(d: DiscoveryProtocol) =

--- a/eth/p2p/p2p_backends_helpers.nim
+++ b/eth/p2p/p2p_backends_helpers.nim
@@ -66,15 +66,13 @@ proc requestResolver[MsgType](msg: pointer, future: FutureBase) {.gcsafe.} =
       # This can except when the future still completes with an error.
       # E.g. the `sendMsg` fails because of an already closed transport or a
       # broken pipe
-      except TransportOsError:
+      except TransportOsError as e:
         # E.g. broken pipe
-        trace "TransportOsError during request", err = getCurrentExceptionMsg()
+        trace "TransportOsError during request", err = e.msg
       except TransportError:
         trace "Transport got closed during request"
-      except:
-        debug "Exception in requestResolver()",
-          exc = getCurrentException().name,
-          err = getCurrentExceptionMsg()
+      except Exception as e:
+        debug "Exception in requestResolver()", exc = e.name, err = e.msg
         raise
 
 proc linkSendFailureToReqFuture[S, R](sendFut: Future[S], resFut: Future[R]) =

--- a/eth/p2p/peer_pool.nim
+++ b/eth/p2p/peer_pool.nim
@@ -173,8 +173,7 @@ proc run(p: PeerPool) {.async.} =
       # Most unexpected errors should be transient, so we log and restart from
       # scratch.
       error "Unexpected PeerPool error, restarting",
-            err = getCurrentExceptionMsg(),
-            stackTrace = e.getStackTrace()
+        err = e.msg, stackTrace = e.getStackTrace()
       dropConnections = true
 
     if dropConnections:

--- a/eth/p2p/rlpx_protocols/les/flow_control.nim
+++ b/eth/p2p/rlpx_protocols/les/flow_control.nim
@@ -118,9 +118,8 @@ proc loadMessageStats*(network: LesNetwork,
 
       return true
 
-    except RlpError:
-      error "Error while loading LES message stats",
-            err = getCurrentExceptionMsg()
+    except RlpError as e:
+      error "Error while loading LES message stats", err = e.msg
 
   newSeq(network.messageStats, les.messages[^1].id + 1)
   return false

--- a/tests/fuzzing/discovery/fuzz.nim
+++ b/tests/fuzzing/discovery/fuzz.nim
@@ -30,5 +30,5 @@ test:
     targetNode.receive(address, msg)
   # These errors are also catched in `processClient` in discovery.nim
   # TODO: move them a layer down in discovery so we can do a cleaner test there?
-  except RlpError, DiscProtocolError:
-    debug "Receive failed", err = getCurrentExceptionMsg()
+  except RlpError, DiscProtocolError as e:
+    debug "Receive failed", err = e.msg

--- a/tests/fuzzing/fuzztest.nim
+++ b/tests/fuzzing/fuzztest.nim
@@ -7,7 +7,8 @@ template fuzz(body) =
     try:
       body
     except Exception as e:
-      error "Fuzzer input created exception", exception=e.name, trace=e.repr, msg=e.msg
+      error "Fuzzer input created exception", exception=e.name, trace=e.repr,
+        msg=e.msg
       discard kill(getpid(), SIGSEGV)
   else:
     body

--- a/tests/fuzzing/readme.md
+++ b/tests/fuzzing/readme.md
@@ -32,8 +32,8 @@ test:
   try:
     var rlp = rlpFromBytes(@payload.toRange)
     discard rlp.inspect()
-  except RlpError:
-    debug "Inspect failed", err = getCurrentExceptionMsg()
+  except RlpError as e:
+    debug "Inspect failed", err = e.msg
 ```
 
 ## Supported Fuzzers

--- a/tests/fuzzing/rlp/rlp_inspect.nim
+++ b/tests/fuzzing/rlp/rlp_inspect.nim
@@ -4,5 +4,5 @@ test:
   try:
     var rlp = rlpFromBytes(@payload.toRange)
     discard rlp.inspect()
-  except RlpError:
-    debug "Inspect failed", err = getCurrentExceptionMsg()
+  except RlpError as e:
+    debug "Inspect failed", err = e.msg


### PR DESCRIPTION
Similar as for the other repos, change to stop using `getCurrentException`. From going over them, didn't actually notice any that could create an issue.