### PR TITLE
sqlite3: support option type

### DIFF
--- a/tests/db/test_kvstore_sqlite3.nim
+++ b/tests/db/test_kvstore_sqlite3.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/os,
+  std/[os, options],
   testutils/unittests,
   ../../eth/db/[kvstore, kvstore_sqlite3],
   ./test_kvstore
@@ -45,7 +45,6 @@ procSuite "SqStoreRef":
       NoParams, int64).get
 
     var totalRecords = 0
-    echo "About to call total records"
     let countRes = countStmt.exec do (res: int64):
       totalRecords = int res
 
@@ -138,7 +137,6 @@ procSuite "SqStoreRef":
       NoParams, int64).get
 
     var totalRecords = 0
-    echo "About to call total attestations"
     let countRes = countStmt.exec do (res: int64):
       totalRecords = int res
 
@@ -178,3 +176,43 @@ procSuite "SqStoreRef":
         source == 2
         target == 4
         digest == hash
+
+  test "null values":
+    #
+    let db = SqStoreRef.init("", "test", inMemory = true)[]
+    defer: db.close()
+
+    let createTableRes = db.exec """
+      CREATE TABLE IF NOT EXISTS testnull(
+         a INTEGER PRIMARY KEY,
+         b INTEGER NULL,
+         c INTEGER NULL
+      );
+    """
+    check createTableRes.isOk
+
+    type
+      ABC = (int64, Option[int64], Option[int64])
+    let insertStmt = db.prepareStmt("""
+      INSERT INTO testnull(a, b, c) VALUES (?,?,?);
+    """, ABC, void).get()
+
+    const val = (42'i64, none(int64), some(44'i64))
+    check:
+      insertStmt.exec(val).isOk()
+
+    let selectStmt = db.prepareStmt("""
+      SELECT a, b, c FROM testnull
+      """, NoParams, ABC).get()
+
+    block:
+      var abc: ABC
+      let selectRes = selectStmt.exec do (res: ABC):
+        abc = res
+
+      if selectRes.isErr:
+        echo selectRes.error
+
+      check:
+        selectRes.isOk and selectRes.get == true
+        abc == val


### PR DESCRIPTION
.. and any integer when writing but don't support int32 on reads -
internally sqlite will truncate on overflow which isn't nice.