### PR TITLE
Revert part of "top level push raises Defect to p2p code (#374)"

### DIFF
--- a/eth/p2p/p2p_protocol_dsl.nim
+++ b/eth/p2p/p2p_protocol_dsl.nim
@@ -1,5 +1,3 @@
-{.push raises: [Defect].}
-
 import
   std/[options, sequtils],
   stew/shims/macros, chronos, faststreams/outputs
@@ -1006,11 +1004,7 @@ macro emitForSingleBackend(
     peerState.getType, networkState.getType)
 
   result = p.genCode()
-  try:
-    result.storeMacroResult true
-  except IOError:
-    # IO error so the generated nim code might not be stored, don't sweat it.
-    discard
+  result.storeMacroResult true
 
 macro emitForAllBackends(backendSyms: typed, options: untyped, body: untyped): untyped =
   let name = $(options[0])


### PR DESCRIPTION
PR #374 a8d11dd breaks the `nimbus-eth1` build, with this compile error:

    /home/jamie/Status/nimbus-eth1/vendor/nim-eth/eth/p2p/p2p_protocol_dsl.nim(200, 1) template/generic instantiation from here
    /home/jamie/Status/nimbus-eth1/vendor/nim-eth/eth/p2p/p2p_protocol_dsl.nim(204, 11) Error: can raise an unlisted exception: Exception

Only one change causes the problem, in `p2p_protocol_dsl.nim`. So this PR reverts just that change.

The cause appears to be that `$` can raise `Exception`, and `$` is used a lot in the p2p macro.  (Could it be due to the version of Nim used?  Why doesn't this break `nimbus-eth2`?)

I tried adding `{.raises: [Exception.}` to each proc where the above error occurred, until they stopped, in `p2p_protocol_dsl.nim`.

It was getting a bit ugly at 15 annotations, but I found that wasn't enough anyway.  The following error was output even when the proc containing line 852, `processProtocolBody`, had `{.raises: [Exception].}`:

    /home/jamie/Status/nimbus-eth1/vendor/nim-eth/eth/p2p/p2p_protocol_dsl.nim(288, 1) template/generic instantiation from here
    /home/jamie/Status/nimbus-eth1/vendor/nim-eth/eth/p2p/p2p_protocol_dsl.nim(852, 41) Error: can raise an unlisted exception: Exception

As this is blocking other work on `nimbus-eth1`, revert the change until a better fix to `p2p_protocol_dsp.nim` can be found.  We could branch but it seems best not to diverge, as there are a number of other changes to `nim-eth` for `nimbus-eth1` to go in.

Signed-off-by: Jamie Lokier <jamie@shareable.org>