### PR TITLE
Use brHmacDrbgGenerate for all random operations in discovery

### DIFF
--- a/eth/p2p/discoveryv5/random2.nim
+++ b/eth/p2p/discoveryv5/random2.nim
@@ -1,0 +1,22 @@
+import bearssl
+
+## Random helpers: similar as in stdlib, but with BrHmacDrbgContext rng
+# TODO: Move these somewhere else?
+const randMax = 18_446_744_073_709_551_615'u64
+
+proc rand*(rng: var BrHmacDrbgContext, max: Natural): int =
+  if max == 0: return 0
+
+  var x: uint64
+  while true:
+    brHmacDrbgGenerate(addr rng, addr x, csize_t(sizeof(x)))
+    if x < randMax - (randMax mod (uint64(max) + 1'u64)): # against modulo bias
+      return int(x mod (uint64(max) + 1'u64))
+
+proc sample*[T](rng: var BrHmacDrbgContext, a: openarray[T]): T =
+  result = a[rng.rand(a.high)]
+
+proc shuffle*[T](rng: var BrHmacDrbgContext, a: var openarray[T]) =
+  for i in countdown(a.high, 1):
+    let j = rng.rand(i)
+    swap(a[i], a[j])

--- a/tests/p2p/test_routing_table.nim
+++ b/tests/p2p/test_routing_table.nim
@@ -12,7 +12,7 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1)
+    table.init(node, 1, rng)
 
     for j in 0..5'u32:
       for i in 0..<BUCKET_SIZE:
@@ -24,7 +24,7 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1)
+    table.init(node, 1, rng)
 
     # Add 16 nodes, distance 256
     for i in 0..<BUCKET_SIZE:
@@ -44,7 +44,7 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 2, allow not in range branch to split once (2 buckets).
-    table.init(node, 2)
+    table.init(node, 2, rng)
 
     # Add 16 nodes, distance 256 from `node`, but all with 2 bits shared prefix
     # among themselves.
@@ -74,7 +74,7 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1)
+    table.init(node, 1, rng)
 
     # create a full bucket
     let bucketNodes = node.nodesAtDistance(rng[], 256, BUCKET_SIZE)
@@ -108,7 +108,7 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1)
+    table.init(node, 1, rng)
 
     check table.nodeToRevalidate().isNil()
 
@@ -132,7 +132,7 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1)
+    table.init(node, 1, rng)
 
     # create a full bucket TODO: no need to store bucketNodes
     let bucketNodes = node.nodesAtDistance(rng[], 256, BUCKET_SIZE)
@@ -148,7 +148,7 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1)
+    table.init(node, 1, rng)
 
     let doubleNode = node.nodeAtDistance(rng[], 256)
     # Try to add the node twice
@@ -178,7 +178,7 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1)
+    table.init(node, 1, rng)
 
     # create a full bucket
     let bucketNodes = node.nodesAtDistance(rng[], 256, BUCKET_SIZE)
@@ -208,7 +208,7 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1)
+    table.init(node, 1, rng)
 
     # create a full bucket
     let bucketNodes = node.nodesAtDistance(rng[], 256, BUCKET_SIZE)
@@ -228,7 +228,7 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1)
+    table.init(node, 1, rng)
 
     # create a full bucket
     let bucketNodes = node.nodesAtDistance(rng[], 256, BUCKET_SIZE)


### PR DESCRIPTION
Alright, this is an attempt to resolve https://github.com/status-im/nim-eth/issues/233.

Random is currently used for 3 things in discovery v5:
1. `randomNodes`, to get a random selection of nodes from the routing table (random node in random bucket)
2. `nodeToRevalidate`, to get a random bucket
3. `revalidateLoop`, to ping on an average interval, but not always the same interval.

I believe all 3 would be rather difficult to abuse with current implementation, but perhaps not impossible. And with the idea of not using stdlib random in general to set good example and avoid mistakes, I decided to remove it. 

The idea of 1. is that it could perhaps be abused if an attacker manages to fill our routing table with a specific set of nodes, with node ids that would then be triggered to be selected in the first rounds of `randomNodes`. This is quite difficult because there is more randomization going on then just the `random` call. Discovery itself has a difficulty to it that you have to create specific node ids to be placed in the right buckets. And then the locations of your nodes in the buckets will highly depend on the order of network calls made. But if such effort could be done, it would be troublesome, yes.

Not sure how 2. could be abused, but it could be used to have your nodes being revalidated "as late as possible", but eventually they will be revalidated and removed if not reachable.

Then number 3., not sure why it was placed there originally (I noticed the go code also does this). I would assume it is against an attacker for making revalidating (pinging) fail each time in case the interval is fixed by timing some network congestion on that moment. Not sure about other scenarios.

Regarding the random helper calls, aside from the rng, I've based myself on the stdlib implementation mostly, however I noticed what I believe to be a bug in the stdlib at the location where possible modulo bias is removed. Please have a good look at this, I don't want to worsen things. :)
I've tested it with a `randMax=255` (uint8) version and it "seems" to be correct now. (testing with uint64 version would not easily give you practical differences).

Aside from these changes, 1. and 2. could probably also avoid using random in general:
1. I've thought about passing a random node ID and then selecting all neighbours, but I think this too is similarly playable. Perhaps better would be just to not use that call at all and start doing `loopupRandom`, see: https://github.com/status-im/nim-eth/issues/271. It will probably be more resilient in general, especially in case you use smaller routing tables (smaller b factor, less bucket splits, less nodes)
2. Here we could select the bucket that was last validated, I guess the random part is more of a simpler convenient way.
