### PR TITLE
Fix `NewBlock` message by removing `{.rlpInline.}` which was never really implemented

### DIFF
--- a/doc/rlp.md
+++ b/doc/rlp.md
@@ -122,11 +122,9 @@ var bytes = encode(t1)
 var t2 = bytes.decode(Transaction)
 ```
 
-By default, sub-fields within objects are wrapped in RLP lists. You can avoid this
-behavior by adding the custom pragma `rlpInline` on a particular field. In rare
-circumstances, you may need to serialize the same field type differently depending
-on the enclosing object type. You can use the `rlpCustomSerialization` pragma to
-achieve this.
+In rare circumstances, you may need to serialize the same field type
+differently depending on the enclosing object type. You can use the
+`rlpCustomSerialization` pragma to achieve this.
 
 ### Contributing / Testing
 

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -252,15 +252,8 @@ func asCapability*(p: ProtocolInfo): Capability =
   result.name = p.name
   result.version = p.version
 
-func nameStr*(p: ProtocolInfo): string =
-  result = newStringOfCap(3)
-  for c in p.name: result.add(c)
-
 proc cmp*(lhs, rhs: ProtocolInfo): int =
-  for i in 0..2:
-    if lhs.name[i] != rhs.name[i]:
-      return int16(lhs.name[i]) - int16(rhs.name[i])
-  return 0
+  return cmp(lhs.name, rhs.name)
 
 proc nextMsgResolver[MsgType](msgData: Rlp, future: FutureBase)
     {.gcsafe, raises: [RlpError, Defect].} =
@@ -666,9 +659,8 @@ proc p2pProtocolBackendImpl*(protocol: P2PProtocol): Backend =
     isSubprotocol = protocol.rlpxName != "p2p"
 
   if protocol.rlpxName.len == 0: protocol.rlpxName = protocol.name
-  # By convention, all Ethereum protocol names were abbreviated to 3 letters,
-  # but this informal spec has since been relaxed (e.g. `hive`).
-  doAssert protocol.rlpxName.len > 2
+  # By convention, all Ethereum protocol names have at least 3 characters.
+  doAssert protocol.rlpxName.len >= 3
 
   new result
 

--- a/eth/p2p/rlpx_protocols/eth_protocol.nim
+++ b/eth/p2p/rlpx_protocols/eth_protocol.nim
@@ -23,7 +23,8 @@ type
 
   NewBlockAnnounce* = object
     header*: BlockHeader
-    body* {.rlpInline.}: BlockBody
+    txs*:    seq[Transaction]
+    uncles*: seq[BlockHeader]
 
   PeerState = ref object
     initialized*: bool

--- a/eth/rlp/object_serialization.nim
+++ b/eth/rlp/object_serialization.nim
@@ -4,10 +4,6 @@ template rlpIgnore* {.pragma.}
   ## Specifies that a certain field should be ignored for the purposes
   ## of RLP serialization
 
-template rlpInline* {.pragma.}
-  ## This can be specified on a record field in order to avoid the
-  ## default behavior of wrapping the record in a RLP list.
-
 template rlpCustomSerialization* {.pragma.}
   ## This pragma can be applied to a record field to enable the
   ## use of custom `read` and `append` overloads that also take


### PR DESCRIPTION
For a long time this caused invalid RLP parsing of `NewBlock` messages in the `eth` protocol.

The `rlpInline` pragma was accepted but had no effect.  We could implemented it, but it doesn't seem worth doing, with tests etc, as there's only one user which has been fixed another way.

With `NewBlock`, whenever a peer sent us `NewBlock`, we'd get an RLP decoding error, and disconnected the peer thinking it was the peer's error.

These messages are sent often by good peers, so whenever we connected to a really good peer, we'd end up disconnecting within a minute due to this.  This went unnoticed for years, as we stayed connected to old peers which have no new blocks, and we weren't looking at peer quality, disconnect reasons or real-time blockchain updates anyway.