### PR TITLE
Discv5: Specifically handle decryption errors

### DIFF
--- a/eth/p2p/discoveryv5/discovery_db.nim
+++ b/eth/p2p/discoveryv5/discovery_db.nim
@@ -50,3 +50,10 @@ method loadKeys*(db: DiscoveryDB, id: NodeId, address: Address, r, w: var AesKey
   except CatchableError:
     return false
 
+method deleteKeys*(db: DiscoveryDB, id: NodeId, address: Address):
+    bool {.raises: [Defect].} =
+  try:
+    db.backend.del(makeKey(id, address))
+    return true
+  except CatchableError:
+    return false

--- a/eth/p2p/discoveryv5/encoding.nim
+++ b/eth/p2p/discoveryv5/encoding.nim
@@ -1,5 +1,5 @@
 import
-  std/tables, nimcrypto, stint, chronicles,
+  std/[tables, options], nimcrypto, stint, chronicles,
   types, node, enr, hkdf, ../enode, eth/[rlp, keys]
 
 const
@@ -7,7 +7,7 @@ const
   keyAgreementPrefix = "discovery v5 key agreement"
   authSchemeName* = "gcm"
   gcmNonceSize* = 12
-  gcmTagSize = 16
+  gcmTagSize* = 16
   tagSize* = 32 ## size of the tag where each message (except whoareyou) starts
   ## with
 
@@ -43,7 +43,8 @@ type
   DecodeStatus* = enum
     Success,
     HandshakeError,
-    PacketError
+    PacketError,
+    DecryptError
 
 proc randomBytes*(v: var openarray[byte]) =
   if nimcrypto.randomBytes(v) != v.len:
@@ -159,16 +160,24 @@ proc encodeEncrypted*(c: Codec,
   headBuf.add(encryptGCM(writeKey, nonce, body, tag))
   return (headBuf, nonce)
 
-proc decryptGCM(key: AesKey, nonce, ct, authData: openarray[byte]): seq[byte] =
+proc decryptGCM*(key: AesKey, nonce, ct, authData: openarray[byte]):
+    Option[seq[byte]] =
+  if ct.len <= gcmTagSize:
+    debug "cipher is missing tag", len = ct.len
+    return
+
   var dctx: GCM[aes128]
   dctx.init(key, nonce, authData)
-  result = newSeq[byte](ct.len - gcmTagSize)
+  var res = newSeq[byte](ct.len - gcmTagSize)
   var tag: array[gcmTagSize, byte]
-  dctx.decrypt(ct.toOpenArray(0, ct.high - gcmTagSize), result)
+  dctx.decrypt(ct.toOpenArray(0, ct.high - gcmTagSize), res)
   dctx.getTag(tag)
-  if tag != ct.toOpenArray(ct.len - gcmTagSize, ct.high):
-    result = @[]
   dctx.clear()
+
+  if tag != ct.toOpenArray(ct.len - gcmTagSize, ct.high):
+    return
+
+  return some(res)
 
 type
   DecodePacketResult = enum
@@ -222,7 +231,10 @@ proc decodeAuthResp(c: Codec, fromId: NodeId, head: AuthHeader,
 
   var zeroNonce: array[gcmNonceSize, byte]
   let respData = decryptGCM(secrets.authRespKey, zeroNonce, head.response, [])
-  let authResp = rlp.decode(respData, AuthResponse)
+  if respData.isNone():
+    return false
+
+  let authResp = rlp.decode(respData.get(), AuthResponse)
 
   newNode = newNode(authResp.record)
   return true
@@ -275,7 +287,7 @@ proc decodeEncrypted*(c: var Codec,
     var writeKey: AesKey
     if not c.db.loadKeys(fromId, fromAddr, readKey, writeKey):
       trace "Decoding failed (no keys)"
-      return PacketError
+      return DecryptError
       # doAssert(false, "TODO: HANDLE ME!")
 
   let headSize = tagSize + r.position
@@ -283,8 +295,14 @@ proc decodeEncrypted*(c: var Codec,
 
   let body = decryptGCM(readKey, auth.auth, bodyEnc.toOpenArray,
     input[0 .. tagSize - 1].toOpenArray)
-  if body.len > 1:
-    let status = decodePacketBody(body[0], body.toOpenArray(1, body.high), packet)
+  if body.isNone():
+    discard c.db.deleteKeys(fromId, fromAddr)
+    return DecryptError
+
+  let packetData = body.get()
+  if packetData.len > 1:
+    let status = decodePacketBody(packetData[0],
+      packetData.toOpenArray(1, packetData.high), packet)
     if status == decodingSuccessful:
       return Success
     else:

--- a/eth/p2p/discoveryv5/encoding.nim
+++ b/eth/p2p/discoveryv5/encoding.nim
@@ -235,6 +235,11 @@ proc decodeAuthResp(c: Codec, fromId: NodeId, head: AuthHeader,
     return false
 
   let authResp = rlp.decode(respData.get(), AuthResponse)
+  # TODO:
+  # 1. Should allow for not having an ENR included, solved for now by sending
+  # whoareyou with always recordSeq of 0
+  # 2. Should verify ENR and check for correct id in case an ENR is included
+  # 3. Should verify id nonce signature
 
   newNode = newNode(authResp.record)
   return true

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -93,7 +93,7 @@ proc decodeWhoAreYou(d: Protocol, msg: Bytes): Whoareyou =
 
 proc sendWhoareyou(d: Protocol, address: Address, toNode: NodeId, authTag: AuthTag) =
   trace "sending who are you", to = $toNode, toAddress = $address
-  let challenge = Whoareyou(authTag: authTag, recordSeq: 1)
+  let challenge = Whoareyou(authTag: authTag, recordSeq: 0)
   encoding.randomBytes(challenge.idNonce)
   # If there is already a handshake going on for this nodeid then we drop this
   # new one. Handshake will get cleaned up after `handshakeTimeout`.
@@ -362,6 +362,7 @@ proc revalidateNode(p: Protocol, n: Node)
       discard
 
     p.routingTable.setJustSeen(n)
+    trace "Revalidated node", node = $n
   else:
     if false: # TODO: if not bootnode:
       p.routingTable.removeNode(n)
@@ -392,7 +393,8 @@ proc lookupLoop(d: Protocol) {.async.} =
     trace "lookupLoop canceled"
 
 proc open*(d: Protocol) =
-  debug "Starting discovery node", node = $d.localNode
+  debug "Starting discovery node", node = $d.localNode,
+    uri = toURI(d.localNode.record)
   # TODO allow binding to specific IP / IPv6 / etc
   let ta = initTAddress(IPv4_any(), d.localNode.node.address.udpPort)
   d.transp = newDatagramTransport(processClient, udata = d, local = ta)

--- a/eth/p2p/discoveryv5/types.nim
+++ b/eth/p2p/discoveryv5/types.nim
@@ -87,6 +87,9 @@ method storeKeys*(db: Database, id: NodeId, address: Address, r, w: AesKey):
 method loadKeys*(db: Database, id: NodeId, address: Address, r, w: var AesKey):
     bool {.base, raises: [Defect].} = discard
 
+method deleteKeys*(db: Database, id: NodeId, address: Address):
+    bool {.raises: [Defect].} = discard
+
 proc toBytes*(id: NodeId): array[32, byte] {.inline.} =
   id.toByteArrayBE()
 


### PR DESCRIPTION
Fixing some missing decryption checks causing (potential) crashes.

Slight improvement also on https://github.com/status-im/nim-eth/issues/191, by differentiating on decryption error and others, in order to decide on sending whoareyou (and deleting keys) or adding the node.

Still feels very brittle and would probably benefit from splitting the handshake code from the regular packet decryption.