### PR TITLE
fix compile error due to cyrillic T

### DIFF
--- a/eth/ssz/merkleization.nim
+++ b/eth/ssz/merkleization.nim
@@ -469,9 +469,9 @@ func chunkedHashTreeRootForBasicTypes[T](merkleizer: var SszMerkleizerImpl,
   else:
     static:
       doAssert T is UintN
-      doAssert bytesPerChunk mod sizeof(Т) == 0
+      doAssert bytesPerChunk mod sizeof(T) == 0
 
-    const valuesPerChunk = bytesPerChunk div sizeof(Т)
+    const valuesPerChunk = bytesPerChunk div sizeof(T)
 
     var writtenValues = 0
 


### PR DESCRIPTION
There was a cyrillic T in some big-endian specific code that broke the
compilation on such platforms. This replaces that T with an ASCII T to
fix the build.