### PR TITLE
Fix import syntax error in `les_protocol.nim` added by PR #344

### DIFF
--- a/eth/p2p/rlpx_protocols/les_protocol.nim
+++ b/eth/p2p/rlpx_protocols/les_protocol.nim
@@ -11,8 +11,8 @@
 import
   std/[times, tables, options, sets, hashes, strutils],
   stew/shims/macros, chronicles, chronos, nimcrypto/[keccak, hash],
-  ../../[rlp, keys], ../../common/eth_types,
-  ../[rlpx, kademlia, blockchain_utils], ../private/p2p_types,
+  ".."/../[rlp, keys], ../../common/eth_types,
+  ".."/[rlpx, kademlia, blockchain_utils], ../private/p2p_types,
   ./les/private/les_types, ./les/flow_control
 
 export


### PR DESCRIPTION
`les_protocol.nim` failed to build, due to very silly Nim bugs https://github.com/nim-lang/Nim/issues/8792 and https://github.com/nim-lang/Nim/issues/17102.

    import
      ../../[rlp, keys], ../../common/eth_types,
      ../[rlpx, kademlia, blockchain_utils], ../private/p2p_types,

The silly part is `../` has to be quoted if it's before a group of files, but
not before a single file.  Most places in PR #344 / 7624153 use the workaround `".."/`
but it was missed in `les_protocol.nim`:

    nimbus-eth1/vendor/nim-eth/eth/p2p/rlpx_protocols/les_protocol.nim(14, 3)
        Error: cannot open file: ../../[rlp,keys]