### PR TITLE
Adjust for chronosStrictException usage in rest of eth/p2p

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -44,21 +44,10 @@ task test_discv5, "Run discovery v5 tests":
   runTest("tests/p2p/all_discv5_tests")
 
 task test_discv4, "Run discovery v4 tests":
-  runTest("tests/p2p/test_discovery", chronosStrict = false)
+  runTest("tests/p2p/test_discovery")
 
 task test_p2p, "Run p2p tests":
   runTest("tests/p2p/all_tests")
-
-  # Code that still requires chronosStrict = false
-  for filename in [
-      "les/test_flow_control",
-      "test_rlpx_thunk",
-      "test_shh",
-      "test_shh_config",
-      "test_shh_connect",
-      "test_protocol_handlers"
-    ]:
-    runTest("tests/p2p/" & filename, chronosStrict = false)
 
 task test_rlp, "Run rlp tests":
   # workaround for github action CI

--- a/eth/common/eth_types.nim
+++ b/eth/common/eth_types.nim
@@ -373,7 +373,7 @@ method genesisHash*(db: AbstractChainDB): KeccakHash
   notImplemented()
 
 method getBlockHeader*(db: AbstractChainDB, b: HashOrNum,
-    output: var BlockHeader): bool {.base, gcsafe, raises: [Defect].} =
+    output: var BlockHeader): bool {.base, gcsafe, raises: [CatchableError, Defect].} =
   notImplemented()
 
 proc getBlockHeader*(db: AbstractChainDB, hash: KeccakHash): BlockHeaderRef {.gcsafe.} =
