### PR TITLE
Add support for discv5 talk protocols

### DIFF
--- a/tests/p2p/test_discoveryv5_encoding.nim
+++ b/tests/p2p/test_discoveryv5_encoding.nim
@@ -110,6 +110,41 @@ suite "Discovery v5.1 Protocol Message Encodings":
       message.nodes.enrs[0] == e1
       message.nodes.enrs[1] == e2
 
+  test "Talk Request":
+    let
+      tr = TalkReqMessage(protocol: "echo".toBytes(), request: "hi".toBytes())
+      reqId = RequestId(id: @[1.byte])
+
+    let encoded = encodeMessage(tr, reqId)
+    check encoded.toHex == "05c901846563686f826869"
+
+    let decoded = decodeMessage(encoded)
+    check decoded.isOk()
+
+    let message = decoded.get()
+    check:
+      message.reqId == reqId
+      message.kind == talkreq
+      message.talkreq.protocol == "echo".toBytes()
+      message.talkreq.request == "hi".toBytes()
+
+  test "Talk Response":
+    let
+      tr = TalkRespMessage(response: "hi".toBytes())
+      reqId = RequestId(id: @[1.byte])
+
+    let encoded = encodeMessage(tr, reqId)
+    check encoded.toHex == "06c401826869"
+
+    let decoded = decodeMessage(encoded)
+    check decoded.isOk()
+
+    let message = decoded.get()
+    check:
+      message.reqId == reqId
+      message.kind == talkresp
+      message.talkresp.response == "hi".toBytes()
+
   test "Ping with too large RequestId":
     let
       enrSeq = 1'u64


### PR DESCRIPTION
Add proper support for talk sub protocols over discv5 with talkreq and talkresp messages, see: https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md#talkreq-request-0x05