### PR TITLE
use sqlite3 write-ahead logging to avoid excessive fsync()

### DIFF
--- a/eth/db/kvstore_sqlite3.nim
+++ b/eth/db/kvstore_sqlite3.nim
@@ -145,10 +145,11 @@ proc init*(
       discard sqlite3_close(env)
       return err($sqlite3_errstr(x))
 
-    if (let x = sqlite3_column_text(journalModePragma, 0); x != "wal"):
+    if (let x = sqlite3_column_text(journalModePragma, 0);
+        x != "memory" and x != "wal"):
       discard sqlite3_finalize(journalModePragma)
       discard sqlite3_close(env)
-      return err("Invalid result from pramga")
+      return err("Invalid result from pragma: " & $x)
 
   # TODO: check current version and implement schema versioning
   checkExec "PRAGMA user_version = 1;"

--- a/eth/db/kvstore_sqlite3.nim
+++ b/eth/db/kvstore_sqlite3.nim
@@ -149,7 +149,7 @@ proc init*(
         x != "memory" and x != "wal"):
       discard sqlite3_finalize(journalModePragma)
       discard sqlite3_close(env)
-      return err("Invalid result from pragma: " & $x)
+      return err("Invalid pragma result: " & $x)
 
   # TODO: check current version and implement schema versioning
   checkExec "PRAGMA user_version = 1;"


### PR DESCRIPTION
https://github.com/jasonrohrer/wallClockProfiler revealed that `fsync()` had become, even before BLST, a bottleneck for `store_block()` in `nim-beacon-chain`. This switches `journal_mode` from the default `DELETE` to `WAL` to ameliorate that bottleneck, as https://www.sqlite.org/wal.html describes that:

- WAL is significantly faster in most scenarios.
- WAL uses many fewer fsync() operations and is thus less vulnerable to problems on systems where the fsync() system call is broken. 

https://www.cs.utexas.edu/~vijay/papers/apsys17-sqlite.pdf suggests that, indeed, WAL journal mode provides substantial speed increases for many small transactions.