### PR TITLE
Discv5 ip limits for routing table

### DIFF
--- a/eth/net/utils.nim
+++ b/eth/net/utils.nim
@@ -1,0 +1,27 @@
+import
+  std/[tables, hashes],
+  stew/shims/net as stewNet
+
+{.push raises: [Defect].}
+
+type
+  IpLimits* = object
+    limit*: uint
+    ips: Table[ValidIpAddress, uint]
+
+proc hash(ip: ValidIpAddress): Hash = hash($ip)
+
+proc inc*(ipLimits: var IpLimits, ip: ValidIpAddress): bool =
+  let val = ipLimits.ips.getOrDefault(ip, 0)
+  if val < ipLimits.limit:
+    ipLimits.ips[ip] = val + 1
+    true
+  else:
+    false
+
+proc dec*(ipLimits: var IpLimits, ip: ValidIpAddress) =
+  let val = ipLimits.ips.getOrDefault(ip, 0)
+  if val == 1:
+    ipLimits.ips.del(ip)
+  elif val > 1:
+    ipLimits.ips[ip] = val - 1

--- a/eth/p2p/discoveryv5/node.nim
+++ b/eth/p2p/discoveryv5/node.nim
@@ -46,6 +46,19 @@ func newNode*(r: Record): Result[Node, cstring] =
     ok(Node(id: pk.get().toNodeId(), pubkey: pk.get(), record: r,
        address: none(Address)))
 
+proc updateNode*(n: Node, pk: PrivateKey, ip: Option[ValidIpAddress],
+    tcpPort, udpPort: Port, extraFields: openarray[FieldPair] = []):
+    Result[void, cstring] =
+  ? n.record.update(pk, ip, tcpPort, udpPort, extraFields)
+
+  if ip.isSome():
+    let a = Address(ip: ip.get(), port: Port(udpPort))
+    n.address = some(a)
+  else:
+    n.address = none(Address)
+
+  ok()
+
 func hash*(n: Node): hashes.Hash = hash(n.pubkey.toRaw)
 func `==`*(a, b: Node): bool =
   (a.isNil and b.isNil) or

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -760,7 +760,9 @@ proc newProtocol*(privKey: PrivateKey,
                   localEnrFields: openarray[(string, seq[byte])] = [],
                   bootstrapRecords: openarray[Record] = [],
                   previousRecord = none[enr.Record](),
-                  bindIp = IPv4_any(), rng = newRng()):
+                  bindIp = IPv4_any(),
+                  tableIpLimits = DefaultTableIpLimits,
+                  rng = newRng()):
                   Protocol {.raises: [Defect].} =
   # TODO: Tried adding bindPort = udpPort as parameter but that gave
   # "Error: internal error: environment misses: udpPort" in nim-beacon-chain.
@@ -793,7 +795,7 @@ proc newProtocol*(privKey: PrivateKey,
     bootstrapRecords: @bootstrapRecords,
     rng: rng)
 
-  result.routingTable.init(node, 5, rng)
+  result.routingTable.init(node, DefaultBitsPerHop, tableIpLimits, rng)
 
 proc open*(d: Protocol) {.raises: [Exception, Defect].} =
   info "Starting discovery node", node = d.localNode,

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -127,11 +127,12 @@ type
 proc addNode*(d: Protocol, node: Node): bool =
   ## Add `Node` to discovery routing table.
   ##
-  ## Returns false only if `Node` is not eligable for adding (no Address).
-  if node.address.isSome():
-    # Only add nodes with an address to the routing table
-    discard d.routingTable.addNode(node)
+  ## Returns true only when `Node` was added as a new entry to a bucket in the
+  ## routing table.
+  if d.routingTable.addNode(node) == Added:
     return true
+  else:
+    return false
 
 proc addNode*(d: Protocol, r: Record): bool =
   ## Add `Node` from a `Record` to discovery routing table.
