### PR TITLE
Waku mail client implementation

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -53,6 +53,7 @@ proc runP2pTests() =
       "test_shh_config",
       "test_shh_connect",
       "test_waku_bridge",
+      "test_waku_mail",
       "test_protocol_handlers",
     ]:
     runTest("tests/p2p/" & filename)

--- a/eth/p2p.nim
+++ b/eth/p2p.nim
@@ -162,3 +162,7 @@ proc randomPeerWith*(node: EthereumNode, Protocol: type): Peer =
   if candidates.len > 0:
     return candidates.rand()
 
+proc getPeer*(node: EthereumNode, peerId: NodeId, Protocol: type): Option[Peer] =
+  for peer in node.peers(Protocol):
+    if peer.remote.id == peerId:
+      return some(peer)

--- a/eth/p2p/rlpx_protocols/waku_mail.nim
+++ b/eth/p2p/rlpx_protocols/waku_mail.nim
@@ -32,6 +32,9 @@ proc requestMail*(node: EthereumNode, peerId: NodeId, request: MailRequest,
   # TODO: Perhaps don't go the recursive route or could use the actual response
   # proc to implement this (via a handler) and store the necessary data in the
   # WakuPeer object.
+  # TODO: Several requestMail calls in parallel can create issues with handling
+  # the wrong response to a request. Can additionaly check the requestId but
+  # that would only solve it half. Better to use the requestResponse mechanism.
 
   # TODO: move this check out of requestMail?
   let peer = node.getPeer(peerId, Waku)

--- a/eth/p2p/rlpx_protocols/waku_mail.nim
+++ b/eth/p2p/rlpx_protocols/waku_mail.nim
@@ -1,0 +1,82 @@
+#
+#            Waku Mail Client & Server
+#              (c) Copyright 2019
+#       Status Research & Development GmbH
+#
+#            Licensed under either of
+#  Apache License, version 2.0, (LICENSE-APACHEv2)
+#            MIT license (LICENSE-MIT)
+#
+import
+  chronos,
+  eth/[p2p, async_utils], eth/p2p/rlpx_protocols/waku_protocol
+
+const
+  requestCompleteTimeout = chronos.seconds(5)
+
+type
+  Cursor = Bytes
+
+  MailRequest* = object
+    lower*: uint32 ## Unix timestamp; oldest requested envelope's creation time
+    upper*: uint32 ## Unix timestamp; newest requested envelope's creation time
+    bloom*: Bytes ## Bloom filter to apply on the envelopes
+    limit*: uint32 ## Maximum amount of envelopes to return
+    cursor*: Cursor ## Optional cursor
+
+proc requestMail*(node: EthereumNode, peerId: NodeId, request: MailRequest,
+    symKey: SymKey, requests = 10): Future[Option[Cursor]] {.async.} =
+  ## Send p2p mail request and check request complete.
+  ## If result is none, and error occured. If result is a none empty cursor,
+  ## more envelopes are available.
+  # TODO: Perhaps don't go the recursive route or could use the actual response
+  # proc to implement this (via a handler) and store the necessary data in the
+  # WakuPeer object.
+
+  # TODO: move this check out of requestMail?
+  let peer = node.getPeer(peerId, Waku)
+  if not peer.isSome():
+    error "Invalid peer"
+    return result
+  elif not peer.get().state(Waku).trusted:
+    return result
+
+  var writer = initRlpWriter()
+  writer.append(request)
+  let payload = writer.finish()
+  let data = encode(Payload(payload: payload, symKey: some(symKey)))
+  if not data.isSome():
+    error "Encoding of payload failed"
+    return result
+
+  # TODO: should this envelope be valid in terms of ttl, PoW, etc.?
+  let env = Envelope(expiry:0, ttl: 0, data: data.get(), nonce: 0)
+  # Send the request
+  traceAsyncErrors peer.get().p2pRequest(env)
+
+  # Wait for the Request Complete packet
+  var f = peer.get().nextMsg(Waku.p2pRequestComplete)
+  if await f.withTimeout(requestCompleteTimeout):
+    let response = f.read()
+    # TODO: I guess the idea is to check requestId (Hash) also?
+    let requests = requests - 1
+    # If there is cursor data, do another request
+    if response.data.cursor.len > 0 and requests > 0:
+      var newRequest = request
+      newRequest.cursor = response.data.cursor
+      return await requestMail(node, peerId, newRequest, symKey, requests)
+    else:
+      return some(response.data.cursor)
+  else:
+    error "p2pRequestComplete timeout"
+    return result
+
+proc p2pRequestHandler(peer: Peer, envelope: Envelope) =
+  # Mail server p2p request implementation
+  discard
+
+proc enableMailServer*(node: EthereumNode, customHandler: P2PRequestHandler) =
+  node.protocolState(Waku).p2pRequestHandler = customHandler
+
+proc enableMailServer*(node: EthereumNode) =
+  node.protocolState(Waku).p2pRequestHandler = p2pRequestHandler

--- a/tests/p2p/test_waku_mail.nim
+++ b/tests/p2p/test_waku_mail.nim
@@ -1,0 +1,71 @@
+import
+  unittest, chronos, tables, sequtils, times, eth/p2p, eth/p2p/peer_pool,
+  eth/p2p/rlpx_protocols/waku_protocol, chronicles,
+  ./p2p_test_helper
+
+suite "Waku Mail Client":
+  var client = setupTestNode(Waku)
+  var simpleServer = setupTestNode(Waku)
+
+  simpleServer.startListening()
+  let simpleServerNode = newNode(initENode(simpleServer.keys.pubKey,
+    simpleServer.address))
+  let clientNode = newNode(initENode(client.keys.pubKey, client.address))
+  waitFor client.peerPool.connectToNode(simpleServerNode)
+
+  asyncTest "Two peers connected":
+    check:
+      client.peerPool.connectedNodes.len() == 1
+
+  asyncTest "Test Mail Request":
+    let
+      topic = [byte 0, 0, 0, 0]
+      bloom = toBloom(@[topic])
+      lower = 0'u32
+      upper = epochTime().uint32
+      limit = 100'u32
+      request = MailRequest(lower: lower, upper: upper, bloom: @bloom,
+        limit: limit)
+
+    var symKey: SymKey
+    check client.requestMail(simpleServerNode.id, request, symKey)
+
+    # Simple mailserver part
+    let peer = simpleServer.peerPool.connectedNodes[clientNode]
+    var f = peer.nextMsg(Waku.p2pRequest)
+    require await f.withTimeout(chronos.milliseconds(100))
+    let response = f.read()
+    let decoded = decode(response.envelope.data, symKey = some(symKey))
+    require decoded.isSome()
+
+    var rlp = rlpFromBytes(decoded.get().payload.toRange)
+    let output = rlp.read(MailRequest)
+    check:
+      output.lower == lower
+      output.upper == upper
+      output.bloom == bloom
+      output.limit == limit
+
+  asyncTest "Test Mail Send":
+    let topic = [byte 0x12, 0x34, 0x56, 0x78]
+    let payload = repeat(byte 0, 10)
+    var f = newFuture[int]()
+
+    proc handler(msg: ReceivedMessage) =
+      check msg.decoded.payload == payload
+      f.complete(1)
+
+    let filter = subscribeFilter(client,
+      newFilter(topics = @[topic], allowP2P = true), handler)
+
+    check:
+      client.setPeerTrusted(simpleServerNode.id)
+      # ttl 0 to show that ttl should be ignored
+      # TODO: perhaps not the best way to test this, means no PoW calculation
+      # may be done, and not sure if that is OK?
+      simpleServer.postMessage(ttl = 0, topic = topic, payload = payload,
+        targetPeer = some(clientNode.id))
+
+      await f.withTimeout(chronos.milliseconds(100))
+
+      client.unsubscribeFilter(filter)


### PR DESCRIPTION
Starting on mail client as in https://github.com/vacp2p/specs/blob/master/waku.md#mailserver-and-client .

Some parts are unclear:
- cursor -> This means it has to be send back, through the same packet id? Why not some other  packet id (a reponse)? And why the array?
- unclear which validation checking of envelope is done in the P2P Request packet. All like normal messages?
- unclear which validation checking is done on envelopes for P2P Message packet. TTL for sure is skipped, but anything else?