### PR TITLE
rlp: fix test_object_serialization

### DIFF
--- a/tests/rlp/test_object_serialization.nim
+++ b/tests/rlp/test_object_serialization.nim
@@ -4,7 +4,7 @@ import
 type
   Transaction = object
     amount: int
-    time: DateTime
+    time: Time
     sender: string
     receiver: string
 
@@ -52,13 +52,13 @@ test "encoding and decoding an object":
   check:
     originalBar == restoredBar
 
-  var t1 = Transaction(time: now(), amount: 1000, sender: "Alice", receiver: "Bob")
+  var t1 = Transaction(time: getTime(), amount: 1000, sender: "Alice", receiver: "Bob")
   bytes = encode(t1)
   var t2 = bytes.decode(Transaction)
 
   check:
     bytes.hexRepr == "cd85416c69636583426f628203e8" # verifies that Alice comes first
-    t2.time == default(DateTime)
+    t2.time == default(Time)
     t2.sender == "Alice"
     t2.receiver == "Bob"
     t2.amount == 1000


### PR DESCRIPTION
Nim 1.2 disallow 'var x: T' for objects that require initialization.
