### PR TITLE
Handle waku status-update code 22 & increase max topics

### DIFF
--- a/eth/p2p/rlpx_protocols/waku_protocol.nim
+++ b/eth/p2p/rlpx_protocols/waku_protocol.nim
@@ -69,7 +69,7 @@ const
   ## send to peers, in ms.
   pruneInterval* = chronos.milliseconds(1000)  ## Interval at which message
   ## queue is pruned, in ms.
-  topicInterestMax = 1000
+  topicInterestMax = 10000
 
 type
   WakuConfig* = object


### PR DESCRIPTION
Handle waku status-update code 22

This commits adds handling of the status-update code, 22, according to waku specs 0.4 https://github.com/vacp2p/specs/commit/a6a9d6bcb127044e13b47c229da7a5b3f66eadf1
    
Removes unused codes 20,21

Fields not used (RateLimits & ConfirmationsEnabled) are currently ignored.