@@ -393,10 +394,10 @@ proc receive*(d: Protocol, a: Address, packet: openArray[byte]) {.gcsafe,
         # Not filling table with nodes without correct IP in the ENR
         # TODO: Should we care about this???
         if node.address.isSome() and a == node.address.get():
-          debug "Adding new node to routing table", node
-          discard d.addNode(node)
+          if d.addNode(node):
+            trace "Added new node to routing table after handshake", node
   else:
-    debug "Packet decoding error", error = decoded.error, address = a
+    trace "Packet decoding error", error = decoded.error, address = a
 
 # TODO: Not sure why but need to pop the raises here as it is apparently not
 # enough to put it in the raises pragma of `processClient` and other async procs.
@@ -641,7 +642,7 @@ proc lookupWorker(d: Protocol, destNode: Node, target: NodeId):
     inc i
 
   for n in result:
-    discard d.routingTable.addNode(n)
+    discard d.addNode(n)
 
 proc lookup*(d: Protocol, target: NodeId): Future[seq[Node]]
     {.async, raises: [Exception, Defect].} =
@@ -807,8 +808,10 @@ proc open*(d: Protocol) {.raises: [Exception, Defect].} =
   d.transp = newDatagramTransport(processClient, udata = d, local = ta)
 
   for record in d.bootstrapRecords:
-    debug "Adding bootstrap node", uri = toURI(record)
-    discard d.addNode(record)
+    if d.addNode(record):
+      debug "Added bootstrap node", uri = toURI(record)
+    else:
+      debug "Bootstrap node could not be added", uri = toURI(record)
 
 proc start*(d: Protocol) {.raises: [Exception, Defect].} =
   d.lookupLoop = lookupLoop(d)

--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -285,6 +285,9 @@ proc addNode*(r: var RoutingTable, n: Node): NodeStatus =
         if not ipLimitInc(r, bucket, n):
           return IpLimitReached
         ipLimitDec(r, bucket, bucket.nodes[nodeIdx])
+      # Copy over the seen status, we trust here that after the ENR update the
+      # node will still be reachable, but it might not be the case.
+      n.seen = bucket.nodes[nodeIdx].seen
       bucket.nodes[nodeIdx] = n
 
     return Existing

--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -52,6 +52,7 @@ type
     IpLimitReached
     ReplacementAdded
     ReplacementExisting
+    NoAddress
 
 const
   BUCKET_SIZE* = 16 ## Maximum amount of nodes per bucket
@@ -270,6 +271,13 @@ proc addNode*(r: var RoutingTable, n: Node): NodeStatus =
   ## When the IP of the node has reached the IP limits for the bucket or the
   ## total routing table, the node will not be added to the bucket, nor its
   ## replacement cache.
+
+  # Don't allow nodes without an address field in the ENR to be added.
+  # This could also be reworked by having another Node type that always has an
+  # address.
+  if n.address.isNone():
+    return NoAddress
+
   if n == r.thisNode:
     return LocalNode
 

--- a/tests/p2p/discv5_test_helper.nim
+++ b/tests/p2p/discv5_test_helper.nim
@@ -1,8 +1,10 @@
 import
-  stew/shims/net, bearssl,
+  stew/shims/net, bearssl, chronos,
   eth/keys,
   eth/p2p/discoveryv5/[enr, node, routing_table],
   eth/p2p/discoveryv5/protocol as discv5_protocol
+
+export net
 
 proc localAddress*(port: int): Address =
   Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(port))
@@ -13,12 +15,17 @@ proc initDiscoveryNode*(rng: ref BrHmacDrbgContext, privKey: PrivateKey,
                         localEnrFields: openarray[(string, seq[byte])] = [],
                         previousRecord = none[enr.Record]()):
                         discv5_protocol.Protocol =
+  # set bucketIpLimit to allow bucket split
+  let tableIpLimits = TableIpLimits(tableIpLimit: 100,  bucketIpLimit: 17)
+
   result = newProtocol(privKey,
                        some(address.ip),
                        address.port, address.port,
                        bootstrapRecords = bootstrapRecords,
                        localEnrFields = localEnrFields,
-                       previousRecord = previousRecord, rng = rng)
+                       previousRecord = previousRecord,
+                       tableIpLimits = tableIpLimits,
+                       rng = rng)
 
   result.open()
 
@@ -27,22 +34,33 @@ proc nodeIdInNodes*(id: NodeId, nodes: openarray[Node]): bool =
     if id == n.id: return true
 
 proc generateNode*(privKey: PrivateKey, port: int = 20302,
+    ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1"),
     localEnrFields: openarray[FieldPair] = []): Node =
   let port = Port(port)
