### PR TITLE
Add option to `connectToNetwork` return without waiting for peers

### DIFF
--- a/doc/rlp.md
+++ b/doc/rlp.md
@@ -122,11 +122,9 @@ var bytes = encode(t1)
 var t2 = bytes.decode(Transaction)
 ```
 
-By default, sub-fields within objects are wrapped in RLP lists. You can avoid this
-behavior by adding the custom pragma `rlpInline` on a particular field. In rare
-circumstances, you may need to serialize the same field type differently depending
-on the enclosing object type. You can use the `rlpCustomSerialization` pragma to
-achieve this.
+In rare circumstances, you may need to serialize the same field type
+differently depending on the enclosing object type. You can use the
+`rlpCustomSerialization` pragma to achieve this.
 
 ### Contributing / Testing
 

--- a/eth/p2p.nim
+++ b/eth/p2p.nim
@@ -93,7 +93,8 @@ proc startListening*(node: EthereumNode) {.raises: [CatchableError, Defect].} =
 proc connectToNetwork*(node: EthereumNode,
                        bootstrapNodes: seq[ENode],
                        startListening = true,
-                       enableDiscovery = true) {.async.} =
+                       enableDiscovery = true,
+                       waitForPeers = true) {.async.} =
   doAssert node.connectionState == ConnectionState.None
 
   node.connectionState = Connecting
@@ -112,7 +113,7 @@ proc connectToNetwork*(node: EthereumNode,
   else:
     info "Discovery disabled"
 
-  while node.peerPool.connectedNodes.len == 0:
+  while node.peerPool.connectedNodes.len == 0 and waitForPeers:
     trace "Waiting for more peers", peers = node.peerPool.connectedNodes.len
     await sleepAsync(500.milliseconds)
 

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -252,15 +252,8 @@ func asCapability*(p: ProtocolInfo): Capability =
   result.name = p.name
   result.version = p.version
 
-func nameStr*(p: ProtocolInfo): string =
-  result = newStringOfCap(3)
-  for c in p.name: result.add(c)
-
 proc cmp*(lhs, rhs: ProtocolInfo): int =
-  for i in 0..2:
-    if lhs.name[i] != rhs.name[i]:
-      return int16(lhs.name[i]) - int16(rhs.name[i])
-  return 0
+  return cmp(lhs.name, rhs.name)
 
 proc nextMsgResolver[MsgType](msgData: Rlp, future: FutureBase)
     {.gcsafe, raises: [RlpError, Defect].} =
@@ -666,9 +659,8 @@ proc p2pProtocolBackendImpl*(protocol: P2PProtocol): Backend =
     isSubprotocol = protocol.rlpxName != "p2p"
 
   if protocol.rlpxName.len == 0: protocol.rlpxName = protocol.name
-  # By convention, all Ethereum protocol names were abbreviated to 3 letters,
-  # but this informal spec has since been relaxed (e.g. `hive`).
-  doAssert protocol.rlpxName.len > 2
+  # By convention, all Ethereum protocol names have at least 3 characters.
+  doAssert protocol.rlpxName.len >= 3
 
   new result
 

--- a/eth/p2p/rlpx_protocols/eth_protocol.nim
+++ b/eth/p2p/rlpx_protocols/eth_protocol.nim
@@ -23,7 +23,8 @@ type
 
   NewBlockAnnounce* = object
     header*: BlockHeader
-    body* {.rlpInline.}: BlockBody
+    txs*:    seq[Transaction]
+    uncles*: seq[BlockHeader]
 
   PeerState = ref object
     initialized*: bool

--- a/eth/rlp/object_serialization.nim
+++ b/eth/rlp/object_serialization.nim
@@ -4,10 +4,6 @@ template rlpIgnore* {.pragma.}
   ## Specifies that a certain field should be ignored for the purposes
   ## of RLP serialization
 
-template rlpInline* {.pragma.}
-  ## This can be specified on a record field in order to avoid the
-  ## default behavior of wrapping the record in a RLP list.
-
 template rlpCustomSerialization* {.pragma.}
   ## This pragma can be applied to a record field to enable the
   ## use of custom `read` and `append` overloads that also take


### PR DESCRIPTION
The new sync code wants to start without waiting.  We can `discard` the async result but there is no need for a background task polling and running a timer for no clear benefit.