### PR TITLE
Fix lookupDistances function and make it public

### DIFF
--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -654,15 +654,16 @@ proc talkreq*(d: Protocol, toNode: Node, protocol, request: seq[byte]):
     discovery_message_requests_outgoing.inc(labelValues = ["no_response"])
     return err("Talk response message not received in time")
 
-proc lookupDistances(target, dest: NodeId): seq[uint16] =
+proc lookupDistances*(target, dest: NodeId): seq[uint16] =
   let td = logDist(target, dest)
+  let tdAsInt = int(td)
   result.add(td)
-  var i = 1'u16
+  var i = 1
   while result.len < lookupRequestLimit:
-    if td + i < 256:
-      result.add(td + i)
-    if td - i > 0'u16:
-      result.add(td - i)
+    if tdAsInt + i < 256:
+      result.add(td + uint16(i))
+    if tdAsInt - i > 0:
+      result.add(td - uint16(i))
     inc i
 
 proc lookupWorker(d: Protocol, destNode: Node, target: NodeId):

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -527,6 +527,15 @@ procSuite "Discovery v5 Tests":
         test = verifyNodesRecords(records, fromNode, 0'u16)
       check test.len == 0
 
+  test "Calculate lookup distances":
+    # Log distance between zeros is zero
+    let dist = lookupDistances(u256(0), u256(0))
+    check dist == @[0'u16, 1, 2]
+
+    # Log distance between zero and one is one
+    let dist1 = lookupDistances(u256(0), u256(1))
+    check dist1 == @[1'u16, 2, 3]
+
   asyncTest "Handshake cleanup: different ids":
     # Node to test the handshakes on.
     let receiveNode = initDiscoveryNode(


### PR DESCRIPTION
There was a bug in lookup distances functions due to the fact of operating on `u16` types i.e `0'u16 - 1 ==  65535`, so function could return invalid values when log distances where near zero. For example:
`lookupDistances(u256(0), u256(0)) -> was: @[0, 1, 65535], should be: @[0, 1, 2]`
`lookupDistances(u256(0), u256(1)) -> was: @[@[1, 2, 3, 65535]], should be @[1, 2, 3]`