### PR TITLE
kvstore fixes

### DIFF
--- a/eth/db/kvstore.nim
+++ b/eth/db/kvstore.nim
@@ -26,9 +26,11 @@ type
   KvResult*[T] = Result[T, string]
 
   DataProc* = proc(val: openArray[byte]) {.gcsafe, raises: [Defect].}
+  KeyValueProc* = proc(key, val: openArray[byte]) {.gcsafe, raises: [Defect].}
 
   PutProc = proc (db: RootRef, key, val: openArray[byte]): KvResult[void] {.nimcall, gcsafe, raises: [Defect].}
   GetProc = proc (db: RootRef, key: openArray[byte], onData: DataProc): KvResult[bool] {.nimcall, gcsafe, raises: [Defect].}
+  FindProc = proc (db: RootRef, prefix: openArray[byte], onFind: KeyValueProc): KvResult[int] {.nimcall, gcsafe, raises: [Defect].}
   DelProc = proc (db: RootRef, key: openArray[byte]): KvResult[void] {.nimcall, gcsafe, raises: [Defect].}
   ContainsProc = proc (db: RootRef, key: openArray[byte]): KvResult[bool] {.nimcall, gcsafe, raises: [Defect].}
   CloseProc = proc (db: RootRef): KvResult[void] {.nimcall, gcsafe, raises: [Defect].}
@@ -38,6 +40,7 @@ type
     obj: RootRef
     putProc: PutProc
     getProc: GetProc
+    findProc: FindProc
     delProc: DelProc
     containsProc: ContainsProc
     closeProc: CloseProc
@@ -54,6 +57,16 @@ template get*(dbParam: KvStoreRef, key: openArray[byte], onData: untyped): KvRes
   ## returns true if found and false otherwise.
   let db = dbParam
   db.getProc(db.obj, key, onData)
+
+template find*(
+    dbParam: KvStoreRef, prefix: openArray[byte], onFind: untyped): KvResult[int] =
+  ## Perform a prefix find, returning all data starting with the given prefix.
+  ## An empty prefix returns all rows in the store.
+  ## The data is valid for the duration of the callback.
+  ## ``onFind``: ``proc(key, value: openArray[byte])``
+  ## returns the number of rows found
+  let db = dbParam
+  db.findProc(db.obj, prefix, onFind)
 
 template del*(dbParam: KvStoreRef, key: openArray[byte]): KvResult[void] =
   ## Remove value at ``key`` from store - do nothing if the value is not present
