### PR TITLE
Add routing table metrics + tweaks + fixes

### DIFF
--- a/eth/p2p/discoveryv5/node.nim
+++ b/eth/p2p/discoveryv5/node.nim
@@ -16,6 +16,8 @@ type
     pubkey*: PublicKey
     address*: Option[Address]
     record*: Record
+    seen*: bool ## Indicates if there was at least one successful
+    ## request-response with this node.
 
 proc toNodeId*(pk: PublicKey): NodeId =
   readUintBE[256](keccak256.digest(pk.toRaw()).data)

--- a/tests/p2p/discv5_test_helper.nim
+++ b/tests/p2p/discv5_test_helper.nim
@@ -53,3 +53,8 @@ proc nodeAtDistance*(n: Node, d: uint32): Node =
 proc nodesAtDistance*(n: Node, d: uint32, amount: int): seq[Node] =
   for i in 0..<amount:
     result.add(nodeAtDistance(n, d))
+
+proc addSeenNode*(d: discv5_protocol.Protocol, n: Node): bool =
+  # Add it as a seen node, warning: for testing convenience only!
+  n.seen = true
+  d.addNode(n)


### PR DESCRIPTION
- routing table metrics + option in dcli
- only forward "seen" nodes on a findNode request
- setJustSeen & replace on ping AND findnode
- self lookup only at start
- revalidate 10x more
- use bitsPerHop (b) of 5
- small fix in resolve
- small fix in bucket split