### PR TITLE
Add discovery v5.1 implementation

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -53,12 +53,20 @@ proc runP2pTests() =
       "test_lru",
       "test_discoveryv5",
       "test_discv5_encoding",
+      "test_discv51_encoding",
       "test_routing_table"
     ]:
     runTest("tests/p2p/" & filename)
 
+proc runDiscv51Test() =
+  let path = "tests/p2p/test_discoveryv5"
+  echo "\nRunning: ", path
+  exec "nim c -r -d:UseDiscv51=true -d:release -d:chronicles_log_level=ERROR --verbosity:0 --hints:off " & path
+  rmFile path
+
 task test_p2p, "run p2p tests":
   runP2pTests()
+  runDiscv51Test()
 
 proc runRlpTests() =
   runTest("tests/rlp/all_tests")

--- a/eth/p2p/discoveryv5/dcli.nim
+++ b/eth/p2p/discoveryv5/dcli.nim
@@ -4,12 +4,14 @@ import
   stew/byteutils, confutils/std/net,
   eth/keys, eth/net/nat, enr, node
 
+### This is all just temporary to be compatible with both versions
 const UseDiscv51* {.booldefine.} = false
 
 when UseDiscv51:
   import protocolv1
 else:
   import protocol
+###
 
 type
   DiscoveryCmd* = enum
@@ -173,7 +175,10 @@ proc run(config: DiscoveryConf) =
     else:
       echo "No Pong message returned"
   of findnode:
-    let nodes = waitFor d.findNode(config.findNodeTarget, config.distance)
+    when UseDiscv51:
+      let nodes = waitFor d.findNode(config.findNodeTarget, @[config.distance])
+    else:
+      let nodes = waitFor d.findNode(config.findNodeTarget, config.distance)
     if nodes.isOk():
       echo "Received valid records:"
       for node in nodes[]:

--- a/eth/p2p/discoveryv5/dcli.nim
+++ b/eth/p2p/discoveryv5/dcli.nim
@@ -2,7 +2,14 @@ import
   std/[options, strutils],
   chronos, chronicles, chronicles/topics_registry, confutils, metrics,
   stew/byteutils, confutils/std/net,
-  eth/keys, eth/net/nat, protocol, enr, node
+  eth/keys, eth/net/nat, enr, node
+
+const UseDiscv51* {.booldefine.} = false
+
+when UseDiscv51:
+  import protocolv1
+else:
+  import protocol
 
 type
   DiscoveryCmd* = enum

--- a/eth/p2p/discoveryv5/encodingv1.nim
+++ b/eth/p2p/discoveryv5/encodingv1.nim
@@ -478,8 +478,6 @@ proc decodeHandshakePacket(c: var Codec, fromAddr: Address, srcId: NodeId,
     ephKey, challenge.whoareyouData.idNonce)
 
   swap(secrets.readKey, secrets.writeKey)
-  c.sessions.store(srcId, fromAddr, secrets.readKey,
-    secrets.writeKey)
 
   let pt = decryptGCM(secrets.readKey, nonce, ct, header)
   if pt.isNone():
