### PR TITLE
Allow anonymous data proc for kvstore get

### DIFF
--- a/eth/db/kvstore.nim
+++ b/eth/db/kvstore.nim
@@ -50,22 +50,23 @@ template put*(dbParam: KvStoreRef, key, val: openArray[byte]): KvResult[void] =
   let db = dbParam
   db.putProc(db.obj, key, val)
 
-template get*(dbParam: KvStoreRef, key: openArray[byte], onData: untyped): KvResult[bool] =
+# template would be preferred, but cannot be called with an anonymous proc on Nim 1.2.12.
+# See https://github.com/nim-lang/Nim/issues/18648
+proc get*(db: KvStoreRef, key: openArray[byte], onData: DataProc): KvResult[bool] =
   ## Retrive value at ``key`` and call ``onData`` with the value. The data is
   ## valid for the duration of the callback.
   ## ``onData``: ``proc(data: openArray[byte])``
   ## returns true if found and false otherwise.
-  let db = dbParam
   db.getProc(db.obj, key, onData)
 
-template find*(
-    dbParam: KvStoreRef, prefix: openArray[byte], onFind: untyped): KvResult[int] =
+# template would be preferred, but cannot be called with an anonymous proc on Nim 1.2.12.
+# See https://github.com/nim-lang/Nim/issues/18648
+proc find*(db: KvStoreRef, prefix: openArray[byte], onFind: KeyValueProc): KvResult[int] =
   ## Perform a prefix find, returning all data starting with the given prefix.
   ## An empty prefix returns all rows in the store.
   ## The data is valid for the duration of the callback.
   ## ``onFind``: ``proc(key, value: openArray[byte])``
   ## returns the number of rows found
-  let db = dbParam
   db.findProc(db.obj, prefix, onFind)
 
 template del*(dbParam: KvStoreRef, key: openArray[byte]): KvResult[void] =

--- a/tests/db/test_kvstore.nim
+++ b/tests/db/test_kvstore.nim
@@ -32,6 +32,11 @@ proc testKvStore*(db: KvStoreRef, supportsFind: bool) =
     db.contains(key)[]
     db.get(key, grab)[]
     v == value
+    # Test that compilation succeeds when called with anonymous proc.
+    # See https://github.com/nim-lang/Nim/issues/18648
+    db.contains(key)[]
+    db.get(key, proc(data: openArray[byte]) = v = @data)[]
+    v == value
 
   db.put(key, value2)[] # overwrite old value
   check:


### PR DESCRIPTION
Allow anonymous data proc for kvstore get

Nim 1.2.12 has trouble compiling kvstore clients that attempt to fetch
data by passing an anonymous proc to `get`, i.e.,
```
    db.get(key, proc(data: openArray[byte]) = v = @data)[]
```
leads to a compilation error such as:
```
    internal error: expr: param not init data_34695004
```

Note that defining the proc in a named fashion, then passing the name,
works fine. Nim 1.4.8 also succeeds in the case of an anonymous proc.

The error seems to show up due to an interaction with templates taking
`openArray` procs. As the kvstore functions do not need to use templates
this patch replaces them with inline procs. Furthermore, an additional
test checks that passing an anonymous proc works as expected.

A minimal standalone program triggering the same compilation problem:

```
    type
      X* = ref object
        bar: proc (p: proc(v: openArray[byte]))

    template foo(x: X, p: proc(v: openArray[byte])) =
      x.bar(p)

    X().foo(proc(v: openArray[byte]) = discard @v)
```

See https://github.com/nim-lang/Nim/issues/18648