### PR TITLE
Do not send empty messages packets at interval

### DIFF
--- a/eth/p2p/rlpx_protocols/waku_protocol.nim
+++ b/eth/p2p/rlpx_protocols/waku_protocol.nim
@@ -270,10 +270,11 @@ proc processQueue(peer: Peer) =
     envelopes.add(message.env)
     wakuPeer.received.incl(message)
 
-  trace "Sending envelopes", amount=envelopes.len
-  # Ignore failure of sending messages, this could occur when the connection
-  # gets dropped
-  traceAsyncErrors peer.messages(envelopes)
+  if envelopes.len() > 0:
+    trace "Sending envelopes", amount=envelopes.len
+    # Ignore failure of sending messages, this could occur when the connection
+    # gets dropped
+    traceAsyncErrors peer.messages(envelopes)
 
 proc run(peer: Peer) {.async.} =
   while peer.connectionState notin {Disconnecting, Disconnected}:

--- a/eth/p2p/rlpx_protocols/whisper_protocol.nim
+++ b/eth/p2p/rlpx_protocols/whisper_protocol.nim
@@ -265,10 +265,11 @@ proc processQueue(peer: Peer) =
     envelopes.add(message.env)
     whisperPeer.received.incl(message)
 
-  trace "Sending envelopes", amount=envelopes.len
-  # Ignore failure of sending messages, this could occur when the connection
-  # gets dropped
-  traceAsyncErrors peer.messages(envelopes)
+  if envelopes.len() > 0:
+    trace "Sending envelopes", amount=envelopes.len
+    # Ignore failure of sending messages, this could occur when the connection
+    # gets dropped
+    traceAsyncErrors peer.messages(envelopes)
 
 proc run(peer: Peer) {.async.} =
   while peer.connectionState notin {Disconnecting, Disconnected}:


### PR DESCRIPTION
While it is allowed to send `messages` packets with empty envelopes list, there is no real reason to do so. So lets disable it to have less drain of battery.

While it might occur for full nodes (probably not often) and probably more for nodes with narrow bloomfilter set, it will be extremely important for light nodes, if they are allowed to send envelopes via the `messages` packet, see also https://github.com/status-im/nim-eth/issues/131