@@ -387,17 +387,17 @@ proc getBlockHeader*(db: AbstractChainDB, b: BlockNumber): BlockHeaderRef {.gcsa
     return nil
 
 method getBestBlockHeader*(self: AbstractChainDB): BlockHeader
-    {.base, gcsafe, raises: [Defect].} =
+    {.base, gcsafe, raises: [CatchableError, Defect].} =
   notImplemented()
 
 method getSuccessorHeader*(db: AbstractChainDB, h: BlockHeader,
     output: var BlockHeader, skip = 0'u): bool
-    {.base, gcsafe, raises: [Defect].} =
+    {.base, gcsafe, raises: [CatchableError, Defect].} =
   notImplemented()
 
 method getAncestorHeader*(db: AbstractChainDB, h: BlockHeader,
     output: var BlockHeader, skip = 0'u): bool
-    {.base, gcsafe, raises: [Defect].} =
+    {.base, gcsafe, raises: [CatchableError, Defect].} =
   notImplemented()
 
 method getBlockBody*(db: AbstractChainDB, blockHash: KeccakHash): BlockBodyRef

--- a/eth/common/eth_types.nim
+++ b/eth/common/eth_types.nim
@@ -368,10 +368,12 @@ template deref*(b: Blob): auto = b
 template deref*(o: Option): auto = o.get
 template deref*(r: EthResourceRefs): auto = r[]
 
-method genesisHash*(db: AbstractChainDB): KeccakHash {.base, gcsafe.} =
+method genesisHash*(db: AbstractChainDB): KeccakHash
+    {.base, gcsafe, raises: [Defect].} =
   notImplemented()
 
-method getBlockHeader*(db: AbstractChainDB, b: HashOrNum, output: var BlockHeader): bool {.base, gcsafe.} =
+method getBlockHeader*(db: AbstractChainDB, b: HashOrNum,
+    output: var BlockHeader): bool {.base, gcsafe, raises: [Defect].} =
   notImplemented()
 
 proc getBlockHeader*(db: AbstractChainDB, hash: KeccakHash): BlockHeaderRef {.gcsafe.} =
@@ -384,22 +386,29 @@ proc getBlockHeader*(db: AbstractChainDB, b: BlockNumber): BlockHeaderRef {.gcsa
   if not db.getBlockHeader(HashOrNum(isHash: false, number: b), result[]):
     return nil
 
-method getBestBlockHeader*(self: AbstractChainDB): BlockHeader {.base, gcsafe.} =
+method getBestBlockHeader*(self: AbstractChainDB): BlockHeader
+    {.base, gcsafe, raises: [Defect].} =
   notImplemented()
 
-method getSuccessorHeader*(db: AbstractChainDB, h: BlockHeader, output: var BlockHeader, skip = 0'u): bool {.base, gcsafe.} =
+method getSuccessorHeader*(db: AbstractChainDB, h: BlockHeader,
+    output: var BlockHeader, skip = 0'u): bool
+    {.base, gcsafe, raises: [Defect].} =
   notImplemented()
 
-method getAncestorHeader*(db: AbstractChainDB, h: BlockHeader, output: var BlockHeader, skip = 0'u): bool {.base, gcsafe.} =
+method getAncestorHeader*(db: AbstractChainDB, h: BlockHeader,
+    output: var BlockHeader, skip = 0'u): bool
+    {.base, gcsafe, raises: [Defect].} =
   notImplemented()
 
-method getBlockBody*(db: AbstractChainDB, blockHash: KeccakHash): BlockBodyRef {.base, gcsafe.} =
+method getBlockBody*(db: AbstractChainDB, blockHash: KeccakHash): BlockBodyRef
+    {.base, gcsafe, raises: [Defect].} =
   notImplemented()
 
 method getReceipt*(db: AbstractChainDB, hash: KeccakHash): ReceiptRef {.base, gcsafe.} =
   notImplemented()
 
-method getTrieDB*(db: AbstractChainDB): TrieDatabaseRef {.base, gcsafe.} =
+method getTrieDB*(db: AbstractChainDB): TrieDatabaseRef
+    {.base, gcsafe, raises: [Defect].} =
   notImplemented()
 
 method getCodeByHash*(db: AbstractChainDB, hash: KeccakHash): Blob {.base, gcsafe.} =

--- a/eth/common/state_accessors.nim
+++ b/eth/common/state_accessors.nim
@@ -18,6 +18,7 @@ proc getContractCode*(chain: AbstractChainDB, req: ContractCodeRequest): Blob {.
     let acc = getAccount(chain.getTrieDB, b.stateRoot, req.key)
     result = chain.getCodeByHash(acc.codeHash)
 
-proc getStorageNode*(chain: AbstractChainDB, hash: KeccakHash): Blob =
+proc getStorageNode*(chain: AbstractChainDB, hash: KeccakHash): Blob
+    {.raises: [CatchableError, Defect].} =
   let db = chain.getTrieDB
   return db.get(hash.data)

--- a/eth/p2p.nim
+++ b/eth/p2p.nim
@@ -1,12 +1,9 @@
-#
-#                 Ethereum P2P
-#              (c) Copyright 2018
-#       Status Research & Development GmbH
-#
-#            Licensed under either of
-#  Apache License, version 2.0, (LICENSE-APACHEv2)
-#            MIT license (LICENSE-MIT)
-#
+# nim-eth
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
   std/[tables, algorithm, random],

--- a/eth/p2p.nim
+++ b/eth/p2p.nim
@@ -17,7 +17,8 @@ import
 export
   p2p_types, rlpx, enode, kademlia
 
-proc addCapability*(node: var EthereumNode, p: ProtocolInfo) =
+proc addCapability*(node: var EthereumNode, p: ProtocolInfo)
+    {.raises: [Defect].} =
   doAssert node.connectionState == ConnectionState.None
 
   let pos = lowerBound(node.protocols, p, rlpx.cmp)
@@ -38,10 +39,10 @@ proc newEthereumNode*(keys: KeyPair,
                       addAllCapabilities = true,
                       useCompression: bool = false,
                       minPeers = 10,
-                      rng = newRng()): EthereumNode =
+                      rng = newRng()): EthereumNode {.raises: [Defect].} =
 
   if rng == nil: # newRng could fail
-    raise (ref CatchableError)(msg: "Cannot initialize RNG")
+    raise (ref Defect)(msg: "Cannot initialize RNG")
 
   new result
   result.keys = keys

--- a/eth/p2p/blockchain_sync.nim
+++ b/eth/p2p/blockchain_sync.nim
@@ -1,3 +1,10 @@
+# nim-eth
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   std/[sets, options, random, hashes],
   chronos, chronicles,

--- a/eth/p2p/blockchain_sync.nim
+++ b/eth/p2p/blockchain_sync.nim
@@ -43,7 +43,7 @@ type
     trustedPeers: HashSet[Peer]
     hasOutOfOrderBlocks: bool
 
-proc hash*(p: Peer): Hash {.inline.} = hash(cast[pointer](p))
+proc hash*(p: Peer): Hash = hash(cast[pointer](p))
 
 proc endIndex(b: WantedBlocks): BlockNumber =
   result = b.startIndex

--- a/eth/p2p/blockchain_utils.nim
+++ b/eth/p2p/blockchain_utils.nim
@@ -1,3 +1,10 @@
+# nim-eth
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   eth/common/[eth_types, state_accessors]
 

--- a/eth/p2p/blockchain_utils.nim
+++ b/eth/p2p/blockchain_utils.nim
@@ -4,7 +4,7 @@ import
 # TODO: Perhaps we can move this to eth-common
 
 proc getBlockHeaders*(db: AbstractChainDB, req: BlocksRequest): seq[BlockHeader]
-    {.gcsafe, raises: [Defect].} =
+    {.gcsafe, raises: [CatchableError, Defect].} =
   result = newSeqOfCap[BlockHeader](req.maxResults)
 
   var foundBlock: BlockHeader

--- a/eth/p2p/blockchain_utils.nim
+++ b/eth/p2p/blockchain_utils.nim
@@ -3,8 +3,8 @@ import
 
 # TODO: Perhaps we can move this to eth-common
 
-proc getBlockHeaders*(db: AbstractChainDB,
-                      req: BlocksRequest): seq[BlockHeader] {.gcsafe.} =
+proc getBlockHeaders*(db: AbstractChainDB, req: BlocksRequest): seq[BlockHeader]
+    {.gcsafe, raises: [Defect].} =
   result = newSeqOfCap[BlockHeader](req.maxResults)
 
   var foundBlock: BlockHeader

--- a/eth/p2p/discoveryv5/encoding.nim
+++ b/eth/p2p/discoveryv5/encoding.nim
@@ -379,7 +379,7 @@ proc decodeMessage*(body: openarray[byte]): DecodeResult[Message] =
       return err("Invalid request-id")
 
     proc decode[T](rlp: var Rlp, v: var T)
-        {.inline, nimcall, raises:[RlpError, ValueError, Defect].} =
+        {.nimcall, raises:[RlpError, ValueError, Defect].} =
       for k, v in v.fieldPairs:
         v = rlp.read(typeof(v))
 

--- a/eth/p2p/discoveryv5/enr.nim
+++ b/eth/p2p/discoveryv5/enr.nim
@@ -468,7 +468,7 @@ proc `$`*(r: Record): string =
 proc `==`*(a, b: Record): bool = a.raw == b.raw
 
 proc read*(rlp: var Rlp, T: typedesc[Record]):
-    T {.inline, raises:[RlpError, ValueError, Defect].} =
+    T {.raises: [RlpError, ValueError, Defect].} =
   if not rlp.hasData() or not result.fromBytes(rlp.rawData):
     # TODO: This could also just be an invalid signature, would be cleaner to
     # split of RLP deserialisation errors from this.

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -193,7 +193,7 @@ proc neighbours*(d: Protocol, id: NodeId, k: int = BUCKET_SIZE): seq[Node] =
   ## Return up to k neighbours (closest node ids) of the given node id.
   d.routingTable.neighbours(id, k)
 
-proc nodesDiscovered*(d: Protocol): int {.inline.} = d.routingTable.len
+proc nodesDiscovered*(d: Protocol): int = d.routingTable.len
 
 func privKey*(d: Protocol): lent PrivateKey =
   d.privateKey

--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -132,8 +132,8 @@ proc distanceTo(k: KBucket, id: NodeId): UInt256 = k.midpoint xor id
 proc nodesByDistanceTo(k: KBucket, id: NodeId): seq[Node] =
   sortedByIt(k.nodes, it.distanceTo(id))
 
-proc len(k: KBucket): int {.inline.} = k.nodes.len
-proc tail(k: KBucket): Node {.inline.} = k.nodes[high(k.nodes)]
+proc len(k: KBucket): int = k.nodes.len
+proc tail(k: KBucket): Node = k.nodes[high(k.nodes)]
 
 proc ipLimitInc(r: var RoutingTable, b: KBucket, n: Node): bool =
   ## Check if the ip limits of the routing table and the bucket are reached for
@@ -194,7 +194,7 @@ proc split(k: KBucket): tuple[lower, upper: KBucket] =
     doAssert(bucket.ipLimits.inc(node.address.get().ip),
       "IpLimit increment should work as all buckets have the same limits")
 
-proc inRange(k: KBucket, n: Node): bool {.inline.} =
+proc inRange(k: KBucket, n: Node): bool =
   k.istart <= n.id and n.id <= k.iend
 
 proc contains(k: KBucket, n: Node): bool = n in k.nodes
@@ -234,7 +234,7 @@ proc computeSharedPrefixBits(nodes: openarray[NodeId]): int =
   doAssert(false, "Unable to calculate number of shared prefix bits")
 
 proc init*(r: var RoutingTable, thisNode: Node, bitsPerHop = DefaultBitsPerHop,
-    ipLimits = DefaultTableIpLimits, rng: ref BrHmacDrbgContext) {.inline.} =
+    ipLimits = DefaultTableIpLimits, rng: ref BrHmacDrbgContext) =
   ## Initialize the routing table for provided `Node` and bitsPerHop value.
   ## `bitsPerHop` is default set to 5 as recommended by original Kademlia paper.
   r.thisNode = thisNode

--- a/eth/p2p/p2p_backends_helpers.nim
+++ b/eth/p2p/p2p_backends_helpers.nim
@@ -28,9 +28,12 @@ template networkState*(connection: Peer, Protocol: type): untyped =
   ## particular connection.
   protocolState(connection.network, Protocol)
 
-proc initProtocolState*[T](state: T, x: Peer|EthereumNode) {.gcsafe.} = discard
+proc initProtocolState*[T](state: T, x: Peer|EthereumNode)
+    {.gcsafe, raises: [Defect].} =
+  discard
 
-proc initProtocolStates(peer: Peer, protocols: openarray[ProtocolInfo]) =
+proc initProtocolStates(peer: Peer, protocols: openarray[ProtocolInfo])
+    {.raises: [Defect].} =
   # Initialize all the active protocol states
   newSeq(peer.protocolStates, allProtocols.len)
   for protocol in protocols:

--- a/eth/p2p/peer_pool.nim
+++ b/eth/p2p/peer_pool.nim
@@ -108,7 +108,7 @@ proc getRandomBootnode(p: PeerPool): Option[Node] =
   if p.discovery.bootstrapNodes.len != 0:
     result = option(p.discovery.bootstrapNodes.sample())
 
-proc addPeer*(pool: PeerPool, peer: Peer) {.gcsafe.} =
+proc addPeer*(pool: PeerPool, peer: Peer) {.gcsafe, raises: [Defect].} =
   doAssert(peer.remote notin pool.connectedNodes)
   pool.connectedNodes[peer.remote] = peer
   connected_peers.inc()

--- a/eth/p2p/peer_pool.nim
+++ b/eth/p2p/peer_pool.nim
@@ -1,3 +1,10 @@
+# nim-eth
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 # PeerPool attempts to keep connections to at least min_peers
 # on the given network.
 

--- a/eth/p2p/peer_pool.nim
+++ b/eth/p2p/peer_pool.nim
@@ -33,7 +33,7 @@ proc newPeerPool*(network: EthereumNode,
   result.observers = initTable[int, PeerObserver]()
   result.listenPort = listenPort
 
-proc nodesToConnect(p: PeerPool): seq[Node] {.inline.} =
+proc nodesToConnect(p: PeerPool): seq[Node] =
   p.discovery.randomNodes(p.minPeers).filterIt(it notin p.discovery.bootstrapNodes)
 
 proc addObserver(p: PeerPool, observerId: int, observer: PeerObserver) =
@@ -47,10 +47,10 @@ proc addObserver(p: PeerPool, observerId: int, observer: PeerObserver) =
 proc delObserver(p: PeerPool, observerId: int) =
   p.observers.del(observerId)
 
-proc addObserver*(p: PeerPool, observerId: ref, observer: PeerObserver) {.inline.} =
+proc addObserver*(p: PeerPool, observerId: ref, observer: PeerObserver) =
   p.addObserver(cast[int](observerId), observer)
 
-proc delObserver*(p: PeerPool, observerId: ref) {.inline.} =
+proc delObserver*(p: PeerPool, observerId: ref) =
   p.delObserver(cast[int](observerId))
 
 template setProtocol*(observer: PeerObserver, Protocol: type) =

--- a/eth/p2p/private/p2p_types.nim
+++ b/eth/p2p/private/p2p_types.nim
@@ -140,7 +140,8 @@ type
   MessageHandlerDecorator* = proc(msgId: int, n: NimNode): NimNode
   ThunkProc* = proc(x: Peer, msgId: int, data: Rlp): Future[void]
     {.gcsafe, raises: [RlpError, Defect].}
-  MessageContentPrinter* = proc(msg: pointer): string {.gcsafe.}
+  MessageContentPrinter* = proc(msg: pointer): string
+    {.gcsafe, raises: [Defect].}
   RequestResolver* = proc(msg: pointer, future: FutureBase)
     {.gcsafe, raises: [Defect].}
   NextMsgResolver* = proc(msgData: Rlp, future: FutureBase)

--- a/eth/p2p/private/p2p_types.nim
+++ b/eth/p2p/private/p2p_types.nim
@@ -61,8 +61,8 @@ type
     observers*: Table[int, PeerObserver]
 
   PeerObserver* = object
-    onPeerConnected*: proc(p: Peer) {.gcsafe.}
-    onPeerDisconnected*: proc(p: Peer) {.gcsafe.}
+    onPeerConnected*: proc(p: Peer) {.gcsafe, raises: [Defect].}
+    onPeerDisconnected*: proc(p: Peer) {.gcsafe, raises: [Defect].}
     protocol*: ProtocolInfo
 
   Capability* = object
@@ -138,16 +138,19 @@ type
 
   # Private types:
   MessageHandlerDecorator* = proc(msgId: int, n: NimNode): NimNode
-  ThunkProc* = proc(x: Peer, msgId: int, data: Rlp): Future[void] {.gcsafe.}
+  ThunkProc* = proc(x: Peer, msgId: int, data: Rlp): Future[void]
+    {.gcsafe, raises: [RlpError, Defect].}
   MessageContentPrinter* = proc(msg: pointer): string {.gcsafe.}
   RequestResolver* = proc(msg: pointer, future: FutureBase)
-    {.gcsafe, raises:[Defect].}
-  NextMsgResolver* = proc(msgData: Rlp, future: FutureBase) {.gcsafe.}
-  PeerStateInitializer* = proc(peer: Peer): RootRef {.gcsafe.}
-  NetworkStateInitializer* = proc(network: EthereumNode): RootRef {.gcsafe.}
-  HandshakeStep* = proc(peer: Peer): Future[void] {.gcsafe.}
+    {.gcsafe, raises: [Defect].}
+  NextMsgResolver* = proc(msgData: Rlp, future: FutureBase)
+    {.gcsafe, raises: [RlpError, Defect].}
+  PeerStateInitializer* = proc(peer: Peer): RootRef {.gcsafe, raises: [Defect].}
+  NetworkStateInitializer* = proc(network: EthereumNode): RootRef
+    {.gcsafe, raises: [Defect].}
+  HandshakeStep* = proc(peer: Peer): Future[void] {.gcsafe, raises: [Defect].}
   DisconnectionHandler* = proc(peer: Peer, reason: DisconnectionReason):
-    Future[void] {.gcsafe.}
+    Future[void] {.gcsafe, raises: [Defect].}
 
   ConnectionState* = enum
     None,

--- a/eth/p2p/private/p2p_types.nim
+++ b/eth/p2p/private/p2p_types.nim
@@ -1,3 +1,10 @@
+# nim-eth
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   std/[deques, tables],
   bearssl, chronos,

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -1,3 +1,10 @@
+# nim-eth
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   std/[tables, algorithm, deques, hashes, options, typetraits],
   stew/shims/macros, chronicles, nimcrypto, chronos,

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -255,8 +255,6 @@ func nameStr*(p: ProtocolInfo): string =
   result = newStringOfCap(3)
   for c in p.name: result.add(c)
 
-# XXX: this used to be inline, but inline procs
-# cannot be passed to closure params
 proc cmp*(lhs, rhs: ProtocolInfo): int =
   for i in 0..2:
     if lhs.name[i] != rhs.name[i]:
@@ -297,7 +295,7 @@ proc registerProtocol(protocol: ProtocolInfo) =
 # Message composition and encryption
 #
 
-proc perPeerMsgIdImpl(peer: Peer, proto: ProtocolInfo, msgId: int): int {.inline.} =
+proc perPeerMsgIdImpl(peer: Peer, proto: ProtocolInfo, msgId: int): int =
   result = msgId
   if not peer.dispatcher.isNil:
     result += peer.dispatcher.protocolOffsets[proto.index]
@@ -306,10 +304,10 @@ template getPeer(peer: Peer): auto = peer
 template getPeer(responder: ResponderWithId): auto = responder.peer
 template getPeer(responder: ResponderWithoutId): auto = Peer(responder)
 
-proc supports*(peer: Peer, proto: ProtocolInfo): bool {.inline.} =
+proc supports*(peer: Peer, proto: ProtocolInfo): bool =
   peer.dispatcher.protocolOffsets[proto.index] != -1
 
-proc supports*(peer: Peer, Protocol: type): bool {.inline.} =
+proc supports*(peer: Peer, Protocol: type): bool =
   ## Checks whether a Peer supports a particular protocol
   peer.supports(Protocol.protocolInfo)
 
@@ -514,7 +512,7 @@ proc recvMsg*(peer: Peer): Future[tuple[msgId: int, msgData: Rlp]] {.async.} =
     await peer.disconnectAndRaise(BreachOfProtocol,
                                   "Cannot read RLPx message id")
 
-proc checkedRlpRead(peer: Peer, r: var Rlp, MsgType: type): auto {.inline.} =
+proc checkedRlpRead(peer: Peer, r: var Rlp, MsgType: type): auto =
   when defined(release):
     return r.read(MsgType)
   else:
@@ -947,7 +945,7 @@ proc validatePubKeyInHello(msg: DevP2P.hello, pubKey: PublicKey): bool =
   let pk = PublicKey.fromRaw(msg.nodeId)
   pk.isOk and pk[] == pubKey
 
-proc checkUselessPeer(peer: Peer) {.inline.} =
+proc checkUselessPeer(peer: Peer) =
   if peer.dispatcher.numProtocols == 0:
     # XXX: Send disconnect + UselessPeer
     raise newException(UselessPeerError, "Useless peer")

--- a/eth/p2p/rlpx_protocols/les/flow_control.nim
+++ b/eth/p2p/rlpx_protocols/les/flow_control.nim
@@ -316,7 +316,7 @@ proc acceptRequest*(network: LesNetwork, peer: LesPeer,
   network.updateFlowControl t
 
   while not network.canServeRequest:
-    await sleepAsync(10)
+    await sleepAsync(10.milliseconds)
 
   if peer notin network.peers:
     # The peer was disconnected or the network

--- a/eth/p2p/rlpx_protocols/whisper/whisper_types.nim
+++ b/eth/p2p/rlpx_protocols/whisper/whisper_types.nim
@@ -1,12 +1,9 @@
-#
-#                 Whisper
-#              (c) Copyright 2018-2019
-#       Status Research & Development GmbH
-#
-#            Licensed under either of
-#  Apache License, version 2.0, (LICENSE-APACHEv2)
-#            MIT license (LICENSE-MIT)
-#
+# nim-eth - Whisper
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
   std/[algorithm, bitops, math, options, tables, times, hashes],

--- a/eth/p2p/rlpx_protocols/whisper/whisper_types.nim
+++ b/eth/p2p/rlpx_protocols/whisper/whisper_types.nim
@@ -9,10 +9,13 @@
 #
 
 import
-  std/[algorithm, bitops, math, options, tables, times, strutils, hashes],
+  std/[algorithm, bitops, math, options, tables, times, hashes],
   chronicles, stew/[byteutils, endians2], metrics, bearssl,
   nimcrypto/[bcmode, hash, keccak, rijndael],
   ".."/../../[keys, rlp, p2p], ../../ecies
+
+when chronicles.enabledLogLevel == LogLevel.TRACE:
+  import std/strutils
 
 logScope:
   topics = "whisper_types"

--- a/eth/p2p/rlpx_protocols/whisper_protocol.nim
+++ b/eth/p2p/rlpx_protocols/whisper_protocol.nim
@@ -1,12 +1,9 @@
-#
-#                 Whisper
-#              (c) Copyright 2018-2019
-#       Status Research & Development GmbH
-#
-#            Licensed under either of
-#  Apache License, version 2.0, (LICENSE-APACHEv2)
-#            MIT license (LICENSE-MIT)
-#
+# nim-eth - Whisper
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 ## Whisper
 ## *******

--- a/tests/p2p/all_tests.nim
+++ b/tests/p2p/all_tests.nim
@@ -4,4 +4,10 @@ import
   ./test_crypt,
   ./test_discovery,
   ./test_ecies,
-  ./test_enode
+  ./test_enode,
+  ./test_rlpx_thunk,
+  ./test_shh,
+  ./test_shh_config,
+  ./test_shh_connect,
+  ./test_protocol_handlers,
+  ./les/test_flow_control

--- a/tests/p2p/all_tests.nim
+++ b/tests/p2p/all_tests.nim
@@ -11,3 +11,4 @@ import
   ./test_shh_connect,
   ./test_protocol_handlers,
   ./les/test_flow_control
+  

--- a/tests/p2p/les/test_flow_control.nim
+++ b/tests/p2p/les/test_flow_control.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import
   ../../../eth/p2p/rlpx_protocols/les/flow_control
 

--- a/tests/p2p/p2p_test_helper.nim
+++ b/tests/p2p/p2p_test_helper.nim
@@ -1,6 +1,6 @@
 import
-  std/[unittest, strutils],
-  chronos, nimcrypto, bearssl,
+  std/strutils,
+  chronos, bearssl,
   ../../eth/[keys, p2p], ../../eth/p2p/[discovery, enode]
 
 var nextPort = 30303

--- a/tests/p2p/test_protocol_handlers.nim
+++ b/tests/p2p/test_protocol_handlers.nim
@@ -7,6 +7,8 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #            MIT license (LICENSE-MIT)
 
+{.used.}
+
 import
   std/tables,
   chronos, testutils/unittests,

--- a/tests/p2p/test_rlpx_thunk.nim
+++ b/tests/p2p/test_rlpx_thunk.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import
   std/[json, os, unittest],
   chronos, stew/byteutils,

--- a/tests/p2p/test_shh.nim
+++ b/tests/p2p/test_shh.nim
@@ -7,6 +7,8 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #            MIT license (LICENSE-MIT)
 
+{.used.}
+
 import
   std/[sequtils, options, unittest, tables],
   nimcrypto/hash,

--- a/tests/p2p/test_shh_config.nim
+++ b/tests/p2p/test_shh_config.nim
@@ -7,6 +7,8 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #            MIT license (LICENSE-MIT)
 
+{.used.}
+
 import
   std/[sequtils, options, unittest, times],
   ../../eth/p2p/rlpx_protocols/whisper_protocol as whisper

--- a/tests/p2p/test_shh_connect.nim
+++ b/tests/p2p/test_shh_connect.nim
@@ -7,6 +7,8 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #            MIT license (LICENSE-MIT)
 
+{.used.}
+
 import
   std/[sequtils, options, tables],
   chronos, testutils/unittests, bearssl,


### PR DESCRIPTION
More `raises` work to get `chronosStrictException` fully in nim-eth.

And additional clean-up