@@ -78,6 +91,10 @@ proc getImpl[T](db: RootRef, key: openArray[byte], onData: DataProc): KvResult[b
   mixin get
   get(T(db), key, onData)
 
+proc findImpl[T](db: RootRef, key: openArray[byte], onFind: KeyValueProc): KvResult[int] =
+  mixin get
+  find(T(db), key, onFind)
+
 proc delImpl[T](db: RootRef, key: openArray[byte]): KvResult[void] =
   mixin del
   del(T(db), key)
@@ -97,6 +114,7 @@ func kvStore*[T: RootRef](x: T): KvStoreRef =
     obj: x,
     putProc: putImpl[T],
     getProc: getImpl[T],
+    findProc: findImpl[T],
     delProc: delImpl[T],
     containsProc: containsImpl[T],
     closeProc: closeImpl[T]
@@ -108,6 +126,18 @@ proc get*(db: MemStoreRef, key: openArray[byte], onData: DataProc): KvResult[boo
     return ok(true)
 
   ok(false)
+
+proc find*(
+    db: MemStoreRef, prefix: openArray[byte],
+    onFind: KeyValueProc): KvResult[int] =
+  var total = 0
+  # Should use lower/upper bounds instead
+  for k, v in db.records:
+    if k.len() >= prefix.len and k.toOpenArray(0, prefix.len() - 1) == prefix:
+      onFind(k, v)
+      total += 1
+
+  ok(total)
 
 proc del*(db: MemStoreRef, key: openArray[byte]): KvResult[void] =
   db.records.del(@key)

--- a/eth/db/kvstore_rocksdb.nim
+++ b/eth/db/kvstore_rocksdb.nim
@@ -16,6 +16,9 @@ type
 proc get*(db: RocksStoreRef, key: openarray[byte], onData: kvstore.DataProc): KvResult[bool] =
   db.store.get(key, onData)
 
+proc find*(db: RocksStoreRef, prefix: openarray[byte], onFind: kvstore.KeyValueProc): KvResult[int] =
+  raiseAssert "Unimplemented"
+
 proc put*(db: RocksStoreRef, key, value: openarray[byte]): KvResult[void] =
   db.store.put(key, value)
 

--- a/tests/db/test_kvstore.nim
+++ b/tests/db/test_kvstore.nim
@@ -8,8 +8,9 @@ const
   key = [0'u8, 1, 2, 3]
   value = [3'u8, 2, 1, 0]
   value2 = [5'u8, 2, 1, 0]
+  key2 = [255'u8, 255]
 
-proc testKvStore*(db: KvStoreRef) =
+proc testKvStore*(db: KvStoreRef, supportsFind: bool) =
   check:
     db != nil
 
@@ -20,9 +21,12 @@ proc testKvStore*(db: KvStoreRef) =
 
   db.put(key, value)[]
 
-  var v: seq[byte]
+  var k, v: seq[byte]
   proc grab(data: openArray[byte]) =
     v = @data
+  proc grab2(key, value: openArray[byte]) =
+    k = @key
+    v = @value
 
   check:
     db.contains(key)[]
@@ -42,6 +46,27 @@ proc testKvStore*(db: KvStoreRef) =
 
   db.del(key)[] # does nothing
 
+  if supportsFind:
+    check:
+      db.find([], proc(key, value: openArray[byte]) = discard).get() == 0
+
+    db.put(key, value)[]
+
+    check:
+      db.find([], grab2).get() == 1
+      db.find(key, grab2).get() == 1
+      k == key
+      v == value
+
+    db.put(key2, value2)[]
+    check:
+      db.find([], grab2).get() == 2
+      db.find([byte 255], grab2).get() == 1
+      db.find([byte 255, 255], grab2).get() == 1
+      db.find([byte 255, 255, 0], grab2).get() == 0
+      db.find([byte 255, 255, 255], grab2).get() == 0
+      db.find([byte 255, 0], grab2).get() == 0
+
 suite "MemoryStoreRef":
   test "KvStore interface":
-    testKvStore(kvStore MemStoreRef.init())
+    testKvStore(kvStore MemStoreRef.init(), true)

--- a/tests/db/test_kvstore_rocksdb.nim
+++ b/tests/db/test_kvstore_rocksdb.nim
@@ -14,4 +14,4 @@ suite "RocksStoreRef":
     let db = RocksStoreRef.init(tmp, "test")[]
     defer: db.close()
 
-    testKvStore(kvStore db)
+    testKvStore(kvStore db, false)

--- a/tests/db/test_kvstore_sqlite3.nim
+++ b/tests/db/test_kvstore_sqlite3.nim
@@ -10,8 +10,10 @@ procSuite "SqStoreRef":
   test "KvStore interface":
     let db = SqStoreRef.init("", "test", inMemory = true)[]
     defer: db.close()
+    let kv = db.openKvStore()
+    defer: kv.get()[].close()
 
-    testKvStore(kvStore db)
+    testKvStore(kvStore kv.get(), true)
 
   test "Prepare and execute statements":
     let db = SqStoreRef.init("", "test", inMemory = true)[]


### PR DESCRIPTION
Storing large blobs in a "WITHOUT ROWID" table turns out to be extremely
slow when the tree must be rebalanced.

* Split out keystore capability into separate interface, making each
keystore a separate instance
* Disable "WITHOUT ROWID" optimization by default
* Implement prefix lookup that allows iterating over all values with a
certain prefix in their key