-  let enr = enr.Record.init(1, privKey, some(ValidIpAddress.init("127.0.0.1")),
+  let enr = enr.Record.init(1, privKey, some(ip),
     port, port, localEnrFields).expect("Properly intialized private key")
   result = newNode(enr).expect("Properly initialized node")
 
-proc nodeAtDistance*(n: Node, rng: var BrHmacDrbgContext, d: uint32): Node =
+proc nodeAtDistance*(n: Node, rng: var BrHmacDrbgContext, d: uint32,
+    ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): Node =
   while true:
-    let node = generateNode(PrivateKey.random(rng))
+    let node = generateNode(PrivateKey.random(rng), ip = ip)
     if logDist(n.id, node.id) == d:
       return node
 
 proc nodesAtDistance*(
-    n: Node, rng: var BrHmacDrbgContext, d: uint32, amount: int): seq[Node] =
+    n: Node, rng: var BrHmacDrbgContext, d: uint32, amount: int,
+    ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): seq[Node] =
   for i in 0..<amount:
-    result.add(nodeAtDistance(n, rng, d))
+    result.add(nodeAtDistance(n, rng, d, ip))
+
+proc nodesAtDistanceUniqueIp*(
+    n: Node, rng: var BrHmacDrbgContext, d: uint32, amount: int,
+    ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): seq[Node] =
+  var ta = initTAddress(ip, Port(0))
+  for i in 0..<amount:
+    ta.inc()
+    result.add(nodeAtDistance(n, rng, d, ValidIpAddress.init(ta.address())))
 
 proc addSeenNode*(d: discv5_protocol.Protocol, n: Node): bool =
   # Add it as a seen node, warning: for testing convenience only!

--- a/tests/p2p/discv5_test_helper.nim
+++ b/tests/p2p/discv5_test_helper.nim
@@ -41,12 +41,18 @@ proc generateNode*(privKey: PrivateKey, port: int = 20302,
     port, port, localEnrFields).expect("Properly intialized private key")
   result = newNode(enr).expect("Properly initialized node")
 
+proc nodeAndPrivKeyAtDistance*(n: Node, rng: var BrHmacDrbgContext, d: uint32,
+    ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): (Node, PrivateKey) =
+  while true:
+    let pk = PrivateKey.random(rng)
+    let node = generateNode(pk, ip = ip)
+    if logDist(n.id, node.id) == d:
+      return (node, pk)
+
 proc nodeAtDistance*(n: Node, rng: var BrHmacDrbgContext, d: uint32,
     ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): Node =
-  while true:
-    let node = generateNode(PrivateKey.random(rng), ip = ip)
-    if logDist(n.id, node.id) == d:
-      return node
+  let (node, _) = n.nodeAndPrivKeyAtDistance(rng, d, ip)
+  node
 
 proc nodesAtDistance*(
     n: Node, rng: var BrHmacDrbgContext, d: uint32, amount: int,

--- a/tests/p2p/discv5_test_helper.nim
+++ b/tests/p2p/discv5_test_helper.nim
@@ -16,7 +16,7 @@ proc initDiscoveryNode*(rng: ref BrHmacDrbgContext, privKey: PrivateKey,
                         previousRecord = none[enr.Record]()):
                         discv5_protocol.Protocol =
   # set bucketIpLimit to allow bucket split
-  let tableIpLimits = TableIpLimits(tableIpLimit: 100,  bucketIpLimit: 17)
+  let tableIpLimits = TableIpLimits(tableIpLimit: 1000,  bucketIpLimit: 24)
 
   result = newProtocol(privKey,
                        some(address.ip),

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -319,7 +319,7 @@ procSuite "Discovery v5 Tests":
         n.get().record.seqNum == targetSeqNum
 
       # Add the updated version
-      check mainNode.addNode(n.get())
+      discard mainNode.addNode(n.get())
 
     # Update seqNum in ENR again, ping lookupNode to be added in routing table,
     # close targetNode, resolve should lookup, check if we get updated ENR.

--- a/tests/p2p/test_routing_table.nim
+++ b/tests/p2p/test_routing_table.nim
@@ -6,88 +6,103 @@ import
 suite "Routing Table Tests":
   let rng = newRng()
 
+  # Used for testing. Could also at runtime check whether the address is the
+  # loopback address as these are only allowed to be added when coming from
+  # another loopback nodes, however that check is done in the protocol code and
+  # thus independent of routing_table.
+  let ipLimits = TableIpLimits(tableIpLimit: 200,
+    bucketIpLimit: BUCKET_SIZE + REPLACEMENT_CACHE_SIZE + 1)
+
+  test "Add local node":
+    let node = generateNode(PrivateKey.random(rng[]))
+    var table: RoutingTable
+
+    table.init(node, 1, ipLimits, rng = rng)
+
+    check table.addNode(node) == LocalNode
+
   test "Bucket splitting in range branch b=1":
     let node = generateNode(PrivateKey.random(rng[]))
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1, rng)
+    table.init(node, 1, ipLimits, rng = rng)
 
     for j in 0..5'u32:
       for i in 0..<BUCKET_SIZE:
-        check table.addNode(node.nodeAtDistance(rng[], 256-j)) == nil
-      check table.addNode(node.nodeAtDistance(rng[], 256-j)) != nil
+        check table.addNode(node.nodeAtDistance(rng[], 256-j)) == Added
+      check table.addNode(node.nodeAtDistance(rng[], 256-j)) == ReplacementAdded
 
   test "Bucket splitting off range branch b=1":
     let node = generateNode(PrivateKey.random(rng[]))
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1, rng)
+    table.init(node, 1, ipLimits, rng = rng)
 
     # Add 16 nodes, distance 256
     for i in 0..<BUCKET_SIZE:
-      check table.addNode(node.nodeAtDistance(rng[], 256)) == nil
+      check table.addNode(node.nodeAtDistance(rng[], 256)) == Added
 
     # This should split the bucket in the distance 256 branch, and the distance
     # <=255 branch. But not add the node, as distance 256 bucket is already full
     # and b=1 will not allow it to spit any further
-    check table.addNode(node.nodeAtDistance(rng[], 256)) != nil
+    check table.addNode(node.nodeAtDistance(rng[], 256)) == ReplacementAdded
 
     # This add should be allowed as it is on the branch where the own node's id
     # id belongs to.
-    check table.addNode(node.nodeAtDistance(rng[], 255)) == nil
+    check table.addNode(node.nodeAtDistance(rng[], 255)) == Added
 
   test "Bucket splitting off range branch b=2":
     let node = generateNode(PrivateKey.random(rng[]))
     var table: RoutingTable
 
     # bitsPerHop = 2, allow not in range branch to split once (2 buckets).
-    table.init(node, 2, rng)
+    table.init(node, 2, ipLimits, rng = rng)
 
     # Add 16 nodes, distance 256 from `node`, but all with 2 bits shared prefix
     # among themselves.
     let firstNode = node.nodeAtDistance(rng[], 256)
-    check table.addNode(firstNode) == nil
+    check table.addNode(firstNode) == Added
     for n in 1..<BUCKET_SIZE:
-      check table.addNode(firstNode.nodeAtDistance(rng[], 254)) == nil
+      check table.addNode(firstNode.nodeAtDistance(rng[], 254)) == Added
 
     # Add 16 more nodes with only 1 bit shared prefix with previous 16. This
     # should cause the initial bucket to split and and fill the second bucket
     # with the 16 new entries.
     for n in 0..<BUCKET_SIZE:
-      check table.addNode(firstNode.nodeAtDistance(rng[], 255)) == nil
+      check table.addNode(firstNode.nodeAtDistance(rng[], 255)) == Added
 
     # Adding another should fail as both buckets will be full and not be
     # allowed to split another time.
-    check table.addNode(node.nodeAtDistance(rng[], 256)) != nil
+    check table.addNode(node.nodeAtDistance(rng[], 256)) == ReplacementAdded
     # And also when targetting one of the two specific buckets.
-    check table.addNode(firstNode.nodeAtDistance(rng[], 255)) != nil
-    check table.addNode(firstNode.nodeAtDistance(rng[], 254)) != nil
+    check table.addNode(firstNode.nodeAtDistance(rng[], 255)) == ReplacementAdded
+    check table.addNode(firstNode.nodeAtDistance(rng[], 254)) == ReplacementAdded
     # This add should be allowed as it is on the branch where the own node's id
     # id belongs to.
-    check table.addNode(node.nodeAtDistance(rng[], 255)) == nil
+    check table.addNode(node.nodeAtDistance(rng[], 255)) == Added
 
   test "Replacement cache":
     let node = generateNode(PrivateKey.random(rng[]))
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1, rng)
+    table.init(node, 1, ipLimits, rng = rng)
 
     # create a full bucket
     let bucketNodes = node.nodesAtDistance(rng[], 256, BUCKET_SIZE)
     for n in bucketNodes:
-      check table.addNode(n) == nil
+      check table.addNode(n) == Added
 
     # create a full replacement cache
     let replacementNodes = node.nodesAtDistance(rng[], 256, REPLACEMENT_CACHE_SIZE)
     for n in replacementNodes:
-      check table.addNode(n) != nil
+      check table.addNode(n) == ReplacementAdded
 
     # Add one more node to replacement (would drop first one)
     let lastNode = node.nodeAtDistance(rng[], 256)
-    check table.addNode(lastNode) != nil
+    check table.addNode(lastNode) == ReplacementAdded
 
     # This should replace the last node in the bucket, with the last one of
     # the replacement cache.
@@ -107,7 +122,7 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1, rng)
+    table.init(node, 1, ipLimits, rng = rng)
 
     check table.nodeToRevalidate().isNil()
 
@@ -116,7 +131,7 @@ suite "Routing Table Tests":
     check table.len == 0
 
     let addedNode = generateNode(PrivateKey.random(rng[]))
-    check table.addNode(addedNode) == nil
+    check table.addNode(addedNode) == Added
     check table.len == 1
 
     # try to replace not existing node
@@ -131,12 +146,12 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1, rng)
+    table.init(node, 1, ipLimits, rng = rng)
 
     # create a full bucket TODO: no need to store bucketNodes
     let bucketNodes = node.nodesAtDistance(rng[], 256, BUCKET_SIZE)
     for n in bucketNodes:
-      check table.addNode(n) == nil
+      check table.addNode(n) == Added
 
     table.replaceNode(table.nodeToRevalidate())
     # This node should still be removed
@@ -147,19 +162,19 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1, rng)
+    table.init(node, 1, ipLimits, rng = rng)
 
     let doubleNode = node.nodeAtDistance(rng[], 256)
     # Try to add the node twice
-    check table.addNode(doubleNode) == nil
-    check table.addNode(doubleNode) == nil
+    check table.addNode(doubleNode) == Added
+    check table.addNode(doubleNode) == Existing
 
     for n in 0..<BUCKET_SIZE-1:
-      check table.addNode(node.nodeAtDistance(rng[], 256)) == nil
+      check table.addNode(node.nodeAtDistance(rng[], 256)) == Added
 
-    check table.addNode(node.nodeAtDistance(rng[], 256)) != nil
+    check table.addNode(node.nodeAtDistance(rng[], 256)) == ReplacementAdded
     # Check when adding again once the bucket is full
-    check table.addNode(doubleNode) == nil
+    check table.addNode(doubleNode) == Existing
 
     # Test if its order is preserved, there is one node in replacement cache
     # which is why we run `BUCKET_SIZE` times.
@@ -177,19 +192,19 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1, rng)
+    table.init(node, 1, ipLimits, rng = rng)
 
     # create a full bucket
     let bucketNodes = node.nodesAtDistance(rng[], 256, BUCKET_SIZE)
     for n in bucketNodes:
-      check table.addNode(n) == nil
+      check table.addNode(n) == Added
 
     # create a full replacement cache
     let replacementNodes = node.nodesAtDistance(rng[], 256, REPLACEMENT_CACHE_SIZE)
     for n in replacementNodes:
-      check table.addNode(n) != nil
+      check table.addNode(n) == ReplacementAdded
 
-    check table.addNode(replacementNodes[0]) != nil
+    check table.addNode(replacementNodes[0]) == ReplacementExisting
 
     table.replaceNode(table.nodeToRevalidate())
     block:
@@ -207,12 +222,12 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1, rng)
+    table.init(node, 1, ipLimits, rng = rng)
 
     # create a full bucket
     let bucketNodes = node.nodesAtDistance(rng[], 256, BUCKET_SIZE)
     for n in bucketNodes:
-      check table.addNode(n) == nil
+      check table.addNode(n) == Added
 
     # swap seen order
     for n in bucketNodes:
@@ -227,17 +242,17 @@ suite "Routing Table Tests":
     var table: RoutingTable
 
     # bitsPerHop = 1 -> Split only the branch in range of own id
-    table.init(node, 1, rng)
+    table.init(node, 1, ipLimits, rng = rng)
 
     # create a full bucket
     let bucketNodes = node.nodesAtDistance(rng[], 256, BUCKET_SIZE)
     for n in bucketNodes:
-      check table.addNode(n) == nil
+      check table.addNode(n) == Added
 
     # create a full replacement cache
     let replacementNodes = node.nodesAtDistance(rng[], 256, REPLACEMENT_CACHE_SIZE)
     for n in replacementNodes:
-      check table.addNode(n) != nil
+      check table.addNode(n) == ReplacementAdded
 
     for i in countdown(replacementNodes.high, 0):
       table.replaceNode(table.nodeToRevalidate())
@@ -254,3 +269,169 @@ suite "Routing Table Tests":
       check:
         result.isSome()
         result.get() == bucketNodes[i]
+
+  test "Ip limits on bucket":
+    let node = generateNode(PrivateKey.random(rng[]))
+    var table: RoutingTable
+
+    # bitsPerHop = 1 -> Split only the branch in range of own id
+    table.init(node, 1, DefaultTableIpLimits, rng = rng)
+
+    block: # First bucket
+      let sameIpNodes = node.nodesAtDistance(rng[], 256,
+        int(DefaultTableIpLimits.bucketIpLimit))
+      for n in sameIpNodes:
+        check table.addNode(n) == Added
+
+      # Try to add a node, which should fail due to ip bucket limit
+      let anotherSameIpNode = node.nodeAtDistance(rng[], 256)
+      check table.addNode(anotherSameIpNode) == IpLimitReached
+
+      # Remove one and try add again
+      table.replaceNode(table.nodeToRevalidate())
+      check table.addNode(anotherSameIpNode) == Added
+
+      # Further fill the bucket with nodes with different ip.
+      let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256,
+        int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit),
+        ValidIpAddress.init("192.168.0.1"))
+      for n in diffIpNodes:
+        check table.addNode(n) == Added
+
+    block: # Second bucket
+      # Try to add another node with the same IP, but different distance.
+      let anotherSameIpNode = node.nodeAtDistance(rng[], 255)
+      check table.addNode(anotherSameIpNode) == IpLimitReached
+
+      # Add more nodes with different ip and distance 255 to get in the new bucket
+      let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 255,
+        int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit),
+        ValidIpAddress.init("192.168.1.1"))
+      for n in diffIpNodes:
+        check table.addNode(n) == Added
+
+      let sameIpNodes = node.nodesAtDistance(rng[], 255,
+        int(DefaultTableIpLimits.bucketIpLimit))
+      for n in sameIpNodes:
+        check table.addNode(n) == Added
+
+      # Adding in another one should fail again
+      check table.addNode(anotherSameIpNode) == IpLimitReached
+
+  test "Ip limits on routing table":
+    let node = generateNode(PrivateKey.random(rng[]))
+    var table: RoutingTable
+
+    # bitsPerHop = 1 -> Split only the branch in range of own id
+    table.init(node, 1, DefaultTableIpLimits, rng = rng)
+
+    let amount = uint32(DefaultTableIpLimits.tableIpLimit div
+      DefaultTableIpLimits.bucketIpLimit)
+    # Fill `amount` of buckets, each with 14 nodes with different ips and 2
+    # with equal ones.
+    for j in 0..<amount:
+      let nodes = node.nodesAtDistanceUniqueIp(rng[], 256 - j,
+        int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit),
+        ValidIpAddress.init("192.168.0.1"))
+      for n in nodes:
+        check table.addNode(n) == Added
+
+      let sameIpNodes = node.nodesAtDistance(rng[], 256 - j,
+        int(DefaultTableIpLimits.bucketIpLimit))
+      for n in sameIpNodes:
+        check table.addNode(n) == Added
+
+    # Add a node with a different IP, should work and split a bucket once more.
+    let anotherDiffIpNode = node.nodeAtDistance(rng[], 256 - amount,
+      ValidIpAddress.init("192.168.1.1"))
+    check table.addNode(anotherDiffIpNode) == Added
+
+    let amountLeft = int(DefaultTableIpLimits.tableIpLimit mod
+      DefaultTableIpLimits.bucketIpLimit)
+
+    let sameIpNodes = node.nodesAtDistance(rng[], 256 - amount, amountLeft)
+    for n in sameIpNodes:
+      check table.addNode(n) == Added
+
+    # Add a node with same ip to this fresh bucket, should fail because of total
+    # ip limit of routing table is reached.
+    let anotherSameIpNode = node.nodeAtDistance(rng[], 256 - amount)
+    check table.addNode(anotherSameIpNode) == IpLimitReached
+
+  test "Ip limits on replacement cache":
+    let node = generateNode(PrivateKey.random(rng[]))
+    var table: RoutingTable
+
+    table.init(node, 1, DefaultTableIpLimits, rng = rng)
+
+    let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256,
+      int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit + 1),
+      ValidIpAddress.init("192.168.0.1"))
+    for n in diffIpNodes:
+      check table.addNode(n) == Added
+
+    let sameIpNodes = node.nodesAtDistance(rng[], 256,
+      int(DefaultTableIpLimits.bucketIpLimit - 1))
+    for n in sameIpNodes:
+      check table.addNode(n) == Added
+
+    let anotherSameIpNode1 = node.nodeAtDistance(rng[], 256)
+    check table.addNode(anotherSameIpNode1) == ReplacementAdded
+
+    let anotherSameIpNode2 = node.nodeAtDistance(rng[], 256)
+    check table.addNode(anotherSameIpNode2) == IpLimitReached
+
+    block: # Replace node to see if the first one becomes available
+      table.replaceNode(table.nodeToRevalidate())
+      let res = table.getNode(anotherSameIpNode1.id)
+      check:
+        res.isSome()
+        res.get() == anotherSameIpNode1
+
+        table.getNode(anotherSameIpNode2.id).isNone()
+
+    block: # Replace again to see if the first one never becomes available
+      table.replaceNode(table.nodeToRevalidate())
+      check:
+        table.getNode(anotherSameIpNode1.id).isNone()
+        table.getNode(anotherSameIpNode2.id).isNone()
+
+  test "Ip limits on replacement cache: deletion":
+    let node = generateNode(PrivateKey.random(rng[]))
+    var table: RoutingTable
+
+    table.init(node, 1, DefaultTableIpLimits, rng = rng)
+
+    block: # Fill bucket
+      let sameIpNodes = node.nodesAtDistance(rng[], 256,
+        int(DefaultTableIpLimits.bucketIpLimit - 1))
+      for n in sameIpNodes:
+        check table.addNode(n) == Added
+
+      let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256,
+        int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit + 1),
+        ValidIpAddress.init("192.168.0.1"))
+      for n in diffIpNodes:
+        check table.addNode(n) == Added
+
+    block: # Fill bucket replacement cache
+      let sameIpNode = node.nodeAtDistance(rng[], 256)
+      check table.addNode(sameIpNode) == ReplacementAdded
+
+      let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256,
+        int(REPLACEMENT_CACHE_SIZE - 1),
+        ValidIpAddress.init("192.168.1.1"))
+      for n in diffIpNodes:
+        check table.addNode(n) == ReplacementAdded
+
+    # Try to add node to replacement, but limit is reached
+    let sameIpNode = node.nodeAtDistance(rng[], 256)
+    check table.addNode(sameIpNode) == IpLimitReached
+
+    # Add one with different ip, to remove the first
+    let diffIpNode = node.nodeAtDistance(rng[], 256,
+      ValidIpAddress.init("192.168.2.1"))
+    check table.addNode(diffIpNode) == ReplacementAdded
+
+    # Now the add should work
+    check table.addNode(sameIpNode) == ReplacementAdded


### PR DESCRIPTION
Attempt on https://github.com/status-im/nim-eth/issues/269. 
This turned out to be more cumbersome than expected. A lot of corner cases and issues possible due to wrong ordering of checks because of replacement cache, bucket splitting and then also the fact that a newer version of ENR with different ip address is possible. Added tests for all those cases but it still feels rather flaky (could be improved still though).

To make things worse, while creating this PR I realized that the current approach might actually introduce another issue. That is, a malicious peer could temporary make a bucket or the routing table hit an ip limit by responding with records with ip-addresses it doesn't own/control. Causing a node that does own the ip address not to be allowed to be added, until those others are evicted when they can't be verified at revalidation.

So looks like the ip limit checks should probably only be applied when setting a node to verified (currently named "seen"). Either that or we need to verify nodes immediately before adding. But this is typically not recommended (e.g. at least not by original Kademlia paper) as it could/would introduce another DoS vector.

This would require some additional changes, such as only using verified nodes, else the ip limits have not much use. But that is probably a good change (security wise). It will delay the amount of discovered nodes though.

I'll rethink this and keep the PR in draft for now. Input welcome of course.