@@ -489,6 +487,11 @@ proc decodeHandshakePacket(c: var Codec, fromAddr: Address, srcId: NodeId,
     return err(DecryptError)
 
   let message = ? decodeMessage(pt.get())
+
+  # Only store the session secrets in case decryption was successful and also
+  # in case the message can get decoded.
+  c.sessions.store(srcId, fromAddr, secrets.readKey,
+    secrets.writeKey)
 
   return ok(Packet(flag: Flag.HandshakeMessage, message: message, srcId: srcId,
     node: newNode))

--- a/eth/p2p/discoveryv5/encodingv1.nim
+++ b/eth/p2p/discoveryv5/encodingv1.nim
@@ -187,10 +187,10 @@ proc encodeMessagePacket*(rng: var BrHmacDrbgContext, c: var Codec,
     # We might not have the node's keys if the handshake hasn't been performed
     # yet. That's fine, we send a random-packet and we will be responded with
     # a WHOAREYOU packet.
-    # TODO Minumum packet size is 63, we have here 16 + 23 + 32 = 71, so in theory
-    # we don't need to add random data? But then how do we know if decryption
-    # fails. Empty message automatically means -> whoareyou?
-    var randomData: array[8, byte]
+    # The 16 here is the aes gcm tag size, as an empty plain text would result
+    # in that size. TODO: Is that ok though? Shouldn't some extra data be added
+    # not to be recognized as a "random message"?
+    var randomData: array[16, byte]
     brHmacDrbgGenerate(rng, randomData)
     messageEncrypted.add(randomData)
 

--- a/eth/p2p/discoveryv5/encodingv1.nim
+++ b/eth/p2p/discoveryv5/encodingv1.nim
@@ -1,0 +1,540 @@
+import
+  std/[tables, options],
+  nimcrypto, stint, chronicles, stew/results, bearssl, stew/byteutils,
+  eth/[rlp, keys], typesv1, node, enr, hkdf, sessions
+
+export keys
+
+{.push raises: [Defect].}
+
+const
+  version: uint8 = 1
+  idNoncePrefix = "discovery-id-nonce"
+  keyAgreementPrefix = "discovery v5 key agreement"
+  protocolIdStr = "discv5  "
+  protocolId = toBytes(protocolIdStr)
+  gcmNonceSize* = 12
+  idNonceSize* = 32
+  gcmTagSize* = 16
+  ivSize = 16
+  staticHeaderSize = protocolId.len + sizeof(NodeId) + 1 + 2
+  authdataHeadSize = 1 + gcmNonceSize + 1 + 1
+
+type
+  AESGCMNonce* = array[gcmNonceSize, byte]
+  IdNonce* = array[idNonceSize, byte]
+
+  WhoareyouData* = object
+    requestNonce*: AESGCMNonce
+    idNonce*: IdNonce
+    recordSeq*: uint64
+
+  Challenge* = object
+    whoareyouData*: WhoareyouData
+    pubkey*: Option[PublicKey]
+
+  StaticHeader* = object
+    srcId: NodeId
+    flag: Flag
+    authdataSize: uint16
+
+  HandshakeSecrets* = object
+    writeKey*: AesKey
+    readKey*: AesKey
+
+  Flag* = enum
+    OrdinaryMessage = 0x00
+    Whoareyou = 0x01
+    HandshakeMessage = 0x02
+
+  Packet* = object
+    case flag*: Flag
+    of OrdinaryMessage:
+      messageOpt*: Option[Message]
+      requestNonce*: AESGCMNonce
+    of Whoareyou:
+      whoareyou*: WhoareyouData
+    of HandshakeMessage:
+      message*: Message # In a handshake we expect to always be able to decrypt
+      # TODO record or node immediately?
+      node*: Option[Node]
+    srcId*: NodeId
+
+  Codec* = object
+    localNode*: Node
+    privKey*: PrivateKey
+    handshakes*: Table[HandShakeKey, Challenge]
+    sessions*: Sessions
+
+  DecodeError* = enum
+    HandshakeError = "discv5: handshake failed"
+    PacketError = "discv5: invalid packet"
+    DecryptError = "discv5: decryption failed"
+    UnsupportedMessage = "discv5: unsupported message"
+
+  DecodeResult*[T] = Result[T, DecodeError]
+  EncodeResult*[T] = Result[T, cstring]
+
+proc mapErrTo[T, E](r: Result[T, E], v: static DecodeError):
+    DecodeResult[T] =
+  r.mapErr(proc (e: E): DecodeError = v)
+
+proc idNonceHash(nonce, ephkey: openarray[byte]): MDigest[256] =
+  var ctx: sha256
+  ctx.init()
+  ctx.update(idNoncePrefix)
+  ctx.update(nonce)
+  ctx.update(ephkey)
+  result = ctx.finish()
+  ctx.clear()
+
+proc signIDNonce*(privKey: PrivateKey, idNonce, ephKey: openarray[byte]):
+    SignatureNR =
+  signNR(privKey, SkMessage(idNonceHash(idNonce, ephKey).data))
+
+proc deriveKeys*(n1, n2: NodeID, priv: PrivateKey, pub: PublicKey,
+    idNonce: openarray[byte]): HandshakeSecrets =
+  let eph = ecdhRawFull(priv, pub)
+
+  var info = newSeqOfCap[byte](keyAgreementPrefix.len + 32 * 2)
+  for i, c in keyAgreementPrefix: info.add(byte(c))
+  info.add(n1.toByteArrayBE())
+  info.add(n2.toByteArrayBE())
+
+  var secrets: HandshakeSecrets
+  static: assert(sizeof(secrets) == aesKeySize * 2)
+  var res = cast[ptr UncheckedArray[byte]](addr secrets)
+  hkdf(sha256, eph.data, idNonce, info, toOpenArray(res, 0, sizeof(secrets) - 1))
+  secrets
+
+proc encryptGCM*(key, nonce, pt, authData: openarray[byte]): seq[byte] =
+  var ectx: GCM[aes128]
+  ectx.init(key, nonce, authData)
+  result = newSeq[byte](pt.len + gcmTagSize)
+  ectx.encrypt(pt, result)
+  ectx.getTag(result.toOpenArray(pt.len, result.high))
+  ectx.clear()
+
+proc decryptGCM*(key: AesKey, nonce, ct, authData: openarray[byte]):
+    Option[seq[byte]] =
+  if ct.len <= gcmTagSize:
+    debug "cipher is missing tag", len = ct.len
+    return
+
+  var dctx: GCM[aes128]
+  dctx.init(key, nonce, authData)
+  var res = newSeq[byte](ct.len - gcmTagSize)
+  var tag: array[gcmTagSize, byte]
+  dctx.decrypt(ct.toOpenArray(0, ct.high - gcmTagSize), res)
+  dctx.getTag(tag)
+  dctx.clear()
+
+  if tag != ct.toOpenArray(ct.len - gcmTagSize, ct.high):
+    return
+
+  return some(res)
+
+proc encryptHeader*(id: NodeId, iv, header: openarray[byte]): seq[byte] =
+  var ectx: CTR[aes128]
+  ectx.init(id.toByteArrayBE().toOpenArray(0, 15), iv)
+  result = newSeq[byte](header.len)
+  ectx.encrypt(header, result)
+  ectx.clear()
+
+proc encodeStaticHeader*(srcId: NodeId, flag: Flag, authSize: int): seq[byte] =
+  result.add(protocolId)
+  result.add(srcId.toByteArrayBE())
+  result.add(byte(flag))
+  # TODO: assert on authSize of > 2^16?
+  result.add((uint16(authSize)).toBytesBE())
+
+proc encodeMessagePacket*(rng: var BrHmacDrbgContext, c: var Codec,
+    toId: NodeID, toAddr: Address, message: openarray[byte]):
+    (seq[byte], AESGCMNonce) =
+  var authdata: AESGCMNonce
+  brHmacDrbgGenerate(rng, authdata) # Random AESGCM nonce
+
+  # static-header
+  let staticHeader = encodeStaticHeader(c.localNode.id, Flag.OrdinaryMessage,
+    authdata.len())
+  # header = static-header || authdata
+  var header: seq[byte]
+  header.add(staticHeader)
+  header.add(authdata)
+
+  # message
+  var messageEncrypted: seq[byte]
+  var writeKey, readKey: AesKey
+  if c.sessions.load(toId, toAddr, readKey, writeKey):
+    messageEncrypted = encryptGCM(writeKey, authdata, message, header)
+  else:
+    # We might not have the node's keys if the handshake hasn't been performed
+    # yet. That's fine, we send a random-packet and we will be responded with
+    # a WHOAREYOU packet.
+    # TODO: What is minimum size of an encrypted message that we should provided
+    # here?
+    var randomData: array[44, byte]
+    brHmacDrbgGenerate(rng, randomData)
+    messageEncrypted.add(randomData)
+
+  var iv: array[ivSize, byte]
+  brHmacDrbgGenerate(rng, iv) # Random IV
+
+  let maskedHeader = encryptHeader(toId, iv, header)
+
+  var packet: seq[byte]
+  packet.add(iv)
+  packet.add(maskedHeader)
+  packet.add(messageEncrypted)
+
+  return (packet, authdata)
+
+proc encodeWhoareyouPacket*(rng: var BrHmacDrbgContext, c: var Codec,
+    toId: NodeID, requestNonce: AESGCMNonce, idNonce: IdNonce, enrSeq: uint64):
+    seq[byte] =
+  # authdata
+  var authdata: seq[byte]
+  authdata.add(requestNonce)
+  authdata.add(idNonce)
+  authdata.add(enrSeq.tobytesBE)
+
+  # static-header
+  let staticHeader = encodeStaticHeader(c.localNode.id, Flag.Whoareyou,
+    authdata.len()) # authdata will always be 52 bytes
+
+  # header = static-header || authdata
+  var header: seq[byte]
+  header.add(staticHeader)
+  header.add(authdata)
+
+  var iv: array[ivSize, byte]
+  brHmacDrbgGenerate(rng, iv) # Random IV
+
+  let maskedHeader = encryptHeader(toId, iv, header)
+
+  var packet: seq[byte]
+  packet.add(iv)
+  packet.add(maskedHeader)
+
+  return packet
+
+proc encodeHandshakePacket*(rng: var BrHmacDrbgContext, c: var Codec,
+    toId: NodeID, toAddr: Address, message: openarray[byte], idNonce: IdNonce,
+    enrSeq: uint64, pubkey: PublicKey): seq[byte] =
+  var header: seq[byte]
+  var nonce: AESGCMNonce
+  brHmacDrbgGenerate(rng, nonce)
+
+  var authdata: seq[byte]
+  var authdataHead: seq[byte]
+  authdataHead.add(version)
+  authdataHead.add(nonce)
+  authdataHead.add(64'u8) # sig-size: 64
+  authdataHead.add(33'u8) # eph-key-size: 33
+  authdata.add(authdataHead)
+
+  let ephKeys = KeyPair.random(rng)
+  let signature = signIDNonce(c.privKey, idNonce,
+    ephKeys.pubkey.toRawCompressed())
+
+  authdata.add(signature.toRaw())
+  # compressed pub key format (33 bytes)
+  authdata.add(ephKeys.pubkey.toRawCompressed())
+
+  # Add ENR of sequence number is newer
+  if enrSeq < c.localNode.record.seqNum:
+    authdata.add(encode(c.localNode.record))
+
+  let secrets = deriveKeys(c.localNode.id, toId, ephKeys.seckey, pubkey,
+    idNonce)
+
+  # Header
+  let staticHeader = encodeStaticHeader(c.localNode.id, Flag.HandshakeMessage,
+    authdata.len())
+
+  header.add(staticHeader)
+  header.add(authdata)
+
+  c.sessions.store(toId, toAddr, secrets.readKey, secrets.writeKey)
+  let messageEncrypted = encryptGCM(secrets.writeKey, nonce, message, header)
+
+  var iv: array[ivSize, byte]
+  brHmacDrbgGenerate(rng, iv) # Random IV
+
+  let maskedHeader = encryptHeader(toId, iv, header)
+
+  var packet: seq[byte]
+  packet.add(iv)
+  packet.add(maskedHeader)
+  packet.add(messageEncrypted)
+
+  return packet
+
+proc decodeHeader*(id: NodeId, iv, maskedHeader: openarray[byte]):
+    DecodeResult[(StaticHeader, seq[byte])] =
+  # Smallest header is staticHeader + gcm nonce for a ordinary message
+  let inputLen = maskedHeader.len
+  if inputLen < staticHeaderSize + gcmNonceSize:
+    return err(PacketError)
+
+  var ectx: CTR[aes128]
+  ectx.init(id.toByteArrayBE().toOpenArray(0, ivSize - 1), iv)
+  # Decrypt static-header part of the header
+  var staticHeader = newSeq[byte](staticHeaderSize)
+  ectx.decrypt(maskedHeader.toOpenArray(0, staticHeaderSize - 1), staticHeader)
+
+  # Check fields of the static-header
+  if staticHeader.toOpenArray(0, protocolId.len - 1) != protocolId:
+    return err(PacketError)
+
+  let srcId = NodeId.fromBytesBE(staticHeader.toOpenArray(8, 39))
+
+  if staticHeader[40] < Flag.low.byte or staticHeader[40] > Flag.high.byte:
+    return err(PacketError)
+  let flag = cast[Flag](staticHeader[40])
+
+  let authdataSize = uint16.fromBytesBE(staticHeader.toOpenArray(41, 42))
+  # Input should have minimum size of staticHeader + provided authdata size
+  if inputLen < staticHeaderSize + int(authdataSize):
+    return err(PacketError)
+
+  var authdata = newSeq[byte](int(authdataSize))
+  ectx.decrypt(maskedHeader.toOpenArray(staticHeaderSize,
+    staticHeaderSize + int(authdataSize) - 1), authdata)
+  ectx.clear()
+
+  ok((StaticHeader(srcId: srcId, flag: flag, authdataSize: authdataSize),
+    staticHeader & authdata))
+
+proc decodeMessage*(body: openarray[byte]): DecodeResult[Message] =
+  ## Decodes to the specific `Message` type.
+  if body.len < 1:
+    return err(PacketError)
+
+  if body[0] < MessageKind.low.byte or body[0] > MessageKind.high.byte:
+    return err(PacketError)
+
+  # This cast is covered by the above check (else we could get enum with invalid
+  # data!). However, can't we do this in a cleaner way?
+  let kind = cast[MessageKind](body[0])
+  var message = Message(kind: kind)
+  var rlp = rlpFromBytes(body.toOpenArray(1, body.high))
+  if rlp.enterList:
+    try:
+      message.reqId = rlp.read(RequestId)
+    except RlpError:
+      return err(PacketError)
+
+    proc decode[T](rlp: var Rlp, v: var T)
+        {.inline, nimcall, raises:[RlpError, ValueError, Defect].} =
+      for k, v in v.fieldPairs:
+        v = rlp.read(typeof(v))
+
+    try:
+      case kind
+      of unused: return err(PacketError)
+      of ping: rlp.decode(message.ping)
+      of pong: rlp.decode(message.pong)
+      of findNode: rlp.decode(message.findNode)
+      of nodes: rlp.decode(message.nodes)
+      of talkreq, talkresp, regtopic, ticket, regconfirmation, topicquery:
+        # TODO: Implement support for topic advertisement and talkreq/resp
+        return err(UnsupportedMessage)
+    except RlpError, ValueError:
+      return err(PacketError)
+
+    ok(message)
+  else:
+    err(PacketError)
+
+proc decodeMessagePacket(c: var Codec, fromAddr: Address, srcId: NodeId,
+    ct, header: openArray[byte]): DecodeResult[Packet] =
+    # We now know the exact size that the header should be
+    if header.len != staticHeaderSize + gcmNonceSize:
+      return err(PacketError)
+
+    var nonce: AESGCMNonce
+    copyMem(addr nonce[0], unsafeAddr header[staticHeaderSize], gcmNonceSize)
+
+    var writeKey, readKey: AesKey
+    if not c.sessions.load(srcId, fromAddr, readKey, writeKey):
+      # Don't consider this an error, simply haven't done a handshake yet or
+      # the session got removed.
+      trace "Decrypting failed (no keys)"
+      return ok(Packet(flag: Flag.OrdinaryMessage, requestNonce: nonce,
+        srcId: srcId))
+
+    let pt = decryptGCM(readKey, nonce, ct, header)
+    if pt.isNone():
+      # Don't consider this an error, the session got probably removed at the
+      # peer's side.
+      trace "Decrypting failed (invalid keys)"
+      c.sessions.del(srcId, fromAddr)
+      return ok(Packet(flag: Flag.OrdinaryMessage, requestNonce: nonce,
+        srcId: srcId))
+
+    let message = ? decodeMessage(pt.get())
+
+    return ok(Packet(flag: Flag.OrdinaryMessage,
+      messageOpt: some(message), requestNonce: nonce, srcId: srcId))
+
+proc decodeWhoareyouPacket(c: var Codec, srcId: NodeId,
+    authdata: openArray[byte]): DecodeResult[Packet] =
+  # We now know the exact size that the authdata should be
+  if authdata.len != gcmNonceSize + idNonceSize + sizeof(uint64):
+    return err(PacketError)
+
+  var requestNonce: AESGCMNonce
+  copyMem(addr requestNonce[0], unsafeAddr authdata[0], gcmNonceSize)
+  var idNonce: IdNonce
+  copyMem(addr idNonce[0], unsafeAddr authdata[gcmNonceSize], idNonceSize)
+  let whoareyou = WhoareyouData(requestNonce: requestNonce, idNonce: idNonce,
+    recordSeq: uint64.fromBytesBE(
+      authdata.toOpenArray(gcmNonceSize + idNonceSize, authdata.high)))
+
+  return ok(Packet(flag: Flag.Whoareyou, whoareyou: whoareyou,
+    srcId: srcId))
+
+proc decodeHandshakePacket(c: var Codec, fromAddr: Address, srcId: NodeId,
+    ct, header: openArray[byte]): DecodeResult[Packet] =
+  # Checking if there is enough data to decode authdata-head
+  if header.len <= staticHeaderSize + authdataHeadSize:
+    return err(PacketError)
+
+  # check version
+  let authData = header[staticHeaderSize..header.high()]
+  if uint8(authData[0]) != version:
+    return err(HandshakeError)
+
+  let
+    nonce = authdata[1..12]
+    sigSize = uint8(authdata[13])
+    ephKeySize = uint8(authdata[14])
+
+  # If smaller, as it can be equal and bigger (in case it holds an enr)
+  if header.len < staticHeaderSize + authdataHeadSize + int(sigSize) + int(ephKeySize):
+    return err(PacketError)
+
+  let key = HandShakeKey(nodeId: srcId, address: $fromAddr)
+  var challenge: Challenge
+  if not c.handshakes.pop(key, challenge):
+    debug "Decoding failed (no previous stored handshake challenge)"
+    return err(HandshakeError)
+
+  # This should be the compressed public key. But as we use the provided
+  # ephKeySize, it should also work with full sized key. However, the idNonce
+  # signature verification will fail.
+  let
+    ephKeyPos = authdataHeadSize + int(sigSize)
+    ephKeyRaw = authdata[ephKeyPos..<ephKeyPos + int(ephKeySize)]
+    ephKey = ? PublicKey.fromRaw(ephKeyRaw).mapErrTo(HandshakeError)
+
+  var record: Option[enr.Record]
+  let recordPos = ephKeyPos + int(ephKeySize)
+  if authdata.len() > recordPos:
+    # There is possibly an ENR still
+    try:
+      # Signature check of record happens in decode.
+      record = some(rlp.decode(authdata.toOpenArray(recordPos, authdata.high),
+        enr.Record))
+    except RlpError, ValueError:
+      return err(HandshakeError)
+
+  var pubKey: PublicKey
+  var newNode: Option[Node]
+  # TODO: Shall we return Node or Record? Record makes more sense, but we do
+  # need the pubkey and the nodeid
+  if record.isSome():
+    # Node returned might not have an address or not a valid address.
+    let node = ? newNode(record.get()).mapErrTo(HandshakeError)
+    if node.id != srcId:
+      return err(HandshakeError)
+
+    pubKey = node.pubKey
+    newNode = some(node)
+  else:
+    if challenge.pubkey.isSome():
+      pubKey = challenge.pubkey.get()
+    else:
+      # We should have received a Record in this case.
+      return err(HandshakeError)
+
+  # Verify the id-nonce-sig
+  let sig = ? SignatureNR.fromRaw(
+    authdata.toOpenArray(authdataHeadSize,
+      authdataHeadSize + int(sigSize) - 1)).mapErrTo(HandshakeError)
+
+  let h = idNonceHash(challenge.whoareyouData.idNonce, ephKeyRaw)
+  if not verify(sig, SkMessage(h.data), pubkey):
+    return err(HandshakeError)
+
+  # Do the key derivation step only after id-nonce-sig is verified!
+  var secrets = deriveKeys(srcId, c.localNode.id, c.privKey,
+    ephKey, challenge.whoareyouData.idNonce)
+
+  swap(secrets.readKey, secrets.writeKey)
+  c.sessions.store(srcId, fromAddr, secrets.readKey,
+    secrets.writeKey)
+
+  let pt = decryptGCM(secrets.readKey, nonce, ct, header)
+  if pt.isNone():
+    c.sessions.del(srcId, fromAddr)
+    # Differently from an ordinary message, this is seen as an error as the
+    # secrets just got negotiated in the handshake.
+    return err(DecryptError)
+
+  let message = ? decodeMessage(pt.get())
+
+  return ok(Packet(flag: Flag.HandshakeMessage, message: message, srcId: srcId,
+    node: newNode))
+
+proc decodePacket*(c: var Codec, fromAddr: Address, input: openArray[byte]):
+    DecodeResult[Packet] =
+  ## Decode a packet. This can be a regular packet or a packet in response to a
+  ## WHOAREYOU packet. In case of the latter a `newNode` might be provided.
+  # TODO: First size check. Which size however?
+  # IVSize + staticHeaderSize + 12 + ...? What is minimum message size?
+  if input.len() <= ivSize + staticHeaderSize + gcmNonceSize:
+    return err(PacketError)
+  # TODO: Just pass in the full input? Makes more sense perhaps..
+  let (staticHeader, header) = ? decodeHeader(c.localNode.id,
+    input.toOpenArray(0, ivSize - 1), # IV
+    # Don't know the size yet of the full header, so we pass all.
+    input.toOpenArray(ivSize, input.high))
+
+  case staticHeader.flag
+  of OrdinaryMessage:
+    # TODO: Extra size check on ct data?
+    return decodeMessagePacket(c, fromAddr, staticHeader.srcId,
+      input.toOpenArray(ivSize + header.len, input.high), header)
+
+  of Whoareyou:
+    # Header size got checked in decode header
+    return decodeWhoareyouPacket(c, staticHeader.srcId,
+      header.toOpenArray(staticHeaderSize, header.high()))
+
+  of HandshakeMessage:
+    # TODO: Extra size check on ct data?
+    return decodeHandshakePacket(c, fromAddr, staticHeader.srcId,
+      input.toOpenArray(ivSize + header.len, input.high), header)
+
+proc init*(T: type RequestId, rng: var BrHmacDrbgContext): T =
+  var buf: array[sizeof(T), byte]
+  brHmacDrbgGenerate(rng, buf)
+  var id: T
+  copyMem(addr id, addr buf[0], sizeof(id))
+  id
+
+proc numFields(T: typedesc): int =
+  for k, v in fieldPairs(default(T)): inc result
+
+proc encodeMessage*[T: SomeMessage](p: T, reqId: RequestId): seq[byte] =
+  result = newSeqOfCap[byte](64)
+  result.add(messageKind(T).ord)
+
+  const sz = numFields(T)
+  var writer = initRlpList(sz + 1)
+  writer.append(reqId)
+  for k, v in fieldPairs(p):
+    writer.append(v)
+  result.add(writer.finish())

--- a/eth/p2p/discoveryv5/encodingv1.nim
+++ b/eth/p2p/discoveryv5/encodingv1.nim
@@ -337,9 +337,14 @@ proc decodeMessage*(body: openarray[byte]): DecodeResult[Message] =
       of pong: rlp.decode(message.pong)
       of findNode: rlp.decode(message.findNode)
       of nodes: rlp.decode(message.nodes)
-      of talkreq, talkresp, regtopic, ticket, regconfirmation, topicquery:
-        # TODO: Implement support for topic advertisement and talkreq/resp
-        return err(UnsupportedMessage)
+      of talkreq: rlp.decode(message.talkreq)
+      of talkresp: rlp.decode(message.talkresp)
+      of regtopic, ticket, regconfirmation, topicquery:
+        # We just pass the empty type of this message without attempting to
+        # decode, so that the protocol knows what was received.
+        # But we ignore the message as per specification as "the content and
+        # semantics of this message are not final".
+        discard
     except RlpError, ValueError:
       return err(PacketError)
 

--- a/eth/p2p/discoveryv5/encodingv1.nim
+++ b/eth/p2p/discoveryv5/encodingv1.nim
@@ -351,9 +351,8 @@ proc decodeMessage*(body: openarray[byte]): DecodeResult[Message] =
   var rlp = rlpFromBytes(body.toOpenArray(1, body.high))
   if rlp.enterList:
     try:
-      # TODO: 8 bytes limitation on RequestId decode.
       message.reqId = rlp.read(RequestId)
-    except RlpError:
+    except RlpError, ValueError:
       return err(PacketError)
 
     proc decode[T](rlp: var Rlp, v: var T)
@@ -556,9 +555,9 @@ proc decodePacket*(c: var Codec, fromAddr: Address, input: openArray[byte]):
       input.toOpenArray(ivSize + header.len, input.high))
 
 proc init*(T: type RequestId, rng: var BrHmacDrbgContext): T =
-  var id = newSeq[byte](8) # RequestId must be <= 8 bytes
-  brHmacDrbgGenerate(rng, id)
-  id
+  var reqId = RequestId(id: newSeq[byte](8)) # RequestId must be <= 8 bytes
+  brHmacDrbgGenerate(rng, reqId.id)
+  reqId
 
 proc numFields(T: typedesc): int =
   for k, v in fieldPairs(default(T)): inc result

--- a/eth/p2p/discoveryv5/protocolv1.nim
+++ b/eth/p2p/discoveryv5/protocolv1.nim
@@ -1,0 +1,799 @@
+# nim-eth - Node Discovery Protocol v5
+# Copyright (c) 2020 Status Research & Development GmbH
+# Licensed under either of
+#   * Apache License, version 2.0, (LICENSE-APACHEv2)
+#   * MIT license (LICENSE-MIT)
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+## Node Discovery Protocol v5
+##
+## Node discovery protocol implementation as per specification:
+## https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md
+##
+## This node discovery protocol implementation uses the same underlying
+## implementation of routing table as is also used for the discovery v4
+## implementation, which is the same or similar as the one described in the
+## original Kademlia paper:
+## https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
+##
+## This might not be the most optimal implementation for the node discovery
+## protocol v5. Why?
+##
+## The Kademlia paper describes an implementation that starts off from one
+## k-bucket, and keeps splitting the bucket as more nodes are discovered and
+## added. The bucket splits only on the part of the binary tree where our own
+## node its id belongs too (same prefix). Resulting eventually in a k-bucket per
+## logarithmic distance (log base2 distance). Well, not really, as nodes with
+## ids in the closer distance ranges will never be found. And because of this an
+## optimisation is done where buckets will also split sometimes even if the
+## nodes own id does not have the same prefix (this is to avoid creating highly
+## unbalanced branches which would require longer lookups).
+##
+## Now, some implementations take a more simplified approach. They just create
+## directly a bucket for each possible logarithmic distance (e.g. here 1->256).
+## Some implementations also don't create buckets with logarithmic distance
+## lower than a certain value (e.g. only 1/15th of the highest buckets),
+## because the closer to the node (the lower the distance), the less chance
+## there is to still find nodes.
+##
+## The discovery protocol v4 its `FindNode` call will request the k closest
+## nodes. As does original Kademlia. This effectively puts the work at the node
+## that gets the request. This node will have to check its buckets and gather
+## the closest. Some implementations go over all the nodes in all the buckets
+## for this (e.g. go-ethereum discovery v4). However, in our bucket splitting
+## approach, this search is improved.
+##
+## In the discovery protocol v5 the `FindNode` call is changed and now the
+## logarithmic distance is passed as parameter instead of the NodeId. And only
+## nodes that match that logarithmic distance are allowed to be returned.
+## This change was made to not put the trust at the requested node for selecting
+## the closest nodes. To counter a possible (mistaken) difference in
+## implementation, but more importantly for security reasons. See also:
+## https://github.com/ethereum/devp2p/blob/master/discv5/discv5-rationale.md#115-guard-against-kademlia-implementation-flaws
+##
+## The result is that in an implementation which just stores buckets per
+## logarithmic distance, it simply needs to return the right bucket. In our
+## split-bucket implementation, this cannot be done as such and thus the closest
+## neighbours search is still done. And to do this, a reverse calculation of an
+## id at given logarithmic distance is needed (which is why there is the
+## `idAtDistance` proc). Next, nodes with invalid distances need to be filtered
+## out to be compliant to the specification. This can most likely get further
+## optimised, but it sounds likely better to switch away from the split-bucket
+## approach. I believe that the main benefit it has is improved lookups
+## (due to no unbalanced branches), and it looks like this will be negated by
+## limiting the returned nodes to only the ones of the requested logarithmic
+## distance for the `FindNode` call.
+
+## This `FindNode` change in discovery v5 will also have an effect on the
+## efficiency of the network. Work will be moved from the receiver of
+## `FindNodes` to the requester. But this also means more network traffic,
+## as less nodes will potentially be passed around per `FindNode` call, and thus
+## more requests will be needed for a lookup (adding bandwidth and latency).
+## This might be a concern for mobile devices.
+
+import
+  std/[tables, sets, options, math, sequtils],
+  stew/shims/net as stewNet, json_serialization/std/net,
+  stew/[byteutils, endians2], chronicles, chronos, stint, bearssl,
+  eth/[rlp, keys, async_utils],
+  typesv1, encodingv1, node, routing_table, enr, random2, sessions
+
+import nimcrypto except toHex
+
+export options
+
+{.push raises: [Defect].}
+
+logScope:
+  topics = "discv5"
+
+const
+  alpha = 3 ## Kademlia concurrency factor
+  lookupRequestLimit = 3
+  findNodeResultLimit = 15 # applies in FINDNODE handler
+  maxNodesPerMessage = 3
+  lookupInterval = 60.seconds ## Interval of launching a random lookup to
+  ## populate the routing table. go-ethereum seems to do 3 runs every 30
+  ## minutes. Trinity starts one every minute.
+  revalidateMax = 1000 ## Revalidation of a peer is done between 0 and this
+  ## value in milliseconds
+  handshakeTimeout* = 2.seconds ## timeout for the reply on the
+  ## whoareyou message
+  responseTimeout* = 4.seconds ## timeout for the response of a request-response
+  ## call
+
+type
+  Protocol* = ref object
+    transp: DatagramTransport
+    localNode*: Node
+    privateKey: PrivateKey
+    bindAddress: Address ## UDP binding address
+    pendingRequests: Table[AESGCMNonce, PendingRequest]
+    routingTable: RoutingTable
+    codec*: Codec
+    awaitedMessages: Table[(NodeId, RequestId), Future[Option[Message]]]
+    lookupLoop: Future[void]
+    revalidateLoop: Future[void]
+    bootstrapRecords*: seq[Record]
+    rng*: ref BrHmacDrbgContext
+
+  PendingRequest = object
+    node: Node
+    message: seq[byte]
+
+  DiscResult*[T] = Result[T, cstring]
+
+proc addNode*(d: Protocol, node: Node): bool =
+  ## Add `Node` to discovery routing table.
+  ##
+  ## Returns false only if `Node` is not eligable for adding (no Address).
+  if node.address.isSome():
+    # Only add nodes with an address to the routing table
+    discard d.routingTable.addNode(node)
+    return true
+
+proc addNode*(d: Protocol, r: Record): bool =
+  ## Add `Node` from a `Record` to discovery routing table.
+  ##
+  ## Returns false only if no valid `Node` can be created from the `Record` or
+  ## on the conditions of `addNode` from a `Node`.
+  let node = newNode(r)
+  if node.isOk():
+    return d.addNode(node[])
+
+proc addNode*(d: Protocol, enr: EnrUri): bool =
+  ## Add `Node` from a ENR URI to discovery routing table.
+  ##
+  ## Returns false if no valid ENR URI, or on the conditions of `addNode` from
+  ## an `Record`.
+  var r: Record
+  let res = r.fromUri(enr)
+  if res:
+    return d.addNode(r)
+
+proc getNode*(d: Protocol, id: NodeId): Option[Node] =
+  ## Get the node with id from the routing table.
+  d.routingTable.getNode(id)
+
+proc randomNodes*(d: Protocol, maxAmount: int): seq[Node] =
+  ## Get a `maxAmount` of random nodes from the local routing table.
+  d.routingTable.randomNodes(maxAmount)
+
+proc randomNodes*(d: Protocol, maxAmount: int,
+    pred: proc(x: Node): bool {.gcsafe, noSideEffect.}): seq[Node] =
+  ## Get a `maxAmount` of random nodes from the local routing table with the
+  ## `pred` predicate function applied as filter on the nodes selected.
+  d.routingTable.randomNodes(maxAmount, pred)
+
+proc randomNodes*(d: Protocol, maxAmount: int,
+  enrField: (string, seq[byte])): seq[Node] =
+  ## Get a `maxAmount` of random nodes from the local routing table. The
+  ## the nodes selected are filtered by provided `enrField`.
+  d.randomNodes(maxAmount, proc(x: Node): bool = x.record.contains(enrField))
+
+proc neighbours*(d: Protocol, id: NodeId, k: int = BUCKET_SIZE): seq[Node] =
+  ## Return up to k neighbours (closest node ids) of the given node id.
+  d.routingTable.neighbours(id, k)
+
+proc nodesDiscovered*(d: Protocol): int {.inline.} = d.routingTable.len
+
+func privKey*(d: Protocol): lent PrivateKey =
+  d.privateKey
+
+func getRecord*(d: Protocol): Record =
+  ## Get the ENR of the local node.
+  d.localNode.record
+
+proc updateRecord*(
+    d: Protocol, enrFields: openarray[(string, seq[byte])]): DiscResult[void] =
+  ## Update the ENR of the local node with provided `enrFields` k:v pairs.
+  let fields = mapIt(enrFields, toFieldPair(it[0], it[1]))
+  d.localNode.record.update(d.privateKey, fields)
+  # TODO: Would it make sense to actively ping ("broadcast") to all the peers
+  # we stored a handshake with in order to get that ENR updated?
+
+proc send(d: Protocol, a: Address, data: seq[byte]) =
+  let ta = initTAddress(a.ip, a.port)
+  try:
+    let f = d.transp.sendTo(ta, data)
+    f.callback = proc(data: pointer) {.gcsafe.} =
+      if f.failed:
+        # Could be `TransportUseClosedError` in case the transport is already
+        # closed, or could be `TransportOsError` in case of a socket error.
+        # In the latter case this would probably mostly occur if the network
+        # interface underneath gets disconnected or similar.
+        # TODO: Should this kind of error be propagated upwards? Probably, but
+        # it should not stop the process as that would reset the discovery
+        # progress in case there is even a small window of no connection.
+        # One case that needs this error available upwards is when revalidating
+        # nodes. Else the revalidation might end up clearing the routing tabl
+        # because of ping failures due to own network connection failure.
+        debug "Discovery send failed", msg = f.readError.msg
+  except Exception as e:
+    # TODO: General exception still being raised from Chronos, but in practice
+    # all CatchableErrors should be grabbed by the above `f.failed`.
+    if e of Defect:
+      raise (ref Defect)(e)
+    else: doAssert(false)
+
+proc send(d: Protocol, n: Node, data: seq[byte]) =
+  doAssert(n.address.isSome())
+  d.send(n.address.get(), data)
+
+proc sendNodes(d: Protocol, toId: NodeId, toAddr: Address, reqId: RequestId,
+    nodes: openarray[Node]) =
+  proc sendNodes(d: Protocol, toId: NodeId, toAddr: Address,
+      message: NodesMessage, reqId: RequestId) {.nimcall.} =
+    let (data, _) = encodeMessagePacket(d.rng[], d.codec, toId, toAddr,
+      encodeMessage(message, reqId))
+
+    d.send(toAddr, data)
+
+  if nodes.len == 0:
+    # In case of 0 nodes, a reply is still needed
+    d.sendNodes(toId, toAddr, NodesMessage(total: 1, enrs: @[]), reqId)
+    return
+
+  var message: NodesMessage
+  # TODO: Do the total calculation based on the max UDP packet size we want to
+  # send and the ENR size of all (max 16) nodes.
+  # Which UDP packet size to take? 1280? 576?
+  message.total = ceil(nodes.len / maxNodesPerMessage).uint32
+
+  for i in 0 ..< nodes.len:
+    message.enrs.add(nodes[i].record)
+    if message.enrs.len == maxNodesPerMessage:
+      d.sendNodes(toId, toAddr, message, reqId)
+      message.enrs.setLen(0)
+
+  if message.enrs.len != 0:
+    d.sendNodes(toId, toAddr, message, reqId)
+
+proc handlePing(d: Protocol, fromId: NodeId, fromAddr: Address,
+    ping: PingMessage, reqId: RequestId) =
+  let a = fromAddr
+  var pong: PongMessage
+  pong.enrSeq = d.localNode.record.seqNum
+  pong.ip = case a.ip.family
+    of IpAddressFamily.IPv4: @(a.ip.address_v4)
+    of IpAddressFamily.IPv6: @(a.ip.address_v6)
+  pong.port = a.port.uint16
+
+  let (data, _) = encodeMessagePacket(d.rng[], d.codec, fromId, fromAddr,
+    encodeMessage(pong, reqId))
+
+  d.send(fromAddr, data)
+
+proc handleFindNode(d: Protocol, fromId: NodeId, fromAddr: Address,
+    fn: FindNodeMessage, reqId: RequestId) =
+  if fn.distance == 0:
+    d.sendNodes(fromId, fromAddr, reqId, [d.localNode])
+  else:
+    let distance = min(fn.distance, 256)
+    d.sendNodes(fromId, fromAddr, reqId,
+      d.routingTable.neighboursAtDistance(distance, seenOnly = true))
+
+proc handleMessage(d: Protocol, srcId: NodeId, fromAddr: Address,
+    message: Message) {.raises:[Exception].} =
+  case message.kind
+  of ping:
+    d.handlePing(srcId, fromAddr, message.ping, message.reqId)
+  of findNode:
+    d.handleFindNode(srcId, fromAddr, message.findNode, message.reqId)
+  else:
+    var waiter: Future[Option[Message]]
+    if d.awaitedMessages.take((srcId, message.reqId), waiter):
+      waiter.complete(some(message)) # TODO: raises: [Exception]
+    else:
+      trace "Timed out or unrequested message", message = message.kind,
+        origin = fromAddr
+
+proc sendWhoareyou(d: Protocol, toId: NodeId, a: Address,
+    requestNonce: AESGCMNonce, node: Option[Node]) {.raises: [Exception].} =
+  var idNonce: IdNonce
+  brHmacDrbgGenerate(d.rng[], idNonce)
+
+  let
+    recordSeq = if node.isSome(): node.get().record.seqNum
+                else: 0
+    whoareyouData = WhoareyouData(requestNonce: requestNonce,
+      idNonce: idNonce, recordSeq: recordSeq)
+    pubkey = if node.isSome(): some(node.get().pubkey)
+             else: none(PublicKey)
+    challenge = Challenge(whoareyouData: whoareyouData, pubkey: pubkey)
+    key = HandShakeKey(nodeId: toId, address: $a)
+
+  if not d.codec.handshakes.hasKeyOrPut(key, challenge):
+    # TODO: raises: [Exception], but it shouldn't.
+    sleepAsync(handshakeTimeout).addCallback() do(data: pointer):
+    # TODO: should we still provide cancellation in case handshake completes
+    # correctly?
+      d.codec.handshakes.del(key)
+
+    let data = encodeWhoareyouPacket(d.rng[], d.codec, toId,
+      requestNonce, idNonce, recordSeq)
+
+    d.send(a, data)
+  else:
+    debug "Node with this id already has ongoing handshake, ignoring packet"
+
+proc receive*(d: Protocol, a: Address, packet: openArray[byte]) {.gcsafe,
+  raises: [
+    Defect,
+    # This just comes now from a future.complete() and `sendWhoareyou` which
+    # has it because of `sleepAsync` with `addCallback`, but practically, no
+    # CatchableError should be raised here, we just can't enforce it for now.
+    Exception
+  ].} =
+
+  let decoded = d.codec.decodePacket(a, packet)
+  if decoded.isOk:
+    let packet = decoded[]
+    case packet.flag
+    of OrdinaryMessage:
+      if packet.messageOpt.isSome():
+        trace "Received message"
+        d.handleMessage(packet.srcId, a, packet.messageOpt.get())
+      else:
+        trace "Not decryptable message packet received, respond with whoareyou",
+          srcId = packet.srcId, address = a
+        d.sendWhoareyou(packet.srcId, a, packet.requestNonce,
+          d.getNode(packet.srcId))
+
+    of Flag.Whoareyou:
+      trace "Received whoareyou packet"
+      var pr: PendingRequest
+      if d.pendingRequests.take(packet.whoareyou.requestNonce, pr):
+        let toNode = pr.node
+        # This is a node we previously contacted and thus must have an address.
+        doAssert(toNode.address.isSome())
+        let data = encodeHandshakePacket(d.rng[], d.codec, toNode.id,
+          toNode.address.get(), pr.message, packet.whoareyou.idNonce,
+          packet.whoareyou.recordSeq, toNode.pubkey)
+
+        d.send(toNode, data)
+      else:
+        debug "Timed out or unrequested Whoareyou packet"
+    of HandshakeMessage:
+      trace "Received handshake packet"
+      d.handleMessage(packet.srcId, a, packet.message)
+      # For a handshake message it is possible that we received an newer ENR.
+      # In that case we can add/update it to the routing table.
+      if packet.node.isSome():
+        let node = packet.node.get()
+        # Not filling table with nodes without correct IP in the ENR
+        # TODO: Should we care about this???
+        if node.address.isSome() and a == node.address.get():
+          debug "Adding new node to routing table", node = $node,
+            localNode = $d.localNode
+          discard d.addNode(node)
+
+  elif decoded.error == DecodeError.UnsupportedMessage:
+    # TODO: Probably should still complete handshake in these cases.
+    trace "Packet contained unsupported message"
+  elif decoded.error == DecodeError.PacketError:
+    debug "Packet decoding error", error = decoded.error
+  elif decoded.error == DecodeError.HandshakeError:
+    debug "Packet handshake error", error = decoded.error
+  elif decoded.error == DecodeError.DecryptError:
+    # This is a specific decryption error on a handshake. We do not send a
+    # new Whoareyou on these as it probably means there is a compatiblity
+    # issue and we might loop forever in failed handshakes with this peer.
+    debug "Packet decrypting error", error = decoded.error
+
+# TODO: Not sure why but need to pop the raises here as it is apparently not
+# enough to put it in the raises pragma of `processClient` and other async procs.
+{.pop.}
+# Next, below there is no more effort done in catching the general `Exception`
+# as async procs always require `Exception` in the raises pragma, see also:
+# https://github.com/status-im/nim-chronos/issues/98
+# So I don't bother for now and just add them in the raises pragma until this
+# gets fixed. It does not mean that we expect these calls to be raising
+# CatchableErrors, in fact, we really don't, but hey, they might, considering we
+# can't enforce it.
+proc processClient(transp: DatagramTransport, raddr: TransportAddress):
+    Future[void] {.async, gcsafe, raises: [Exception, Defect].} =
+  let proto = getUserData[Protocol](transp)
+
+  # TODO: should we use `peekMessage()` to avoid allocation?
+  # TODO: This can still raise general `Exception` while it probably should
+  # only give TransportOsError.
+  let buf = try: transp.getMessage()
+            except TransportOsError as e:
+              # This is likely to be local network connection issues.
+              error "Transport getMessage", exception = e.name, msg = e.msg
+              return
+            except Exception as e:
+              if e of Defect:
+                raise (ref Defect)(e)
+              else: doAssert(false)
+              return # Make compiler happy
+
+  let ip = try: raddr.address()
+           except ValueError as e:
+             error "Not a valid IpAddress", exception = e.name, msg = e.msg
+             return
+  let a = Address(ip: ValidIpAddress.init(ip), port: raddr.port)
+
+  try:
+    proto.receive(a, buf)
+  except Exception as e:
+    if e of Defect:
+      raise (ref Defect)(e)
+    else: doAssert(false)
+
+proc validIp(sender, address: IpAddress): bool {.raises: [Defect].} =
+  let
+    s = initTAddress(sender, Port(0))
+    a = initTAddress(address, Port(0))
+  if a.isAnyLocal():
+    return false
+  if a.isMulticast():
+    return false
+  if a.isLoopback() and not s.isLoopback():
+    return false
+  if a.isSiteLocal() and not s.isSiteLocal():
+    return false
+  # TODO: Also check for special reserved ip addresses:
+  # https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+  # https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
+  return true
+
+proc replaceNode(d: Protocol, n: Node) =
+  if n.record notin d.bootstrapRecords:
+    d.routingTable.replaceNode(n)
+  else:
+    # For now we never remove bootstrap nodes. It might make sense to actually
+    # do so and to retry them only in case we drop to a really low amount of
+    # peers in the routing table.
+    debug "Message request to bootstrap node failed", enr = toURI(n.record)
+
+# TODO: This could be improved to do the clean-up immediatily in case a non
+# whoareyou response does arrive, but we would need to store the AuthTag
+# somewhere
+proc registerRequest(d: Protocol, n: Node, message: seq[byte],
+    nonce: AESGCMNonce) {.raises: [Exception, Defect].} =
+  let request = PendingRequest(node: n, message: message)
+  if not d.pendingRequests.hasKeyOrPut(nonce, request):
+    # TODO: raises: [Exception]
+    sleepAsync(responseTimeout).addCallback() do(data: pointer):
+      d.pendingRequests.del(nonce)
+
+proc waitMessage(d: Protocol, fromNode: Node, reqId: RequestId):
+    Future[Option[Message]] {.raises: [Exception, Defect].} =
+  result = newFuture[Option[Message]]("waitMessage")
+  let res = result
+  let key = (fromNode.id, reqId)
+  # TODO: raises: [Exception]
+  sleepAsync(responseTimeout).addCallback() do(data: pointer):
+    d.awaitedMessages.del(key)
+    if not res.finished:
+      res.complete(none(Message)) # TODO: raises: [Exception]
+  d.awaitedMessages[key] = result
+
+proc verifyNodesRecords*(enrs: openarray[Record], fromNode: Node,
+    distance: uint32): seq[Node] {.raises: [Defect].} =
+  ## Verify and convert ENRs to a sequence of nodes. Only ENRs that pass
+  ## verification will be added. ENRs are verified for duplicates, invalid
+  ## addresses and invalid distances.
+  # TODO:
+  # - Should we fail and ignore values on first invalid Node?
+  # - Should we limit the amount of nodes? The discovery v5 specification holds
+  # no limit on the amount that can be returned.
+  var seen: HashSet[Node]
+  for r in enrs:
+    let node = newNode(r)
+    if node.isOk():
+      let n = node.get()
+      # Check for duplicates in the nodes reply. Duplicates are checked based
+      # on node id.
+      if n in seen:
+        trace "Nodes reply contained records with duplicate node ids",
+          record = n.record.toURI, sender = fromNode.record.toURI, id = n.id
+        continue
+      # Check if the node has an address and if the address is public or from
+      # the same local network or lo network as the sender. The latter allows
+      # for local testing.
+      if not n.address.isSome() or not
+          validIp(fromNode.address.get().ip, n.address.get().ip):
+        trace "Nodes reply contained record with invalid ip-address",
+          record = n.record.toURI, sender = fromNode.record.toURI, node = $n
+        continue
+      # Check if returned node has the requested distance.
+      if logDist(n.id, fromNode.id) != min(distance, 256):
+        warn "Nodes reply contained record with incorrect distance",
+          record = n.record.toURI, sender = fromNode.record.toURI
+        continue
+      # No check on UDP port and thus any port is allowed, also the so called
+      # "well-known" ports.
+
+      seen.incl(n)
+      result.add(n)
+
+proc waitNodes(d: Protocol, fromNode: Node, reqId: RequestId):
+    Future[DiscResult[seq[Record]]] {.async, raises: [Exception, Defect].} =
+  ## Wait for one or more nodes replies.
+  ##
+  ## The first reply will hold the total number of replies expected, and based
+  ## on that, more replies will be awaited.
+  ## If one reply is lost here (timed out), others are ignored too.
+  ## Same counts for out of order receival.
+  var op = await d.waitMessage(fromNode, reqId)
+  if op.isSome and op.get.kind == nodes:
+    var res = op.get.nodes.enrs
+    let total = op.get.nodes.total
+    for i in 1 ..< total:
+      op = await d.waitMessage(fromNode, reqId)
+      if op.isSome and op.get.kind == nodes:
+        res.add(op.get.nodes.enrs)
+      else:
+        # No error on this as we received some nodes.
+        break
+    return ok(res)
+  else:
+    return err("Nodes message not received in time")
+
+proc sendMessage*[T: SomeMessage](d: Protocol, toNode: Node, m: T):
+    RequestId {.raises: [Exception, Defect].} =
+  doAssert(toNode.address.isSome())
+  let
+    reqId = RequestId.init(d.rng[])
+    message = encodeMessage(m, reqId)
+
+  let (data, nonce) = encodeMessagePacket(d.rng[], d.codec, toNode.id,
+    toNode.address.get(), message)
+
+  d.registerRequest(toNode, message, nonce)
+  d.send(toNode, data)
+  return reqId
+
+proc ping*(d: Protocol, toNode: Node):
+    Future[DiscResult[PongMessage]] {.async, raises: [Exception, Defect].} =
+  ## Send a discovery ping message.
+  ##
+  ## Returns the received pong message or an error.
+  let reqId = d.sendMessage(toNode,
+    PingMessage(enrSeq: d.localNode.record.seqNum))
+  let resp = await d.waitMessage(toNode, reqId)
+
+  if resp.isSome() and resp.get().kind == pong:
+    d.routingTable.setJustSeen(toNode)
+    return ok(resp.get().pong)
+  else:
+    d.replaceNode(toNode)
+    return err("Pong message not received in time")
+
+proc findNode*(d: Protocol, toNode: Node, distance: uint32):
+    Future[DiscResult[seq[Node]]] {.async, raises: [Exception, Defect].} =
+  ## Send a discovery findNode message.
+  ##
+  ## Returns the received nodes or an error.
+  ## Received ENRs are already validated and converted to `Node`.
+  let reqId = d.sendMessage(toNode, FindNodeMessage(distance: distance))
+  let nodes = await d.waitNodes(toNode, reqId)
+
+  if nodes.isOk:
+    let res = verifyNodesRecords(nodes.get(), toNode, distance)
+    d.routingTable.setJustSeen(toNode)
+    return ok(res)
+  else:
+    d.replaceNode(toNode)
+    return err(nodes.error)
+
+proc lookupDistances(target, dest: NodeId): seq[uint32] {.raises: [Defect].} =
+  let td = logDist(target, dest)
+  result.add(td)
+  var i = 1'u32
+  while result.len < lookupRequestLimit:
+    if td + i < 256:
+      result.add(td + i)
+    if td - i > 0'u32:
+      result.add(td - i)
+    inc i
+
+proc lookupWorker(d: Protocol, destNode: Node, target: NodeId):
+    Future[seq[Node]] {.async, raises: [Exception, Defect].} =
+  let dists = lookupDistances(target, destNode.id)
+  var i = 0
+  while i < lookupRequestLimit and result.len < findNodeResultLimit:
+    let r = await d.findNode(destNode, dists[i])
+    # TODO: Handle failures better. E.g. stop on different failures than timeout
+    if r.isOk:
+      # TODO: I guess it makes sense to limit here also to `findNodeResultLimit`?
+      result.add(r[])
+    inc i
+
+  for n in result:
+    discard d.routingTable.addNode(n)
+
+proc lookup*(d: Protocol, target: NodeId): Future[seq[Node]]
+    {.async, raises: [Exception, Defect].} =
+  ## Perform a lookup for the given target, return the closest n nodes to the
+  ## target. Maximum value for n is `BUCKET_SIZE`.
+  # TODO: Sort the returned nodes on distance
+  # Also use unseen nodes as a form of validation.
+  result = d.routingTable.neighbours(target, BUCKET_SIZE, seenOnly = false)
+  var asked = initHashSet[NodeId]()
+  asked.incl(d.localNode.id)
+  var seen = asked
+  for node in result:
+    seen.incl(node.id)
+
+  var pendingQueries = newSeqOfCap[Future[seq[Node]]](alpha)
+
+  while true:
+    var i = 0
+    while i < result.len and pendingQueries.len < alpha:
+      let n = result[i]
+      if not asked.containsOrIncl(n.id):
+        pendingQueries.add(d.lookupWorker(n, target))
+      inc i
+
+    trace "discv5 pending queries", total = pendingQueries.len
+
+    if pendingQueries.len == 0:
+      break
+
+    let idx = await oneIndex(pendingQueries)
+    trace "Got discv5 lookup response", idx
+
+    let nodes = pendingQueries[idx].read
+    pendingQueries.del(idx)
+    for n in nodes:
+      if not seen.containsOrIncl(n.id):
+        if result.len < BUCKET_SIZE:
+          result.add(n)
+
+proc lookupRandom*(d: Protocol): Future[seq[Node]]
+    {.async, raises:[Exception, Defect].} =
+  ## Perform a lookup for a random target, return the closest n nodes to the
+  ## target. Maximum value for n is `BUCKET_SIZE`.
+  var id: NodeId
+  var buf: array[sizeof(id), byte]
+  brHmacDrbgGenerate(d.rng[], buf)
+  copyMem(addr id, addr buf[0], sizeof(id))
+
+  return await d.lookup(id)
+
+proc resolve*(d: Protocol, id: NodeId): Future[Option[Node]]
+    {.async, raises: [Exception, Defect].} =
+  ## Resolve a `Node` based on provided `NodeId`.
+  ##
+  ## This will first look in the own routing table. If the node is known, it
+  ## will try to contact if for newer information. If node is not known or it
+  ## does not reply, a lookup is done to see if it can find a (newer) record of
+  ## the node on the network.
+
+  let node = d.getNode(id)
+  if node.isSome():
+    let request = await d.findNode(node.get(), 0)
+
+    # TODO: Handle failures better. E.g. stop on different failures than timeout
+    if request.isOk() and request[].len > 0:
+      return some(request[][0])
+
+  let discovered = await d.lookup(id)
+  for n in discovered:
+    if n.id == id:
+      if node.isSome() and node.get().record.seqNum >= n.record.seqNum:
+        return node
+      else:
+        return some(n)
+
+  return node
+
+proc revalidateNode*(d: Protocol, n: Node)
+    {.async, raises: [Exception, Defect].} = # TODO: Exception
+  let pong = await d.ping(n)
+
+  if pong.isOK():
+    if pong.get().enrSeq > n.record.seqNum:
+      # Request new ENR
+      let nodes = await d.findNode(n, 0)
+      if nodes.isOk() and nodes[].len > 0:
+        discard d.addNode(nodes[][0])
+
+proc revalidateLoop(d: Protocol) {.async, raises: [Exception, Defect].} =
+  # TODO: General Exception raised.
+  try:
+    while true:
+      await sleepAsync(milliseconds(d.rng[].rand(revalidateMax)))
+      let n = d.routingTable.nodeToRevalidate()
+      if not n.isNil:
+        traceAsyncErrors d.revalidateNode(n)
+  except CancelledError:
+    trace "revalidateLoop canceled"
+
+proc lookupLoop(d: Protocol) {.async, raises: [Exception, Defect].} =
+  # TODO: General Exception raised.
+  try:
+    # lookup self (neighbour nodes)
+    let selfLookup = await d.lookup(d.localNode.id)
+    trace "Discovered nodes in self lookup", nodes = $selfLookup
+    while true:
+      let randomLookup = await d.lookupRandom()
+      trace "Discovered nodes in random lookup", nodes = $randomLookup
+      trace "Total nodes in routing table", total = d.routingTable.len()
+      await sleepAsync(lookupInterval)
+  except CancelledError:
+    trace "lookupLoop canceled"
+
+proc newProtocol*(privKey: PrivateKey,
+                  externalIp: Option[ValidIpAddress], tcpPort, udpPort: Port,
+                  localEnrFields: openarray[(string, seq[byte])] = [],
+                  bootstrapRecords: openarray[Record] = [],
+                  previousRecord = none[enr.Record](),
+                  bindIp = IPv4_any(), rng = newRng()):
+                  Protocol {.raises: [Defect].} =
+  # TODO: Tried adding bindPort = udpPort as parameter but that gave
+  # "Error: internal error: environment misses: udpPort" in nim-beacon-chain.
+  # Anyhow, nim-beacon-chain would also require some changes to support port
+  # remapping through NAT and this API is also subject to change once we
+  # introduce support for ipv4 + ipv6 binding/listening.
+  let extraFields = mapIt(localEnrFields, toFieldPair(it[0], it[1]))
+  # TODO:
+  # - Defect as is now or return a result for enr errors?
+  # - In case incorrect key, allow for new enr based on new key (new node id)?
+  var record: Record
+  if previousRecord.isSome():
+    record = previousRecord.get()
+    record.update(privKey, externalIp, tcpPort, udpPort,
+      extraFields).expect("Record within size limits and correct key")
+  else:
+    record = enr.Record.init(1, privKey, externalIp, tcpPort, udpPort,
+     extraFields).expect("Record within size limits")
+  let node = newNode(record).expect("Properly initialized record")
+
+  # TODO Consider whether this should be a Defect
+  doAssert rng != nil, "RNG initialization failed"
+
+  result = Protocol(
+    privateKey: privKey,
+    localNode: node,
+    bindAddress: Address(ip: ValidIpAddress.init(bindIp), port: udpPort),
+    codec: Codec(localNode: node, privKey: privKey,
+      sessions: Sessions.init(256)),
+    bootstrapRecords: @bootstrapRecords,
+    rng: rng)
+
+  result.routingTable.init(node, 5, rng)
+
+proc open*(d: Protocol) {.raises: [Exception, Defect].} =
+  info "Starting discovery node", node = $d.localNode,
+    uri = toURI(d.localNode.record), bindAddress = d.bindAddress
+  # TODO allow binding to specific IP / IPv6 / etc
+  let ta = initTAddress(d.bindAddress.ip, d.bindAddress.port)
+  # TODO: raises `OSError` and `IOSelectorsException`, the latter which is
+  # object of Exception. In Nim devel this got changed to CatchableError.
+  d.transp = newDatagramTransport(processClient, udata = d, local = ta)
+
+  for record in d.bootstrapRecords:
+    debug "Adding bootstrap node", uri = toURI(record)
+    discard d.addNode(record)
+
+proc start*(d: Protocol) {.raises: [Exception, Defect].} =
+  d.lookupLoop = lookupLoop(d)
+  d.revalidateLoop = revalidateLoop(d)
+
+proc close*(d: Protocol) {.raises: [Exception, Defect].} =
+  doAssert(not d.transp.closed)
+
+  debug "Closing discovery node", node = $d.localNode
+  if not d.revalidateLoop.isNil:
+    d.revalidateLoop.cancel()
+  if not d.lookupLoop.isNil:
+    d.lookupLoop.cancel()
+
+  d.transp.close()
+
+proc closeWait*(d: Protocol) {.async, raises: [Exception, Defect].} =
+  doAssert(not d.transp.closed)
+
+  debug "Closing discovery node", node = $d.localNode
+  if not d.revalidateLoop.isNil:
+    await d.revalidateLoop.cancelAndWait()
+  if not d.lookupLoop.isNil:
+    await d.lookupLoop.cancelAndWait()
+
+  await d.transp.closeWait()

--- a/eth/p2p/discoveryv5/protocolv1.nim
+++ b/eth/p2p/discoveryv5/protocolv1.nim
@@ -384,19 +384,8 @@ proc receive*(d: Protocol, a: Address, packet: openArray[byte]) {.gcsafe,
           debug "Adding new node to routing table", node = $node,
             localNode = $d.localNode
           discard d.addNode(node)
-
-  elif decoded.error == DecodeError.UnsupportedMessage:
-    # TODO: Probably should still complete handshake in these cases.
-    trace "Packet contained unsupported message"
-  elif decoded.error == DecodeError.PacketError:
+  else:
     debug "Packet decoding error", error = decoded.error
-  elif decoded.error == DecodeError.HandshakeError:
-    debug "Packet handshake error", error = decoded.error
-  elif decoded.error == DecodeError.DecryptError:
-    # This is a specific decryption error on a handshake. We do not send a
-    # new Whoareyou on these as it probably means there is a compatiblity
-    # issue and we might loop forever in failed handshakes with this peer.
-    debug "Packet decrypting error", error = decoded.error
 
 # TODO: Not sure why but need to pop the raises here as it is apparently not
 # enough to put it in the raises pragma of `processClient` and other async procs.

--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -321,6 +321,20 @@ proc neighboursAtDistance*(r: RoutingTable, distance: uint32,
   # that are exactly the requested distance.
   keepIf(result, proc(n: Node): bool = logDist(n.id, r.thisNode.id) == distance)
 
+proc neighboursAtDistances*(r: RoutingTable, distances: seq[uint32],
+    k: int = BUCKET_SIZE, seenOnly = false): seq[Node] =
+  ## Return up to k neighbours at given logarithmic distances.
+  # TODO: This will currently return nodes with neighbouring distances on the
+  # first one prioritize. It might end up not including all the node distances
+  # requested. Need to rework the logic here and not use the neighbours call.
+  if distances.len > 0:
+    result = r.neighbours(idAtDistance(r.thisNode.id, distances[0]), k,
+      seenOnly)
+    # This is a bit silly, first getting closest nodes then to only keep the ones
+    # that are exactly the requested distances.
+    keepIf(result, proc(n: Node): bool =
+      distances.contains(logDist(n.id, r.thisNode.id)))
+
 proc len*(r: RoutingTable): int =
   for b in r.buckets: result += b.len
 

--- a/eth/p2p/discoveryv5/sessions.nim
+++ b/eth/p2p/discoveryv5/sessions.nim
@@ -1,7 +1,7 @@
 import
   std/options,
   stint, stew/endians2, stew/shims/net,
-  types, node, lru
+  typesv1, node, lru
 
 export lru
 

--- a/eth/p2p/discoveryv5/typesv1.nim
+++ b/eth/p2p/discoveryv5/typesv1.nim
@@ -1,0 +1,88 @@
+import
+  std/hashes,
+  stint,
+  enr, node
+
+{.push raises: [Defect].}
+
+const
+  aesKeySize* = 128 div 8
+
+type
+  AesKey* = array[aesKeySize, byte]
+
+  HandshakeKey* = object
+    nodeId*: NodeId
+    address*: string # TODO: Replace with Address, need hash
+
+  MessageKind* = enum
+    # TODO This is needed only to make Nim 1.0.4 happy
+    #      Without it, the `MessageKind` type cannot be used as
+    #      a discriminator in case objects.
+    unused = 0x00
+
+    ping = 0x01
+    pong = 0x02
+    findnode = 0x03
+    nodes = 0x04
+    talkreq = 0x05
+    talkresp = 0x06
+    regtopic = 0x07
+    ticket = 0x08
+    regconfirmation = 0x09
+    topicquery = 0x10
+
+  RequestId* = uint64
+
+  PingMessage* = object
+    enrSeq*: uint64
+
+  PongMessage* = object
+    enrSeq*: uint64
+    ip*: seq[byte]
+    port*: uint16
+
+  FindNodeMessage* = object
+    distance*: uint32
+
+  NodesMessage* = object
+    total*: uint32
+    enrs*: seq[Record]
+
+  SomeMessage* = PingMessage or PongMessage or FindNodeMessage or NodesMessage
+
+  Message* = object
+    reqId*: RequestId
+    case kind*: MessageKind
+    of ping:
+      ping*: PingMessage
+    of pong:
+      pong*: PongMessage
+    of findnode:
+      findNode*: FindNodeMessage
+    of nodes:
+      nodes*: NodesMessage
+    else:
+      # TODO: Define the rest
+      discard
+
+template messageKind*(T: typedesc[SomeMessage]): MessageKind =
+  when T is PingMessage: ping
+  elif T is PongMessage: pong
+  elif T is FindNodeMessage: findNode
+  elif T is NodesMessage: nodes
+
+proc toBytes*(id: NodeId): array[32, byte] {.inline.} =
+  id.toByteArrayBE()
+
+proc hash*(id: NodeId): Hash {.inline.} =
+  result = hashData(unsafeAddr id, sizeof(id))
+
+# TODO: To make this work I think we also need to implement `==` due to case
+# fields in object
+proc hash*(address: Address): Hash {.inline.} =
+  hashData(unsafeAddr address, sizeof(address))
+
+proc hash*(key: HandshakeKey): Hash =
+  result = key.nodeId.hash !& key.address.hash
+  result = !$result

--- a/eth/p2p/discoveryv5/typesv1.nim
+++ b/eth/p2p/discoveryv5/typesv1.nim
@@ -32,7 +32,7 @@ type
     regconfirmation = 0x09
     topicquery = 0x0A
 
-  RequestId* = uint64
+  RequestId* = seq[byte]
 
   PingMessage* = object
     enrSeq*: uint64

--- a/eth/p2p/discoveryv5/typesv1.nim
+++ b/eth/p2p/discoveryv5/typesv1.nim
@@ -49,7 +49,21 @@ type
     total*: uint32
     enrs*: seq[Record]
 
-  SomeMessage* = PingMessage or PongMessage or FindNodeMessage or NodesMessage
+  TalkReqMessage* = object
+    protocol*: seq[byte]
+    request*: seq[byte]
+
+  TalkRespMessage* = object
+    response*: seq[byte]
+
+  # Not implemented, specification is not final here.
+  RegTopicMessage* = object
+  TicketMessage* = object
+  RegConfirmationMessage* = object
+  TopicQueryMessage* = object
+
+  SomeMessage* = PingMessage or PongMessage or FindNodeMessage or NodesMessage or
+    TalkReqMessage or TalkRespMessage
 
   Message* = object
     reqId*: RequestId
@@ -62,8 +76,19 @@ type
       findNode*: FindNodeMessage
     of nodes:
       nodes*: NodesMessage
+    of talkreq:
+      talkreq*: TalkReqMessage
+    of talkresp:
+      talkresp*: TalkRespMessage
+    of regtopic:
+      regtopic*: RegTopicMessage
+    of ticket:
+      ticket*: TicketMessage
+    of regconfirmation:
+      regconfirmation*: RegConfirmationMessage
+    of topicquery:
+      topicquery*: TopicQueryMessage
     else:
-      # TODO: Define the rest
       discard
 
 template messageKind*(T: typedesc[SomeMessage]): MessageKind =
@@ -71,6 +96,8 @@ template messageKind*(T: typedesc[SomeMessage]): MessageKind =
   elif T is PongMessage: pong
   elif T is FindNodeMessage: findNode
   elif T is NodesMessage: nodes
+  elif T is TalkReqMessage: talkreq
+  elif T is TalkRespMessage: talkresp
 
 proc toBytes*(id: NodeId): array[32, byte] {.inline.} =
   id.toByteArrayBE()

--- a/eth/p2p/discoveryv5/typesv1.nim
+++ b/eth/p2p/discoveryv5/typesv1.nim
@@ -43,7 +43,7 @@ type
     port*: uint16
 
   FindNodeMessage* = object
-    distance*: uint32
+    distances*: seq[uint32]
 
   NodesMessage* = object
     total*: uint32

--- a/eth/p2p/discoveryv5/typesv1.nim
+++ b/eth/p2p/discoveryv5/typesv1.nim
@@ -16,7 +16,7 @@ type
     address*: string # TODO: Replace with Address, need hash
 
   MessageKind* = enum
-    # TODO This is needed only to make Nim 1.0.4 happy
+    # TODO This is needed only to make Nim 1.2.6 happy
     #      Without it, the `MessageKind` type cannot be used as
     #      a discriminator in case objects.
     unused = 0x00
@@ -30,7 +30,7 @@ type
     regtopic = 0x07
     ticket = 0x08
     regconfirmation = 0x09
-    topicquery = 0x10
+    topicquery = 0x0A
 
   RequestId* = uint64
 

--- a/tests/fuzzing/discoveryv5.1/fuzz_decode_message.nim
+++ b/tests/fuzzing/discoveryv5.1/fuzz_decode_message.nim
@@ -1,0 +1,29 @@
+import
+  testutils/fuzzing, stew/byteutils,
+  eth/rlp, eth/p2p/discoveryv5/[encodingv1, typesv1]
+
+test:
+  block:
+    let decoded = decodeMessage(payload)
+
+    if decoded.isOK():
+      let message = decoded.get()
+      var encoded: seq[byte]
+      case message.kind
+      of unused: break
+      of ping: encoded = encodeMessage(message.ping, message.reqId)
+      of pong: encoded = encodeMessage(message.pong, message.reqId)
+      of findNode: encoded = encodeMessage(message.findNode, message.reqId)
+      of nodes: encoded = encodeMessage(message.nodes, message.reqId)
+      of talkreq: encoded = encodeMessage(message.talkreq, message.reqId)
+      of talkresp: encoded = encodeMessage(message.talkresp, message.reqId)
+      of regtopic, ticket, regconfirmation, topicquery:
+        break
+
+      # This will hit assert because of issue:
+      # https://github.com/status-im/nim-eth/issues/255
+      # if encoded != payload:
+      #   echo "payload: ", toHex(payload)
+      #   echo "encoded: ", toHex(encoded)
+
+      #   doAssert(false, "re-encoded result does not equal original payload")

--- a/tests/fuzzing/discoveryv5.1/fuzz_decode_packet.nim
+++ b/tests/fuzzing/discoveryv5.1/fuzz_decode_packet.nim
@@ -1,0 +1,37 @@
+import
+  testutils/fuzzing, stew/shims/net, stew/byteutils,
+  eth/p2p/discoveryv5/[encodingv1, enr, sessions, node]
+
+init:
+  const
+    nodeAKey = "0xeef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f"
+    nodeBKey = "0x66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb1cde628"
+  let
+    rng = newRng()
+    privKeyA = PrivateKey.fromHex(nodeAKey)[] # sender -> encode
+    privKeyB = PrivateKey.fromHex(nodeBKey)[] # receive -> decode
+
+    enrRecA = enr.Record.init(1, privKeyA,
+      some(ValidIpAddress.init("127.0.0.1")), Port(9000),
+      Port(9000)).expect("Properly intialized private key")
+    nodeA = newNode(enrRecA).expect("Properly initialized record")
+
+    enrRecB = enr.Record.init(1, privKeyB,
+      some(ValidIpAddress.init("127.0.0.1")), Port(9000),
+      Port(9000)).expect("Properly intialized private key")
+    nodeB = newNode(enrRecB).expect("Properly initialized record")
+
+  var codecB = Codec(localNode: nodeB, privKey: privKeyB,
+    sessions: Sessions.init(5))
+
+test:
+  # It is not the best idea to generate extra data and encrypt data but we do
+  # it like this as the decodeHeader proc does decrypt + decode + decrypt.
+  # There is no separate decrypt step that can be skipped because of this.
+  var iv: array[ivSize, byte]
+  brHmacDrbgGenerate(rng[], iv)
+  let maskedHeader = encryptHeader(nodeB.id, iv, payload)
+
+  let decoded = decodePacket(codecB, nodeA.address.get(), @iv & maskedHeader)
+  if decoded.isErr():
+    debug "Error occured", error = decoded.error

--- a/tests/p2p/discv5_test_helper.nim
+++ b/tests/p2p/discv5_test_helper.nim
@@ -36,17 +36,6 @@ proc nodeIdInNodes*(id: NodeId, nodes: openarray[Node]): bool =
   for n in nodes:
     if id == n.id: return true
 
-# proc randomPacket*(rng: var BrHmacDrbgContext, tag: PacketTag): seq[byte] =
-#   var
-#     authTag: AuthTag
-#     msg: array[44, byte]
-
-#   brHmacDrbgGenerate(rng, authTag)
-#   brHmacDrbgGenerate(rng, msg)
-#   result.add(tag)
-#   result.add(rlp.encode(authTag))
-#   result.add(msg)
-
 proc generateNode*(privKey: PrivateKey, port: int = 20302,
     localEnrFields: openarray[FieldPair] = []): Node =
   let port = Port(port)

--- a/tests/p2p/discv5_test_helper.nim
+++ b/tests/p2p/discv5_test_helper.nim
@@ -1,8 +1,18 @@
 import
-  testutils/unittests, stew/shims/net, bearssl,
+  stew/shims/net, bearssl,
   eth/[keys, rlp],
-  eth/p2p/discoveryv5/[enr, node, types, routing_table, encoding],
-  eth/p2p/discoveryv5/protocol as discv5_protocol
+  eth/p2p/discoveryv5/[enr, node, routing_table]
+
+const UseDiscv51* {.booldefine.} = false
+
+when UseDiscv51:
+  import
+    eth/p2p/discoveryv5/[typesv1, encodingv1],
+    eth/p2p/discoveryv5/protocolv1 as discv5_protocol
+else:
+  import
+    eth/p2p/discoveryv5/[types, encoding],
+    eth/p2p/discoveryv5/protocol as discv5_protocol
 
 proc localAddress*(port: int): Address =
   Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(port))
@@ -26,17 +36,16 @@ proc nodeIdInNodes*(id: NodeId, nodes: openarray[Node]): bool =
   for n in nodes:
     if id == n.id: return true
 
-# Creating a random packet with specific nodeid each time
-proc randomPacket*(rng: var BrHmacDrbgContext, tag: PacketTag): seq[byte] =
-  var
-    authTag: AuthTag
-    msg: array[44, byte]
+# proc randomPacket*(rng: var BrHmacDrbgContext, tag: PacketTag): seq[byte] =
+#   var
+#     authTag: AuthTag
+#     msg: array[44, byte]
 
-  brHmacDrbgGenerate(rng, authTag)
-  brHmacDrbgGenerate(rng, msg)
-  result.add(tag)
-  result.add(rlp.encode(authTag))
-  result.add(msg)
+#   brHmacDrbgGenerate(rng, authTag)
+#   brHmacDrbgGenerate(rng, msg)
+#   result.add(tag)
+#   result.add(rlp.encode(authTag))
+#   result.add(msg)
 
 proc generateNode*(privKey: PrivateKey, port: int = 20302,
     localEnrFields: openarray[FieldPair] = []): Node =

--- a/tests/p2p/test_discv51_encoding.nim
+++ b/tests/p2p/test_discv51_encoding.nim
@@ -1,0 +1,482 @@
+import
+  std/[unittest, options, sequtils, tables],
+  stint, stew/byteutils, stew/shims/net,
+  eth/[rlp, keys],
+  eth/p2p/discoveryv5/[typesv1, encodingv1, enr, node, sessions]
+
+# According to test vectors:
+# https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire-test-vectors.md
+
+let rng = newRng()
+
+suite "Discovery v5 Protocol Message Encodings":
+  test "Ping Request":
+    var p: PingMessage
+    p.enrSeq = 1
+    var reqId: RequestId = 1
+    check encodeMessage(p, reqId).toHex == "01c20101"
+
+  test "Pong Response":
+    var p: PongMessage
+    p.enrSeq = 1
+    p.port = 5000
+    p.ip = @[127.byte, 0, 0, 1]
+    var reqId: RequestId = 1
+    check encodeMessage(p, reqId).toHex == "02ca0101847f000001821388"
+
+  test "FindNode Request":
+    var p: FindNodeMessage
+    p.distance = 0x0100
+    var reqId: RequestId = 1
+    check encodeMessage(p, reqId).toHex == "03c401820100"
+
+  test "Nodes Response (empty)":
+    var p: NodesMessage
+    p.total = 0x1
+    var reqId: RequestId = 1
+    check encodeMessage(p, reqId).toHex == "04c30101c0"
+
+  test "Nodes Response (multiple)":
+    var p: NodesMessage
+    p.total = 0x1
+    var e1, e2: Record
+    check e1.fromURI("enr:-HW4QBzimRxkmT18hMKaAL3IcZF1UcfTMPyi3Q1pxwZZbcZVRI8DC5infUAB_UauARLOJtYTxaagKoGmIjzQxO2qUygBgmlkgnY0iXNlY3AyNTZrMaEDymNMrg1JrLQB2KTGtv6MVbcNEVv0AHacwUAPMljNMTg")
+    check e2.fromURI("enr:-HW4QNfxw543Ypf4HXKXdYxkyzfcxcO-6p9X986WldfVpnVTQX1xlTnWrktEWUbeTZnmgOuAY_KUhbVV1Ft98WoYUBMBgmlkgnY0iXNlY3AyNTZrMaEDDiy3QkHAxPyOgWbxp5oF1bDdlYE6dLCUUp8xfVw50jU")
+
+    p.enrs = @[e1, e2]
+    var reqId: RequestId = 1
+    check encodeMessage(p, reqId).toHex == "04f8f20101f8eef875b8401ce2991c64993d7c84c29a00bdc871917551c7d330fca2dd0d69c706596dc655448f030b98a77d4001fd46ae0112ce26d613c5a6a02a81a6223cd0c4edaa53280182696482763489736563703235366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138f875b840d7f1c39e376297f81d7297758c64cb37dcc5c3beea9f57f7ce9695d7d5a67553417d719539d6ae4b445946de4d99e680eb8063f29485b555d45b7df16a1850130182696482763489736563703235366b31a1030e2cb74241c0c4fc8e8166f1a79a05d5b0dd95813a74b094529f317d5c39d235"
+
+suite "Discovery v5 Cryptographic Primitives":
+  test "ECDH":
+    const
+      # input
+      publicKey = "0x9961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231503061ac4aaee666073d7e5bc2c80c3f5c5b500c1cb5fd0a76abbb6b675ad157"
+      secretKey = "0xfb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736"
+      # expected output
+      sharedSecret = "0x033b11a2a1f214567e1537ce5e509ffd9b21373247f2a3ff6841f4976f53165e7e"
+
+    let
+      pub = PublicKey.fromHex(publicKey)[]
+      priv = PrivateKey.fromHex(secretKey)[]
+    let eph = ecdhRawFull(priv, pub)
+    check:
+      eph.data == hexToSeqByte(sharedSecret)
+
+  test "Key Derivation":
+    # const
+    #   # input
+    #   secretKey = "0x02a77e3aa0c144ae7c0a3af73692b7d6e5b7a2fdc0eda16e8d5e6cb0d08e88dd04"
+    #   nodeIdA = "0xa448f24c6d18e575453db13171562b71999873db5b286df957af199ec94617f7"
+    #   nodeIdB = "0x885bba8dfeddd49855459df852ad5b63d13a3fae593f3f9fa7e317fd43651409"
+    #   idNonce = "0x0101010101010101010101010101010101010101010101010101010101010101"
+    #   # expected output
+    #   initiatorKey = "0x238d8b50e4363cf603a48c6cc3542967"
+    #   recipientKey = "0xbebc0183484f7e7ca2ac32e3d72c8891"
+    #   authRespKey = "0xe987ad9e414d5b4f9bfe4ff1e52f2fae"
+
+    # Code doesn't allow to start from shared `secretKey`, but only from the
+    # public and private key. Would require pulling `ecdhAgree` out of
+    # `deriveKeys`
+    skip()
+
+  test "Nonce Signing":
+    const
+      # input
+      idNonce = "0xa77e3aa0c144ae7c0a3af73692b7d6e5b7a2fdc0eda16e8d5e6cb0d08e88dd04"
+      ephemeralKey = "0x9961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231503061ac4aaee666073d7e5bc2c80c3f5c5b500c1cb5fd0a76abbb6b675ad157"
+      localSecretKey = "0xfb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736"
+      # expected output
+      idNonceSig = "0xc5036e702a79902ad8aa147dabfe3958b523fd6fa36cc78e2889b912d682d8d35fdea142e141f690736d86f50b39746ba2d2fc510b46f82ee08f08fd55d133a4"
+
+    let
+      privKey = PrivateKey.fromHex(localSecretKey)[]
+      signature = signIDNonce(privKey, hexToByteArray[idNonceSize](idNonce),
+        hexToByteArray[64](ephemeralKey))
+    check signature.toRaw() == hexToByteArray[64](idNonceSig)
+
+  test "Encryption/Decryption":
+    const
+      # input
+      encryptionKey = "0x9f2d77db7004bf8a1a85107ac686990b"
+      nonce = "0x27b5af763c446acd2749fe8e"
+      pt = "0x01c20101"
+      ad = "0x93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903"
+      # expected output
+      messageCiphertext = "0xa5d12a2d94b8ccb3ba55558229867dc13bfa3648"
+
+    let encrypted = encryptGCM(hexToByteArray[aesKeySize](encryptionKey),
+                               hexToByteArray[gcmNonceSize](nonce),
+                               hexToSeqByte(pt),
+                               hexToByteArray[32](ad))
+    check encrypted == hexToSeqByte(messageCiphertext)
+
+  test "Authentication Header and Encrypted Message Generation":
+    # Can't work directly with the provided shared secret as keys are derived
+    # inside makeAuthHeader, and passed on one call up.
+    # The encryption of the auth-resp-pt uses one of these keys, as does the
+    # encryption of the message itself. So the whole test depends on this.
+    skip()
+
+suite "Discovery v5.1 Test Vectors":
+  const
+    nodeAKey = "0xeef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f"
+    nodeBKey = "0x66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb1cde628"
+  setup:
+    let
+      privKeyA = PrivateKey.fromHex(nodeAKey)[] # sender -> encode
+      privKeyB = PrivateKey.fromHex(nodeBKey)[] # receive -> decode
+
+      enrRecA = enr.Record.init(1, privKeyA,
+        some(ValidIpAddress.init("127.0.0.1")), Port(9000),
+        Port(9000)).expect("Properly intialized private key")
+      nodeA = newNode(enrRecA).expect("Properly initialized record")
+
+      enrRecB = enr.Record.init(1, privKeyB,
+        some(ValidIpAddress.init("127.0.0.1")), Port(9000),
+        Port(9000)).expect("Properly intialized private key")
+      nodeB = newNode(enrRecB).expect("Properly initialized record")
+
+    var
+      codecA {.used.} = Codec(localNode: nodeA, privKey: privKeyA,
+        sessions: Sessions.init(5))
+      codecB = Codec(localNode: nodeB, privKey: privKeyB,
+        sessions: Sessions.init(5))
+
+  test "Whoareyou Packet":
+    const
+      whoareyouRequestNonce = "0x0102030405060708090a0b0c"
+      whoareyouIdNonce = "0x0102030405060708090a0b0c0d0e0f1000000000000000000000000000000000"
+      whoareyouEnrSeq = 0
+
+      encodedPacket = "0x00000000000000000000000000000000088b3d4342776668980a4adf72a8fcaa963f24b27a2f6bb44c7ed5ca10e87de130f94d2390b9853c3ecb9ad5e368892ec562137bf19c6d0a9191a5651c4f415117bdfa0c7ab86af62b7a9784eceb28008d03ede83bd1369631f9f3d8da0b45"
+
+    let decoded = codecB.decodePacket(nodeA.address.get(),
+      hexToSeqByte(encodedPacket))
+
+    check:
+      decoded.isOK()
+      decoded.get().flag == Flag.Whoareyou
+      decoded.get().whoareyou.requestNonce == hexToByteArray[gcmNonceSize](whoareyouRequestNonce)
+      decoded.get().whoareyou.idNonce == hexToByteArray[idNonceSize](whoareyouIdNonce)
+      decoded.get().whoareyou.recordSeq == whoareyouEnrSeq
+
+  test "Ping Ordinary Message Packet":
+    const
+      # nonce = "0xffffffffffffffffffffffff"
+      readKey = "0x00000000000000000000000000000000"
+      pingReqId = 0x00000001'u64
+      pingEnrSeq = 2'u64
+
+      encodedPacket = "00000000000000000000000000000000088b3d4342776668980a4adf72a8fcaa963f24b27a2f6bb44c7ed5ca10e87de130f94d2390b9853c3fcba22b1e9472d43c9ae48d04689eb84102ed931f66d180cbb4219f369a24f4e6b24d7bdc2a04"
+
+    let dummyKey = "0x00000000000000000000000000000001" # of no importance
+    codecA.sessions.store(nodeB.id, nodeB.address.get(),
+      hexToByteArray[aesKeySize](dummyKey), hexToByteArray[aesKeySize](readKey))
+    codecB.sessions.store(nodeA.id, nodeA.address.get(),
+      hexToByteArray[aesKeySize](readKey), hexToByteArray[aesKeySize](dummyKey))
+
+    # Note: Noticed when comparing these test vectors that we encode reqId as
+    # integer while it seems the test vectors have it encoded as byte seq,
+    # meaning having potentially heaving leading zeroes.
+
+    let decoded = codecB.decodePacket(nodeA.address.get(), hexToSeqByte(encodedPacket))
+    check:
+      decoded.isOK()
+      decoded.get().messageOpt.isSome()
+      decoded.get().messageOpt.get().reqId == pingReqId
+      decoded.get().messageOpt.get().kind == ping
+      decoded.get().messageOpt.get().ping.enrSeq == pingEnrSeq
+
+  test "Ping Handshake Message Packet":
+    const
+      # srcNodeId = "0xaaaa8419e9f49d0083561b48287df592939a8d19947d8c0ef88f2a4856a69fbb"
+      # destNodeId = "0xbbbb9d047f0488c0b5a93c1c3f2d8bafc7c8ff337024a55434a0d0555de64db9"
+      # nonce = "0xffffffffffffffffffffffff"
+      # readKey = "0x4917330b5aeb51650213f90d5f253c45"
+
+      pingReqId = 0x00000001'u64
+      pingEnrSeq = 1'u64
+      #
+      # handshake inputs:
+      #
+      whoareyouRequestNonce = "0x0102030405060708090a0b0c"
+      whoareyouIdNonce = "0x0102030405060708090a0b0c0d0e0f1000000000000000000000000000000000"
+      whoareyouEnrSeq = 1'u64
+      # ephemeralKey = "0x0288ef00023598499cb6c940146d050d2b1fb914198c327f76aad590bead68b6"
+      # ephemeralPubkey = "0x039a003ba6517b473fa0cd74aefe99dadfdb34627f90fec6362df85803908f53a5"
+
+      encodedPacket = "00000000000000000000000000000000088b3d4342776668980a4adf72a8fcaa963f24b27a2f6bb44c7ed5ca10e87de130f94d2390b9853c3dcbded51e9472d43c9ae48d04689ef4d3b340a9cb02d3f5cb5c73f266876372a497ef20dccc83eebcf61f61bc2bb13655118c2dddd4fa7f66210832e7c45c2af87b635121ae132057cce99aa7d2760b31390fea5142053c97feb5fc3f5d0ff3d71008a5b6724bbfc8c97746524e695129d2bd7fccc3d4569a69fd8a783849a117bd23ec5b5d02be0a0c57"
+
+    let
+      whoareyouData = WhoareyouData(
+        requestNonce: hexToByteArray[gcmNonceSize](whoareyouRequestNonce),
+        idNonce: hexToByteArray[idNonceSize](whoareyouIdNonce),
+        recordSeq: whoareyouEnrSeq)
+      pubkey = some(privKeyA.toPublicKey())
+      challenge = Challenge(whoareyouData: whoareyouData, pubkey: pubkey)
+      key = HandShakeKey(nodeId: nodeA.id, address: $(nodeA.address.get()))
+
+    check: not codecB.handshakes.hasKeyOrPut(key, challenge)
+
+    let decoded = codecB.decodePacket(nodeA.address.get(),
+      hexToSeqByte(encodedPacket))
+
+    skip()
+    # TODO: This test fails at the deriveKeys step. The readkey is not the
+    # expected value of above. Hardcoding that values makes decryption work.
+    # TBI.
+
+    # check:
+    #   decoded.isOk()
+    #   decoded.get().message.reqId == pingReqId
+    #   decoded.get().message.kind == ping
+    #   decoded.get().message.ping.enrSeq == pingEnrSeq
+    #   decoded.get().node.isNone()
+
+  test "Ping Handshake Message Packet with ENR":
+    const
+      # srcNodeId = "0xaaaa8419e9f49d0083561b48287df592939a8d19947d8c0ef88f2a4856a69fbb"
+      # destNodeId = "0xbbbb9d047f0488c0b5a93c1c3f2d8bafc7c8ff337024a55434a0d0555de64db9"
+      # nonce = "0xffffffffffffffffffffffff"
+      # readKey = "0x4917330b5aeb51650213f90d5f253c45"
+
+      pingReqId = 0x00000001'u64
+      pingEnrSeq = 1'u64
+      #
+      # handshake inputs:
+      #
+      whoareyouRequestNonce = "0x0102030405060708090a0b0c"
+      whoareyouIdNonce = "0x0102030405060708090a0b0c0d0e0f1000000000000000000000000000000000"
+      whoareyouEnrSeq = 0'u64
+      # ephemeralKey = "0x0288ef00023598499cb6c940146d050d2b1fb914198c327f76aad590bead68b6"
+      # ephemeralPubkey = "0x039a003ba6517b473fa0cd74aefe99dadfdb34627f90fec6362df85803908f53a5"
+
+      encodedPacket = "00000000000000000000000000000000088b3d4342776668980a4adf72a8fcaa963f24b27a2f6bb44c7ed5ca10e87de130f94d2390b9853c3dcaa0d51e9472d43c9ae48d04689ef4d3d2602a5e89ac340f9e81e722b1d7dac2578d520dd5bc6dc1e38ad3ab33012be1a5d259267a0947bf242219834c5702d1c694c0ceb4a6a27b5d68bd2c2e32e6cb9696706adff216ab862a9186875f9494150c4ae06fa4d1f0396c93f215fa4ef52417d9c40a31564e8d5f31a7f08c38045ff5e30d9661838b1eabee9f1e561120bcc4d9f2f9c839152b4ab970e029b2395b97e8c3aa8d3b497ee98a15e865bcd34effa8b83eb6396bca60ad8f0bff1e047e278454bc2b3d6404c12106a9d0b6107fc2383976fc05fbda2c954d402c28c8fb53a2b3a4b111c286ba2ac4ff880168323c6e97b01dbcbeef4f234e5849f75ab007217c919820aaa1c8a7926d3625917fccc3d4569a69fd8aca026be87afab8e8e645d1ee888992"
+
+    let
+      whoareyouData = WhoareyouData(
+        requestNonce: hexToByteArray[gcmNonceSize](whoareyouRequestNonce),
+        idNonce: hexToByteArray[idNonceSize](whoareyouIdNonce),
+        recordSeq: whoareyouEnrSeq)
+      pubkey = none(PublicKey)
+      challenge = Challenge(whoareyouData: whoareyouData, pubkey: pubkey)
+      key = HandShakeKey(nodeId: nodeA.id, address: $(nodeA.address.get()))
+
+    check: not codecB.handshakes.hasKeyOrPut(key, challenge)
+
+    let decoded = codecB.decodePacket(nodeA.address.get(),
+      hexToSeqByte(encodedPacket))
+
+    skip()
+    # TODO: This test fails at the deriveKeys step. The readkey is not the
+    # expected value of above. Hardcoding that values makes decryption work.
+    # TBI.
+
+    # check:
+    #   decoded.isOk()
+    #   decoded.get().message.reqId == pingReqId
+    #   decoded.get().message.kind == ping
+    #   decoded.get().message.ping.enrSeq == pingEnrSeq
+    #   decoded.get().node.isSome()
+
+suite "Discovery v5.1 Additional":
+  test "Encryption/Decryption":
+    let
+      encryptionKey = hexToByteArray[aesKeySize]("0x9f2d77db7004bf8a1a85107ac686990b")
+      nonce = hexToByteArray[gcmNonceSize]("0x27b5af763c446acd2749fe8e")
+      ad = hexToByteArray[32]("0x93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903")
+      pt = hexToSeqByte("0xa1")
+
+    let ct = encryptGCM(encryptionKey, nonce, pt, ad)
+    let decrypted = decryptGCM(encryptionKey, nonce, ct, ad)
+
+    check decrypted.get() == pt
+
+  test "Decryption":
+    let
+      encryptionKey = hexToByteArray[aesKeySize]("0x9f2d77db7004bf8a1a85107ac686990b")
+      nonce = hexToByteArray[gcmNonceSize]("0x27b5af763c446acd2749fe8e")
+      ad = hexToByteArray[32]("0x93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903")
+      pt = hexToSeqByte("0x01c20101")
+      ct = hexToSeqByte("0xa5d12a2d94b8ccb3ba55558229867dc13bfa3648")
+
+    # valid case
+    check decryptGCM(encryptionKey, nonce, ct, ad).get() == pt
+
+    # invalid tag/data sizes
+    var invalidCipher: seq[byte] = @[]
+    check decryptGCM(encryptionKey, nonce, invalidCipher, ad).isNone()
+
+    invalidCipher = repeat(byte(4), gcmTagSize)
+    check decryptGCM(encryptionKey, nonce, invalidCipher, ad).isNone()
+
+    # invalid tag/data itself
+    invalidCipher = repeat(byte(4), gcmTagSize + 1)
+    check decryptGCM(encryptionKey, nonce, invalidCipher, ad).isNone()
+
+  test "Encrypt / Decrypt header":
+    let
+      privKey = PrivateKey.random(rng[])
+      nodeId = privKey.toPublicKey().toNodeId()
+      authdata = [byte 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+      staticHeader = encodeStaticHeader(nodeId, Flag.OrdinaryMessage,
+        authdata.len())
+      header = @staticHeader & @authdata
+
+    var iv: array[128 div 8, byte]
+    brHmacDrbgGenerate(rng[], iv)
+
+    let
+      encrypted = encryptHeader(nodeId, iv, header)
+      decoded = decodeHeader(nodeId, iv, encrypted)
+
+    check decoded.isOk()
+
+  setup:
+    let
+      privKeyA = PrivateKey.random(rng[]) # sender -> encode
+      privKeyB = PrivateKey.random(rng[]) # receiver -> decode
+
+      enrRecA = enr.Record.init(1, privKeyA, some(ValidIpAddress.init("127.0.0.1")), Port(9000),
+        Port(9000)).expect("Properly intialized private key")
+      nodeA = newNode(enrRecA).expect("Properly initialized record")
+
+      enrRecB = enr.Record.init(1, privKeyB, some(ValidIpAddress.init("127.0.0.1")), Port(9000),
+        Port(9000)).expect("Properly intialized private key")
+      nodeB = newNode(enrRecB).expect("Properly initialized record")
+
+    var
+      codecA = Codec(localNode: nodeA, privKey: privKeyA, sessions: Sessions.init(5))
+      codecB = Codec(localNode: nodeB, privKey: privKeyB, sessions: Sessions.init(5))
+
+  test "Encode / Decode Ordinary Random Message Packet":
+    let
+      m = PingMessage(enrSeq: 0)
+      reqId = RequestId.init(rng[])
+      message = encodeMessage(m, reqId)
+
+    let (data, nonce) = encodeMessagePacket(rng[], codecA, nodeB.id,
+      nodeB.address.get(), message)
+
+    let decoded = codecB.decodePacket(nodeA.address.get(), data)
+    check:
+      decoded.isOk()
+      decoded[].flag == OrdinaryMessage
+      decoded[].messageOpt.isNone()
+      decoded[].requestNonce == nonce
+
+  test "Encode / Decode Whoareyou Packet":
+    var
+      requestNonce: AESGCMNonce
+      idNonce: IdNonce
+    brHmacDrbgGenerate(rng[], idNonce)
+    brHmacDrbgGenerate(rng[], requestNonce)
+    let recordSeq = 0'u64
+
+    let data = encodeWhoareyouPacket(rng[], codecA, nodeB.id, requestNonce, idNonce,
+      recordSeq)
+
+    let decoded = codecB.decodePacket(nodeA.address.get(), data)
+    check:
+      decoded.isOk()
+      decoded[].flag == Flag.Whoareyou
+      decoded[].whoareyou.requestNonce == requestNonce
+      decoded[].whoareyou.idNonce == idNonce
+      decoded[].whoareyou.recordSeq == recordSeq
+
+  test "Encode / Decode Handshake Message Packet":
+    var
+      requestNonce: AESGCMNonce
+      idNonce: IdNonce
+    brHmacDrbgGenerate(rng[], idNonce)
+    brHmacDrbgGenerate(rng[], requestNonce)
+    let recordSeq = 1'u64
+
+    let
+      m = PingMessage(enrSeq: 0)
+      reqId = RequestId.init(rng[])
+      message = encodeMessage(m, reqId)
+    let
+      whoareyouData = WhoareyouData(
+        requestNonce: requestNonce,
+        idNonce: idNonce,
+        recordSeq: recordSeq)
+      pubkey = some(privKeyA.toPublicKey())
+      challenge = Challenge(whoareyouData: whoareyouData, pubkey: pubkey)
+      key = HandShakeKey(nodeId: nodeA.id, address: $(nodeA.address.get()))
+
+    check: not codecB.handshakes.hasKeyOrPut(key, challenge)
+
+    let data = encodeHandshakePacket(rng[], codecA, nodeB.id,
+      nodeB.address.get(), message, idNonce, recordSeq, privKeyB.toPublicKey())
+
+    let decoded = codecB.decodePacket(nodeA.address.get(), data)
+
+    check:
+      decoded.isOk()
+      decoded.get().message.reqId == reqId
+      decoded.get().message.kind == ping
+      decoded.get().message.ping.enrSeq == 0
+      decoded.get().node.isNone()
+
+  test "Encode / Decode Handshake Message Packet with ENR":
+    var
+      requestNonce: AESGCMNonce
+      idNonce: IdNonce
+    brHmacDrbgGenerate(rng[], idNonce)
+    brHmacDrbgGenerate(rng[], requestNonce)
+    let
+      recordSeq = 0'u64
+
+      m = PingMessage(enrSeq: 0)
+      reqId = RequestId.init(rng[])
+      message = encodeMessage(m, reqId)
+
+      whoareyouData = WhoareyouData(requestNonce: requestNonce,
+        idNonce: idNonce, recordSeq: recordSeq)
+      pubkey = none(PublicKey)
+      challenge = Challenge(whoareyouData: whoareyouData, pubkey: pubkey)
+      key = HandShakeKey(nodeId: nodeA.id, address: $(nodeA.address.get()))
+
+    # Need to manually add the handshake, which would normally be done when
+    # sending a whoareyou Packet.
+    check: not codecB.handshakes.hasKeyOrPut(key, challenge)
+
+    let data = encodeHandshakePacket(rng[], codecA, nodeB.id,
+      nodeB.address.get(), message, idNonce, recordSeq, privKeyB.toPublicKey())
+
+    let decoded = codecB.decodePacket(nodeA.address.get(), data)
+
+    check:
+      decoded.isOk()
+      decoded.get().message.reqId == reqId
+      decoded.get().message.kind == ping
+      decoded.get().message.ping.enrSeq == 0
+      decoded.get().node.isSome()
+      decoded.get().node.get().record.seqNum == 1
+
+  test "Encode / Decode Ordinary Message Packet":
+    let
+      m = PingMessage(enrSeq: 0)
+      reqId = RequestId.init(rng[])
+      message = encodeMessage(m, reqId)
+
+    # Need to manually add the secrets the normally get negotiated in the
+    # handshake packet.
+    var secrets: HandshakeSecrets
+    codecA.sessions.store(nodeB.id, nodeB.address.get(), secrets.readKey, secrets.writeKey)
+    codecB.sessions.store(nodeA.id, nodeA.address.get(), secrets.writeKey, secrets.readKey)
+
+    let (data, nonce) = encodeMessagePacket(rng[], codecA, nodeB.id,
+      nodeB.address.get(), message)
+
+    let decoded = codecB.decodePacket(nodeA.address.get(), data)
+    check:
+      decoded.isOk()
+      decoded.get().flag == OrdinaryMessage
+      decoded.get().messageOpt.isSome()
+      decoded.get().messageOpt.get().reqId == reqId
+      decoded.get().messageOpt.get().kind == ping
+      decoded.get().messageOpt.get().ping.enrSeq == 0
+      decoded[].requestNonce == nonce

--- a/tests/p2p/test_discv51_encoding.nim
+++ b/tests/p2p/test_discv51_encoding.nim
@@ -26,9 +26,9 @@ suite "Discovery v5 Protocol Message Encodings":
 
   test "FindNode Request":
     var p: FindNodeMessage
-    p.distance = 0x0100
+    p.distances = @[0x0100'u32]
     var reqId: RequestId = 1
-    check encodeMessage(p, reqId).toHex == "03c401820100"
+    check encodeMessage(p, reqId).toHex == "03c501c3820100"
 
   test "Nodes Response (empty)":
     var p: NodesMessage

--- a/tests/p2p/test_discv51_encoding.nim
+++ b/tests/p2p/test_discv51_encoding.nim
@@ -4,12 +4,9 @@ import
   eth/[rlp, keys],
   eth/p2p/discoveryv5/[typesv1, encodingv1, enr, node, sessions]
 
-# According to test vectors:
-# https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire-test-vectors.md
-
 let rng = newRng()
 
-suite "Discovery v5 Protocol Message Encodings":
+suite "Discovery v5.1 Protocol Message Encodings":
   test "Ping Request":
     var p: PingMessage
     p.enrSeq = 1
@@ -47,11 +44,13 @@ suite "Discovery v5 Protocol Message Encodings":
     var reqId: RequestId = 1
     check encodeMessage(p, reqId).toHex == "04f8f20101f8eef875b8401ce2991c64993d7c84c29a00bdc871917551c7d330fca2dd0d69c706596dc655448f030b98a77d4001fd46ae0112ce26d613c5a6a02a81a6223cd0c4edaa53280182696482763489736563703235366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138f875b840d7f1c39e376297f81d7297758c64cb37dcc5c3beea9f57f7ce9695d7d5a67553417d719539d6ae4b445946de4d99e680eb8063f29485b555d45b7df16a1850130182696482763489736563703235366b31a1030e2cb74241c0c4fc8e8166f1a79a05d5b0dd95813a74b094529f317d5c39d235"
 
-suite "Discovery v5 Cryptographic Primitives":
+# According to test vectors:
+# https://github.com/fjl/devp2p/blob/discv5-v1-update/discv5/discv5-wire-test-vectors.md#cryptographic-primitives
+suite "Discovery v5.1 Cryptographic Primitives Test Vectors":
   test "ECDH":
     const
       # input
-      publicKey = "0x9961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231503061ac4aaee666073d7e5bc2c80c3f5c5b500c1cb5fd0a76abbb6b675ad157"
+      publicKey = "0x039961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231"
       secretKey = "0xfb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736"
       # expected output
       sharedSecret = "0x033b11a2a1f214567e1537ce5e509ffd9b21373247f2a3ff6841f4976f53165e7e"
@@ -59,41 +58,51 @@ suite "Discovery v5 Cryptographic Primitives":
     let
       pub = PublicKey.fromHex(publicKey)[]
       priv = PrivateKey.fromHex(secretKey)[]
-    let eph = ecdhRawFull(priv, pub)
+      eph = ecdhRawFull(priv, pub)
     check:
       eph.data == hexToSeqByte(sharedSecret)
 
   test "Key Derivation":
-    # const
-    #   # input
-    #   secretKey = "0x02a77e3aa0c144ae7c0a3af73692b7d6e5b7a2fdc0eda16e8d5e6cb0d08e88dd04"
-    #   nodeIdA = "0xa448f24c6d18e575453db13171562b71999873db5b286df957af199ec94617f7"
-    #   nodeIdB = "0x885bba8dfeddd49855459df852ad5b63d13a3fae593f3f9fa7e317fd43651409"
-    #   idNonce = "0x0101010101010101010101010101010101010101010101010101010101010101"
-    #   # expected output
-    #   initiatorKey = "0x238d8b50e4363cf603a48c6cc3542967"
-    #   recipientKey = "0xbebc0183484f7e7ca2ac32e3d72c8891"
-    #   authRespKey = "0xe987ad9e414d5b4f9bfe4ff1e52f2fae"
+    const
+      # input
+      ephemeralKey = "0xfb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736"
+      destPubkey = "0x0317931e6e0840220642f230037d285d122bc59063221ef3226b1f403ddc69ca91"
+      nodeIdA = "0xaaaa8419e9f49d0083561b48287df592939a8d19947d8c0ef88f2a4856a69fbb"
+      nodeIdB = "0xbbbb9d047f0488c0b5a93c1c3f2d8bafc7c8ff337024a55434a0d0555de64db9"
+      challengeData = "0x000000000000000000000000000000006469736376350001010102030405060708090a0b0c00180102030405060708090a0b0c0d0e0f100000000000000000"
+      # expected output
+      initiatorKey = "0xdccc82d81bd610f4f76d3ebe97a40571"
+      recipientKey = "0xac74bb8773749920b0d3a8881c173ec5"
 
-    # Code doesn't allow to start from shared `secretKey`, but only from the
-    # public and private key. Would require pulling `ecdhAgree` out of
-    # `deriveKeys`
-    skip()
+    let secrets = deriveKeys(
+      NodeId.fromHex(nodeIdA),
+      NodeId.fromHex(nodeIdB),
+      PrivateKey.fromHex(ephemeralKey)[],
+      PublicKey.fromHex(destPubkey)[],
+      hexToSeqByte(challengeData))
+
+    check:
+      secrets.writeKey == hexToByteArray[aesKeySize](initiatorKey)
+      secrets.readKey == hexToByteArray[aesKeySize](recipientKey)
 
   test "Nonce Signing":
     const
       # input
-      idNonce = "0xa77e3aa0c144ae7c0a3af73692b7d6e5b7a2fdc0eda16e8d5e6cb0d08e88dd04"
-      ephemeralKey = "0x9961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231503061ac4aaee666073d7e5bc2c80c3f5c5b500c1cb5fd0a76abbb6b675ad157"
-      localSecretKey = "0xfb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736"
+      staticKey = "0xfb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736"
+      challengeData = "0x000000000000000000000000000000006469736376350001010102030405060708090a0b0c00180102030405060708090a0b0c0d0e0f100000000000000000"
+      ephemeralPubkey = "0x039961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231"
+      nodeIdB = "0xbbbb9d047f0488c0b5a93c1c3f2d8bafc7c8ff337024a55434a0d0555de64db9"
       # expected output
-      idNonceSig = "0xc5036e702a79902ad8aa147dabfe3958b523fd6fa36cc78e2889b912d682d8d35fdea142e141f690736d86f50b39746ba2d2fc510b46f82ee08f08fd55d133a4"
+      idSignature = "0x94852a1e2318c4e5e9d422c98eaf19d1d90d876b29cd06ca7cb7546d0fff7b484fe86c09a064fe72bdbef73ba8e9c34df0cd2b53e9d65528c2c7f336d5dfc6e6"
 
     let
-      privKey = PrivateKey.fromHex(localSecretKey)[]
-      signature = signIDNonce(privKey, hexToByteArray[idNonceSize](idNonce),
-        hexToByteArray[64](ephemeralKey))
-    check signature.toRaw() == hexToByteArray[64](idNonceSig)
+      privKey = PrivateKey.fromHex(staticKey)[]
+      signature = signIDNonce(
+        privKey,
+        hexToSeqByte(challengeData),
+        hexToSeqByte(ephemeralPubkey),
+        NodeId.fromHex(nodeIdB))
+    check signature.toRaw() == hexToByteArray[64](idSignature)
 
   test "Encryption/Decryption":
     const
@@ -111,14 +120,9 @@ suite "Discovery v5 Cryptographic Primitives":
                                hexToByteArray[32](ad))
     check encrypted == hexToSeqByte(messageCiphertext)
 
-  test "Authentication Header and Encrypted Message Generation":
-    # Can't work directly with the provided shared secret as keys are derived
-    # inside makeAuthHeader, and passed on one call up.
-    # The encryption of the auth-resp-pt uses one of these keys, as does the
-    # encryption of the message itself. So the whole test depends on this.
-    skip()
-
-suite "Discovery v5.1 Test Vectors":
+# According to test vectors:
+# https://github.com/fjl/devp2p/blob/discv5-v1-update/discv5/discv5-wire-test-vectors.md#packet-encodings
+suite "Discovery v5.1 Packet Encodings Test Vectors":
   const
     nodeAKey = "0xeef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f"
     nodeBKey = "0x66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb1cde628"
@@ -143,13 +147,45 @@ suite "Discovery v5.1 Test Vectors":
       codecB = Codec(localNode: nodeB, privKey: privKeyB,
         sessions: Sessions.init(5))
 
+  test "Ping Ordinary Message Packet":
+    const
+      readKey = "0x00000000000000000000000000000000"
+      pingReqId = 0x00000001'u64
+      pingEnrSeq = 2'u64
+
+      encodedPacket =
+        "00000000000000000000000000000000088b3d4342774649325f313964a39e55" &
+        "ea96c005ad52be8c7560413a7008f16c9e6d2f43bbea8814a546b7409ce783d3" &
+        "4c4f53245d08dab84102ed931f66d1492acb308fa1c6715b9d139b81acbdcc"
+
+    let dummyKey = "0x00000000000000000000000000000001" # of no importance
+    codecA.sessions.store(nodeB.id, nodeB.address.get(),
+      hexToByteArray[aesKeySize](dummyKey), hexToByteArray[aesKeySize](readKey))
+    codecB.sessions.store(nodeA.id, nodeA.address.get(),
+      hexToByteArray[aesKeySize](readKey), hexToByteArray[aesKeySize](dummyKey))
+
+    # Note: Noticed when comparing these test vectors that we encode reqId as
+    # integer while it seems the test vectors have it encoded as byte seq,
+    # meaning having potentially leading zeroes.
+
+    let decoded = codecB.decodePacket(nodeA.address.get(), hexToSeqByte(encodedPacket))
+    check:
+      decoded.isOK()
+      decoded.get().messageOpt.isSome()
+      decoded.get().messageOpt.get().reqId == pingReqId
+      decoded.get().messageOpt.get().kind == ping
+      decoded.get().messageOpt.get().ping.enrSeq == pingEnrSeq
+
   test "Whoareyou Packet":
     const
+      whoareyouChallengeData = "0x000000000000000000000000000000006469736376350001010102030405060708090a0b0c00180102030405060708090a0b0c0d0e0f100000000000000000"
       whoareyouRequestNonce = "0x0102030405060708090a0b0c"
-      whoareyouIdNonce = "0x0102030405060708090a0b0c0d0e0f1000000000000000000000000000000000"
+      whoareyouIdNonce = "0x0102030405060708090a0b0c0d0e0f10"
       whoareyouEnrSeq = 0
 
-      encodedPacket = "0x00000000000000000000000000000000088b3d4342776668980a4adf72a8fcaa963f24b27a2f6bb44c7ed5ca10e87de130f94d2390b9853c3ecb9ad5e368892ec562137bf19c6d0a9191a5651c4f415117bdfa0c7ab86af62b7a9784eceb28008d03ede83bd1369631f9f3d8da0b45"
+      encodedPacket =
+        "00000000000000000000000000000000088b3d434277464933a1ccc59f5967ad" &
+        "1d6035f15e528627dde75cd68292f9e6c27d6b66c8100a873fcbaed4e16b8d"
 
     let decoded = codecB.decodePacket(nodeA.address.get(),
       hexToSeqByte(encodedPacket))
@@ -160,59 +196,35 @@ suite "Discovery v5.1 Test Vectors":
       decoded.get().whoareyou.requestNonce == hexToByteArray[gcmNonceSize](whoareyouRequestNonce)
       decoded.get().whoareyou.idNonce == hexToByteArray[idNonceSize](whoareyouIdNonce)
       decoded.get().whoareyou.recordSeq == whoareyouEnrSeq
-
-  test "Ping Ordinary Message Packet":
-    const
-      # nonce = "0xffffffffffffffffffffffff"
-      readKey = "0x00000000000000000000000000000000"
-      pingReqId = 0x00000001'u64
-      pingEnrSeq = 2'u64
-
-      encodedPacket = "00000000000000000000000000000000088b3d4342776668980a4adf72a8fcaa963f24b27a2f6bb44c7ed5ca10e87de130f94d2390b9853c3fcba22b1e9472d43c9ae48d04689eb84102ed931f66d180cbb4219f369a24f4e6b24d7bdc2a04"
-
-    let dummyKey = "0x00000000000000000000000000000001" # of no importance
-    codecA.sessions.store(nodeB.id, nodeB.address.get(),
-      hexToByteArray[aesKeySize](dummyKey), hexToByteArray[aesKeySize](readKey))
-    codecB.sessions.store(nodeA.id, nodeA.address.get(),
-      hexToByteArray[aesKeySize](readKey), hexToByteArray[aesKeySize](dummyKey))
-
-    # Note: Noticed when comparing these test vectors that we encode reqId as
-    # integer while it seems the test vectors have it encoded as byte seq,
-    # meaning having potentially heaving leading zeroes.
-
-    let decoded = codecB.decodePacket(nodeA.address.get(), hexToSeqByte(encodedPacket))
-    check:
-      decoded.isOK()
-      decoded.get().messageOpt.isSome()
-      decoded.get().messageOpt.get().reqId == pingReqId
-      decoded.get().messageOpt.get().kind == ping
-      decoded.get().messageOpt.get().ping.enrSeq == pingEnrSeq
+      decoded.get().whoareyou.challengeData == hexToSeqByte(whoareyouChallengeData)
 
   test "Ping Handshake Message Packet":
     const
-      # srcNodeId = "0xaaaa8419e9f49d0083561b48287df592939a8d19947d8c0ef88f2a4856a69fbb"
-      # destNodeId = "0xbbbb9d047f0488c0b5a93c1c3f2d8bafc7c8ff337024a55434a0d0555de64db9"
-      # nonce = "0xffffffffffffffffffffffff"
-      # readKey = "0x4917330b5aeb51650213f90d5f253c45"
-
       pingReqId = 0x00000001'u64
       pingEnrSeq = 1'u64
       #
       # handshake inputs:
       #
+      whoareyouChallengeData = "0x000000000000000000000000000000006469736376350001010102030405060708090a0b0c00180102030405060708090a0b0c0d0e0f100000000000000001"
       whoareyouRequestNonce = "0x0102030405060708090a0b0c"
-      whoareyouIdNonce = "0x0102030405060708090a0b0c0d0e0f1000000000000000000000000000000000"
+      whoareyouIdNonce = "0x0102030405060708090a0b0c0d0e0f10"
       whoareyouEnrSeq = 1'u64
-      # ephemeralKey = "0x0288ef00023598499cb6c940146d050d2b1fb914198c327f76aad590bead68b6"
-      # ephemeralPubkey = "0x039a003ba6517b473fa0cd74aefe99dadfdb34627f90fec6362df85803908f53a5"
 
-      encodedPacket = "00000000000000000000000000000000088b3d4342776668980a4adf72a8fcaa963f24b27a2f6bb44c7ed5ca10e87de130f94d2390b9853c3dcbded51e9472d43c9ae48d04689ef4d3b340a9cb02d3f5cb5c73f266876372a497ef20dccc83eebcf61f61bc2bb13655118c2dddd4fa7f66210832e7c45c2af87b635121ae132057cce99aa7d2760b31390fea5142053c97feb5fc3f5d0ff3d71008a5b6724bbfc8c97746524e695129d2bd7fccc3d4569a69fd8a783849a117bd23ec5b5d02be0a0c57"
+      encodedPacket =
+        "00000000000000000000000000000000088b3d4342774649305f313964a39e55" &
+        "ea96c005ad521d8c7560413a7008f16c9e6d2f43bbea8814a546b7409ce783d3" &
+        "4c4f53245d08da4bb252012b2cba3f4f374a90a75cff91f142fa9be3e0a5f3ef" &
+        "268ccb9065aeecfd67a999e7fdc137e062b2ec4a0eb92947f0d9a74bfbf44dfb" &
+        "a776b21301f8b65efd5796706adff216ab862a9186875f9494150c4ae06fa4d1" &
+        "f0396c93f215fa4ef524f1eadf5f0f4126b79336671cbcf7a885b1f8bd2a5d83" &
+        "9cf8"
 
     let
       whoareyouData = WhoareyouData(
         requestNonce: hexToByteArray[gcmNonceSize](whoareyouRequestNonce),
         idNonce: hexToByteArray[idNonceSize](whoareyouIdNonce),
-        recordSeq: whoareyouEnrSeq)
+        recordSeq: whoareyouEnrSeq,
+        challengeData: hexToSeqByte(whoareyouChallengeData))
       pubkey = some(privKeyA.toPublicKey())
       challenge = Challenge(whoareyouData: whoareyouData, pubkey: pubkey)
       key = HandShakeKey(nodeId: nodeA.id, address: $(nodeA.address.get()))
@@ -222,43 +234,44 @@ suite "Discovery v5.1 Test Vectors":
     let decoded = codecB.decodePacket(nodeA.address.get(),
       hexToSeqByte(encodedPacket))
 
-    skip()
-    # TODO: This test fails at the deriveKeys step. The readkey is not the
-    # expected value of above. Hardcoding that values makes decryption work.
-    # TBI.
-
-    # check:
-    #   decoded.isOk()
-    #   decoded.get().message.reqId == pingReqId
-    #   decoded.get().message.kind == ping
-    #   decoded.get().message.ping.enrSeq == pingEnrSeq
-    #   decoded.get().node.isNone()
+    check:
+      decoded.isOk()
+      decoded.get().message.reqId == pingReqId
+      decoded.get().message.kind == ping
+      decoded.get().message.ping.enrSeq == pingEnrSeq
+      decoded.get().node.isNone()
 
   test "Ping Handshake Message Packet with ENR":
     const
-      # srcNodeId = "0xaaaa8419e9f49d0083561b48287df592939a8d19947d8c0ef88f2a4856a69fbb"
-      # destNodeId = "0xbbbb9d047f0488c0b5a93c1c3f2d8bafc7c8ff337024a55434a0d0555de64db9"
-      # nonce = "0xffffffffffffffffffffffff"
-      # readKey = "0x4917330b5aeb51650213f90d5f253c45"
-
       pingReqId = 0x00000001'u64
       pingEnrSeq = 1'u64
       #
       # handshake inputs:
       #
+      whoareyouChallengeData = "0x000000000000000000000000000000006469736376350001010102030405060708090a0b0c00180102030405060708090a0b0c0d0e0f100000000000000000"
       whoareyouRequestNonce = "0x0102030405060708090a0b0c"
-      whoareyouIdNonce = "0x0102030405060708090a0b0c0d0e0f1000000000000000000000000000000000"
+      whoareyouIdNonce = "0x0102030405060708090a0b0c0d0e0f10"
       whoareyouEnrSeq = 0'u64
-      # ephemeralKey = "0x0288ef00023598499cb6c940146d050d2b1fb914198c327f76aad590bead68b6"
-      # ephemeralPubkey = "0x039a003ba6517b473fa0cd74aefe99dadfdb34627f90fec6362df85803908f53a5"
 
-      encodedPacket = "00000000000000000000000000000000088b3d4342776668980a4adf72a8fcaa963f24b27a2f6bb44c7ed5ca10e87de130f94d2390b9853c3dcaa0d51e9472d43c9ae48d04689ef4d3d2602a5e89ac340f9e81e722b1d7dac2578d520dd5bc6dc1e38ad3ab33012be1a5d259267a0947bf242219834c5702d1c694c0ceb4a6a27b5d68bd2c2e32e6cb9696706adff216ab862a9186875f9494150c4ae06fa4d1f0396c93f215fa4ef52417d9c40a31564e8d5f31a7f08c38045ff5e30d9661838b1eabee9f1e561120bcc4d9f2f9c839152b4ab970e029b2395b97e8c3aa8d3b497ee98a15e865bcd34effa8b83eb6396bca60ad8f0bff1e047e278454bc2b3d6404c12106a9d0b6107fc2383976fc05fbda2c954d402c28c8fb53a2b3a4b111c286ba2ac4ff880168323c6e97b01dbcbeef4f234e5849f75ab007217c919820aaa1c8a7926d3625917fccc3d4569a69fd8aca026be87afab8e8e645d1ee888992"
+      encodedPacket =
+        "00000000000000000000000000000000088b3d4342774649305f313964a39e55" &
+        "ea96c005ad539c8c7560413a7008f16c9e6d2f43bbea8814a546b7409ce783d3" &
+        "4c4f53245d08da4bb23698868350aaad22e3ab8dd034f548a1c43cd246be9856" &
+        "2fafa0a1fa86d8e7a3b95ae78cc2b988ded6a5b59eb83ad58097252188b902b2" &
+        "1481e30e5e285f19735796706adff216ab862a9186875f9494150c4ae06fa4d1" &
+        "f0396c93f215fa4ef524e0ed04c3c21e39b1868e1ca8105e585ec17315e755e6" &
+        "cfc4dd6cb7fd8e1a1f55e49b4b5eb024221482105346f3c82b15fdaae36a3bb1" &
+        "2a494683b4a3c7f2ae41306252fed84785e2bbff3b022812d0882f06978df84a" &
+        "80d443972213342d04b9048fc3b1d5fcb1df0f822152eced6da4d3f6df27e70e" &
+        "4539717307a0208cd208d65093ccab5aa596a34d7511401987662d8cf62b1394" &
+        "71"
 
     let
       whoareyouData = WhoareyouData(
         requestNonce: hexToByteArray[gcmNonceSize](whoareyouRequestNonce),
         idNonce: hexToByteArray[idNonceSize](whoareyouIdNonce),
-        recordSeq: whoareyouEnrSeq)
+        recordSeq: whoareyouEnrSeq,
+        challengeData: hexToSeqByte(whoareyouChallengeData))
       pubkey = none(PublicKey)
       challenge = Challenge(whoareyouData: whoareyouData, pubkey: pubkey)
       key = HandShakeKey(nodeId: nodeA.id, address: $(nodeA.address.get()))
@@ -268,19 +281,14 @@ suite "Discovery v5.1 Test Vectors":
     let decoded = codecB.decodePacket(nodeA.address.get(),
       hexToSeqByte(encodedPacket))
 
-    skip()
-    # TODO: This test fails at the deriveKeys step. The readkey is not the
-    # expected value of above. Hardcoding that values makes decryption work.
-    # TBI.
+    check:
+      decoded.isOk()
+      decoded.get().message.reqId == pingReqId
+      decoded.get().message.kind == ping
+      decoded.get().message.ping.enrSeq == pingEnrSeq
+      decoded.get().node.isSome()
 
-    # check:
-    #   decoded.isOk()
-    #   decoded.get().message.reqId == pingReqId
-    #   decoded.get().message.kind == ping
-    #   decoded.get().message.ping.enrSeq == pingEnrSeq
-    #   decoded.get().node.isSome()
-
-suite "Discovery v5.1 Additional":
+suite "Discovery v5.1 Additional Encode/Decode":
   test "Encryption/Decryption":
     let
       encryptionKey = hexToByteArray[aesKeySize]("0x9f2d77db7004bf8a1a85107ac686990b")
@@ -288,8 +296,9 @@ suite "Discovery v5.1 Additional":
       ad = hexToByteArray[32]("0x93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903")
       pt = hexToSeqByte("0xa1")
 
-    let ct = encryptGCM(encryptionKey, nonce, pt, ad)
-    let decrypted = decryptGCM(encryptionKey, nonce, ct, ad)
+    let
+      ct = encryptGCM(encryptionKey, nonce, pt, ad)
+      decrypted = decryptGCM(encryptionKey, nonce, ct, ad)
 
     check decrypted.get() == pt
 
@@ -316,13 +325,15 @@ suite "Discovery v5.1 Additional":
     check decryptGCM(encryptionKey, nonce, invalidCipher, ad).isNone()
 
   test "Encrypt / Decrypt header":
+    var nonce: AESGCMNonce
+    brHmacDrbgGenerate(rng[], nonce)
     let
       privKey = PrivateKey.random(rng[])
       nodeId = privKey.toPublicKey().toNodeId()
-      authdata = [byte 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-      staticHeader = encodeStaticHeader(nodeId, Flag.OrdinaryMessage,
+      authdata = newSeq[byte](32)
+      staticHeader = encodeStaticHeader(Flag.OrdinaryMessage, nonce,
         authdata.len())
-      header = @staticHeader & @authdata
+      header = staticHeader & authdata
 
     var iv: array[128 div 8, byte]
     brHmacDrbgGenerate(rng[], iv)
@@ -367,49 +378,47 @@ suite "Discovery v5.1 Additional":
       decoded[].requestNonce == nonce
 
   test "Encode / Decode Whoareyou Packet":
-    var
-      requestNonce: AESGCMNonce
-      idNonce: IdNonce
-    brHmacDrbgGenerate(rng[], idNonce)
+    var requestNonce: AESGCMNonce
     brHmacDrbgGenerate(rng[], requestNonce)
     let recordSeq = 0'u64
 
-    let data = encodeWhoareyouPacket(rng[], codecA, nodeB.id, requestNonce, idNonce,
-      recordSeq)
+    let data = encodeWhoareyouPacket(rng[], codecA, nodeB.id,
+      nodeB.address.get(), requestNonce, recordSeq, none(PublicKey))
 
     let decoded = codecB.decodePacket(nodeA.address.get(), data)
+
+    let key = HandShakeKey(nodeId: nodeB.id, address: $nodeB.address.get())
+    var challenge: Challenge
+
     check:
+      codecA.handshakes.pop(key, challenge)
       decoded.isOk()
       decoded[].flag == Flag.Whoareyou
       decoded[].whoareyou.requestNonce == requestNonce
-      decoded[].whoareyou.idNonce == idNonce
+      decoded[].whoareyou.idNonce == challenge.whoareyouData.idNonce
       decoded[].whoareyou.recordSeq == recordSeq
 
   test "Encode / Decode Handshake Message Packet":
-    var
-      requestNonce: AESGCMNonce
-      idNonce: IdNonce
-    brHmacDrbgGenerate(rng[], idNonce)
+    var requestNonce: AESGCMNonce
     brHmacDrbgGenerate(rng[], requestNonce)
-    let recordSeq = 1'u64
-
     let
+      recordSeq = 1'u64
       m = PingMessage(enrSeq: 0)
       reqId = RequestId.init(rng[])
       message = encodeMessage(m, reqId)
-    let
-      whoareyouData = WhoareyouData(
-        requestNonce: requestNonce,
-        idNonce: idNonce,
-        recordSeq: recordSeq)
       pubkey = some(privKeyA.toPublicKey())
-      challenge = Challenge(whoareyouData: whoareyouData, pubkey: pubkey)
-      key = HandShakeKey(nodeId: nodeA.id, address: $(nodeA.address.get()))
 
-    check: not codecB.handshakes.hasKeyOrPut(key, challenge)
+    # Encode/decode whoareyou packet to get the handshake stored and the
+    # whoareyou data returned. It's either that or construct the header for the
+    # whoareyouData manually.
+    let
+      encodedDummy = encodeWhoareyouPacket(rng[], codecB, nodeA.id,
+        nodeA.address.get(), requestNonce, recordSeq, pubkey)
+      decodedDummy = codecA.decodePacket(nodeB.address.get(), encodedDummy)
 
     let data = encodeHandshakePacket(rng[], codecA, nodeB.id,
-      nodeB.address.get(), message, idNonce, recordSeq, privKeyB.toPublicKey())
+      nodeB.address.get(), message, decodedDummy[].whoareyou,
+      privKeyB.toPublicKey())
 
     let decoded = codecB.decodePacket(nodeA.address.get(), data)
 
@@ -421,32 +430,28 @@ suite "Discovery v5.1 Additional":
       decoded.get().node.isNone()
 
   test "Encode / Decode Handshake Message Packet with ENR":
-    var
-      requestNonce: AESGCMNonce
-      idNonce: IdNonce
-    brHmacDrbgGenerate(rng[], idNonce)
+    var requestNonce: AESGCMNonce
     brHmacDrbgGenerate(rng[], requestNonce)
     let
       recordSeq = 0'u64
-
       m = PingMessage(enrSeq: 0)
       reqId = RequestId.init(rng[])
       message = encodeMessage(m, reqId)
-
-      whoareyouData = WhoareyouData(requestNonce: requestNonce,
-        idNonce: idNonce, recordSeq: recordSeq)
       pubkey = none(PublicKey)
-      challenge = Challenge(whoareyouData: whoareyouData, pubkey: pubkey)
-      key = HandShakeKey(nodeId: nodeA.id, address: $(nodeA.address.get()))
 
-    # Need to manually add the handshake, which would normally be done when
-    # sending a whoareyou Packet.
-    check: not codecB.handshakes.hasKeyOrPut(key, challenge)
+    # Encode/decode whoareyou packet to get the handshake stored and the
+    # whoareyou data returned. It's either that or construct the header for the
+    # whoareyouData manually.
+    let
+      encodedDummy = encodeWhoareyouPacket(rng[], codecB, nodeA.id,
+        nodeA.address.get(), requestNonce, recordSeq, pubkey)
+      decodedDummy = codecA.decodePacket(nodeB.address.get(), encodedDummy)
 
-    let data = encodeHandshakePacket(rng[], codecA, nodeB.id,
-      nodeB.address.get(), message, idNonce, recordSeq, privKeyB.toPublicKey())
+    let encoded = encodeHandshakePacket(rng[], codecA, nodeB.id,
+      nodeB.address.get(), message, decodedDummy[].whoareyou,
+      privKeyB.toPublicKey())
 
-    let decoded = codecB.decodePacket(nodeA.address.get(), data)
+    let decoded = codecB.decodePacket(nodeA.address.get(), encoded)
 
     check:
       decoded.isOk()
@@ -462,7 +467,7 @@ suite "Discovery v5.1 Additional":
       reqId = RequestId.init(rng[])
       message = encodeMessage(m, reqId)
 
-    # Need to manually add the secrets the normally get negotiated in the
+    # Need to manually add the secrets that normally get negotiated in the
     # handshake packet.
     var secrets: HandshakeSecrets
     codecA.sessions.store(nodeB.id, nodeB.address.get(), secrets.readKey, secrets.writeKey)


### PR DESCRIPTION
Here's a go at the discovery v5.1 implementation. Closing https://github.com/status-im/nim-eth/issues/279

Didn't give too much thought right now at the passing/copying around of the data, might revise that at some time (if it is worth it), but feel free to suggest obvious improvements.
Might also restructure/split/move some code a bit at some point.

More important TODOs:
- [x] Two of the current existing test vectors still fail at the decrypt step, more specifically because of different generated secrets, which is rather weird as that is a part of the code that remain the same. TBI
- [x] FindNodes request with multiple distances
- [x] Allow for the not supported (new) packet types to not create a failure.
- [x] Revise / improve input size checks
- [x] Spec changes that are still being looked at
- [x] Fuzzing targets
- [x] Interop
- [x] Fix commented out handshake tests

Switch between discv5 and discv5.1 can be made with `UseDiscv51` compile time flag on `dcli` and the `test_discoveryv5`. 

