### PR TITLE
Add support for array[N, byte] in SQLite queries

### DIFF
--- a/eth/db/kvstore_sqlite3.nim
+++ b/eth/db/kvstore_sqlite3.nim
@@ -137,7 +137,7 @@ template readResult(s: RawStmtPtr, column: cint, T: type): auto =
     res
   elif T is array:
     # array[N, byte]. "genericParams(T)[1]" requires 1.4 to handle nnkTypeOfExpr
-    when typeof(block: (var a: T; a[0])) is byte:
+    when typeof(default(T)[0]) is byte:
       var res: T
       let colLen = sqlite3_column_bytes(s, column)
 


### PR DESCRIPTION
This adds `array[N, byte]` support.
This is a prerequisite to properly use ETH2Digest with multi-columns inserts or selects with Nim 1.2 for slashing protection.
The existing code should theoretically work on Nim 1.4 without the PR's workarounds.

Also strangely it seems like at compile time `when false and foo()` does not shortcut and will evaluate `foo()` causing issues with `when val is array and val.items.typeof is byte:` conditionals if val does not have an `items` iterator defined (for example int64).

### Issues solved
#### Insert
- Matching tuple[int, openarray[byte]] and tuple[int, array[32, byte]] for insert queries
  error:
```
Error: type mismatch: got <SqliteStmt[tuple of (ValidatorInternalID, int64, openArray[byte]), system.void], tuple of (ValidatorInternalID, int64, array[0..31, byte])>
but expected one of: 
proc exec[P](s: SqliteStmt[P, void]; params: P): KvResult[void]
  first type mismatch at position: 2
  required type for params: P
  but expression '(valID, int64(slot), block_root.data)' is of type: tuple of (ValidatorInternalID, int64, array[0..31, byte])
```
- Explicit forcing with toOpenArray will fail with `Error: invalid context for 'toOpenArray'; 'toOpenArray' is only valid within a call expression`

Example
```Nim
    let insertStmt = db.prepareStmt("""
      INSERT INTO attestations(
        validator_id,
        source_epoch,
        target_epoch,
        attestation_root)
      VALUES
        (?,?,?,?);
    """, (int32, int64, int64, array[32, byte]), void).get()
```

#### Select

Returning a single openarray works fine but returning a tuple containing an openarray doesn't.

Example
```Nim
    let selectRangeStmt = db.prepareStmt("""
      SELECT
        source_epoch,
        target_epoch,
        attestation_root
      FROM
        attestations
      WHERE
        validator_id = ?
        AND
        ? < source_epoch AND target_epoch < ?
      LIMIT 1
      """, (int32, int64, int64), (int64, int64, array[32, byte])).get()
```

#### Upstream

This should have been added in Nim 1.4 following RFC https://github.com/nim-lang/RFCs/issues/178  with `--experimental:view`

Also Nim 1.4 related, the typetraits procedure genericParams to extract `byte` from `array[N, byte]` doesn't work with typedesc returned from `typeof` in Nim 1.2 hence requiring a clunky workaround.