### PR TITLE
Add nim dependency restrictions

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -4,7 +4,7 @@ description   = "Ethereum Common library"
 license       = "MIT"
 skipDirs      = @["tests"]
 
-requires "nim >= 1.2.0",
+requires "nim >= 1.2.0 & <= 1.2.12",
          "nimcrypto",
          "stint",
          "secp256k1",


### PR DESCRIPTION
I don't usuallyy test this as I typically work from repos like nimbus-eth2, but trying out latest 1.4.x range of Nim versions gives this issue in nim-eth:

```
stack trace: (most recent call last)
options.nim(313, 22)
options.nim(128, 17)     handleEnumOption
/home/deme/.nimble/pkgs/chronicles-0.10.1/chronicles/options.nim(128, 17) Error: 'error' is not a recognized value for 'chronicles_log_level'. Allowed values are NONE, TRACE, DEBUG, INFO, NOTICE, WARN, ERROR, FATAL
stack trace: (most recent call last)
/tmp/nimblecache-1296743155/nimscriptapi_1170409232.nim(187, 16)
/home/deme/repos/nim-eth/eth.nimble(50, 10) test_portalTask
/home/deme/repos/nim-eth/eth.nimble(26, 8) runTest
/home/deme/.choosenim/toolchains/nim-1.4.8/lib/system/nimscript.nim(260, 7) exec
/home/deme/.choosenim/toolchains/nim-1.4.8/lib/system/nimscript.nim(260, 7) Error: unhandled exception: FAILED: nim c -r -d:release -d:chronosStrictException -d:chronicles_log_level=error --verbosity:0 --hints:off tests/p2p/all_portal_tests [OSError]
     Error: Exception raised during nimble script execution
```

Not sure if that is known already, but restricting nim version for now for those that might run this as stand-alone.