### PR TITLE
More spec compliant ENR

### DIFF
--- a/eth/p2p/discoveryv5/encoding.nim
+++ b/eth/p2p/discoveryv5/encoding.nim
@@ -81,7 +81,7 @@ proc makeAuthHeader(c: Codec, toNode: Node, nonce: array[gcmNonceSize, byte],
   var resp = AuthResponse(version: 5)
   let ln = c.localNode
 
-  if challenge.recordSeq < ln.record.sequenceNumber:
+  if challenge.recordSeq < ln.record.seqNum:
     resp.record = ln.record
 
   var remotePubkey: PublicKey

--- a/eth/p2p/discoveryv5/enr.nim
+++ b/eth/p2p/discoveryv5/enr.nim
@@ -106,8 +106,8 @@ proc init*(T: type Record, seqNum: uint64,
     isV6 = address.ip.family == IPv6
     ipField = if isV6: ("ip6", address.ip.address_v6.toField)
               else: ("ip", address.ip.address_v4.toField)
-    tcpField = ((if isV6: "tcp6" else: "tcp"), address.udpPort.uint16.toField)
-    udpField = ((if isV6: "udp6" else: "udp"), address.tcpPort.uint16.toField)
+    tcpField = ((if isV6: "tcp6" else: "tcp"), address.tcpPort.uint16.toField)
+    udpField = ((if isV6: "udp6" else: "udp"), address.udpPort.uint16.toField)
 
   makeEnrAux(seqNum, pk, [ipField, tcpField, udpField])
 

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -297,7 +297,7 @@ proc processClient(transp: DatagramTransport,
 proc revalidateNode(p: Protocol, n: Node) {.async.} =
   let reqId = newRequestId()
   var ping: PingPacket
-  ping.enrSeq = p.localNode.record.sequenceNumber
+  ping.enrSeq = p.localNode.record.seqNum
   let (data, nonce) = p.codec.encodeEncrypted(n, encodePacket(ping, reqId), challenge = nil)
   p.pendingRequests[nonce] = PendingRequest(node: n, packet: data)
   p.send(n, data)
@@ -305,7 +305,7 @@ proc revalidateNode(p: Protocol, n: Node) {.async.} =
   let resp = await p.waitPacket(n, reqId)
   if resp.isSome and resp.get.kind == pong:
     let pong = resp.get.pong
-    if pong.enrSeq > n.record.sequenceNumber:
+    if pong.enrSeq > n.record.seqNum:
       # TODO: Request new ENR
       discard
 

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -35,14 +35,10 @@ proc whoareyouMagic(toNode: NodeId): array[32, byte] =
 
 proc newProtocol*(privKey: PrivateKey, db: Database, port: Port): Protocol =
   result = Protocol(privateKey: privKey, db: db)
-  var a: Address
-  a.ip = parseIpAddress("127.0.0.1")
-  a.udpPort = port
-  var ipAddr: int32
-  bigEndian32(addr ipAddr, addr a.ip.address_v4)
+  let a = Address(ip: parseIpAddress("127.0.0.1"), udpPort: port)
 
   result.localNode = newNode(initENode(result.privateKey.getPublicKey(), a))
-  result.localNode.record = initRecord(12, result.privateKey, {"udp": int(a.udpPort), "ip": ipAddr})
+  result.localNode.record = enr.Record.init(12, result.privateKey, a)
 
   result.whoareyouMagic = whoareyouMagic(result.localNode.id)
 


### PR DESCRIPTION
* Don't use signed integers in RLP
* Don't store IP addresses as var-sized ints (use fixed-sized blobs instead)
* Allow constructing ENR from ENode.Address