### PR TITLE
Add proof verification to public api

### DIFF
--- a/eth/trie/hexary.nim
+++ b/eth/trie/hexary.nim
@@ -677,3 +677,17 @@ proc isPruning*(self: SecureHexaryTrie): bool {.borrow.}
 template contains*(self: HexaryTrie | SecureHexaryTrie;
                    key: openArray[byte]): bool =
   self.get(key).len > 0
+
+# Validates merkle proof against provided root hash
+proc isValidBranch*(branch: seq[seq[byte]], rootHash: KeccakHash, key, value: seq[byte]): bool =
+  # branch must not be empty
+  doAssert(branch.len != 0)
+
+  var db = newMemoryDB()
+  for node in branch:
+    doAssert(node.len != 0)
+    let nodeHash = hexary.keccak(node)
+    db.put(nodeHash.data, node)
+
+  var trie = initHexaryTrie(db, rootHash)
+  result = trie.get(key) == value

--- a/tests/trie/test_hexary_trie.nim
+++ b/tests/trie/test_hexary_trie.nim
@@ -310,19 +310,6 @@ suite "hexary trie":
         echo "ITERATION: ", iteration
         break
 
-  proc isValidBranch(branch: seq[seq[byte]], rootHash: KeccakHash, key, value: seq[byte]): bool =
-    # branch must not be empty
-    doAssert(branch.len != 0)
-
-    var db = newMemoryDB()
-    for node in branch:
-      doAssert(node.len != 0)
-      let nodeHash = hexary.keccak(node)
-      db.put(nodeHash.data, node)
-
-    var trie = initHexaryTrie(db, rootHash)
-    result = trie.get(key) == value
-
   test "get branch with pruning trie":
     var
       memdb = newMemoryDB()


### PR DESCRIPTION
Currently hexary trie proof verification was only used in test, for fluffy we will need to validates proof form the network, therefore this functionality should be made public.