### PR TITLE
safeEnterList() renamed to enterList()

### DIFF
--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -567,7 +567,7 @@ proc p2pProtocolBackendImpl*(protocol: P2PProtocol): Backend =
     read = bindSym("read", brForceOpen)
     checkedRlpRead = bindSym "checkedRlpRead"
     startList = bindSym "startList"
-    safeEnterList = bindSym "safeEnterList"
+    enterList = bindSym "enterList"
     finish = bindSym "finish"
 
     messagePrinter = bindSym "messagePrinter"
@@ -677,7 +677,7 @@ proc p2pProtocolBackendImpl*(protocol: P2PProtocol): Backend =
 
     let
       paramCount = paramsToWrite.len
-      readParamsPrelude = if paramCount > 1: newCall(safeEnterList, receivedRlp)
+      readParamsPrelude = if paramCount > 1: newCall(enterList, receivedRlp)
                           else: newStmtList()
 
     when tracingEnabled:

--- a/eth/p2p/rlpx_protocols/waku_protocol.nim
+++ b/eth/p2p/rlpx_protocols/waku_protocol.nim
@@ -147,17 +147,9 @@ proc append*(rlpWriter: var RlpWriter, value: StatusOptions) =
   rlpWriter.append(rlpFromBytes(bytes.toRange))
 
 proc read*(rlp: var Rlp, T: typedesc[StatusOptions]): T =
-  if not rlp.isList():
-    raise newException(RlpTypeMismatch,
-      "List expected, but the source RLP is not a list.")
-
   let sz = rlp.listLen()
   rlp.enterList()
   for i in 0 ..< sz:
-    if not rlp.isList():
-      raise newException(RlpTypeMismatch,
-        "List expected, but the source RLP is not a list.")
-
     rlp.enterList()
     var k: KeyKind
     try:

--- a/eth/rlp.nim
+++ b/eth/rlp.nim
@@ -243,13 +243,9 @@ proc currentElemEnd*(self: Rlp): int =
     result += payloadOffset() + payloadBytesCount()
 
 proc enterList*(self: var Rlp) =
-  doAssert isList()
-  position += payloadOffset()
-
-proc safeEnterList*(self: var Rlp) =
   if not isList():
     raise newException(RlpTypeMismatch, "List expected, but source RLP is not a list")
-  enterList()
+  position += payloadOffset()
 
 proc skipElem*(rlp: var Rlp) =
   rlp.position = rlp.currentElemEnd

--- a/eth/trie/hexary.nim
+++ b/eth/trie/hexary.nim
@@ -384,7 +384,7 @@ proc replaceValue(data: Rlp, key: NibblesRange, value: BytesRange): Bytes =
 
   var r = initRlpList(17)
 
-  # XXX: This can be optmized to a direct bitwise copy of the source RLP
+  # XXX: This can be optimized to a direct bitwise copy of the source RLP
   var iter = data
   iter.enterList()
   for i in 0 ..< 16:


### PR DESCRIPTION
...in order to avoid unhandled exceptions due to malformed data received
over the network, like sometimes when running `make testnet1` in nim-beacon-chain:

```text
DBG 2020-02-24 23:37:56+01:00 Got discv5 lookup response                 topics="discv5" tid=26545 idx=1
DBG 2020-02-24 23:37:56+01:00 discv5 pending queries                     topics="discv5" tid=26545 total=3
DBG 2020-02-24 23:37:56+01:00 Got discv5 lookup response                 topics="discv5" tid=26545 idx=2
DBG 2020-02-24 23:37:56+01:00 discv5 pending queries                     topics="discv5" tid=26545 total=3
TRC 2020-02-24 23:37:56+01:00 Decoding failed (no keys)                  tid=26545
DBG 2020-02-24 23:37:56+01:00 Could not decode, respond with whoareyou   topics="discv5" tid=26545
TRC 2020-02-24 23:37:56+01:00 sending who are you                        topics="discv5" tid=26545 to=71903746117165936395423247506562441065595177867592707754147235596739826250520 toAddress="(ip: 3.126.82.94, udpPort: 9100, tcpPort: 9100)"
 peers: 0 ❯ epoch: 3403, slot: 2/8 (27226) ❯ finalized epoch: 0 (1bdb7c6b)                                                                      ETH: 0 Traceback (most recent call last, using override)
/mnt/sda3/storage/CODE/status/nim-beacon-chain/beacon_chain/beacon_node.nim(1172) beacon_node
/mnt/sda3/storage/CODE/status/nim-beacon-chain/beacon_chain/beacon_node.nim(931) start
/mnt/sda3/storage/CODE/status/nim-beacon-chain/beacon_chain/beacon_node.nim(889) run
/mnt/sda3/storage/CODE/status/nim-beacon-chain/vendor/nim-chronos/chronos/asyncloop.nim(941) runForever
/mnt/sda3/storage/CODE/status/nim-beacon-chain/vendor/nim-chronos/chronos/asyncloop.nim(278) poll
Error: unhandled exception: /mnt/sda3/storage/CODE/status/nim-beacon-chain/vendor/nim-eth/eth/rlp.nim(246, 12) `isList()` 
Async traceback:
Exception message: /mnt/sda3/storage/CODE/status/nim-beacon-chain/vendor/nim-eth/eth/rlp.nim(246, 12) `isList()` 
Exception type: [AssertionError]
```