### PR TITLE
fix big-endian merkleization for UintN arrays

### DIFF
--- a/eth/ssz/merkleization.nim
+++ b/eth/ssz/merkleization.nim
@@ -486,7 +486,7 @@ func chunkedHashTreeRootForBasicTypes[T](merkleizer: var SszMerkleizerImpl,
     if remainingValues > 0:
       var lastChunk: array[bytesPerChunk, byte]
       for i in 0 ..< remainingValues:
-        chunk.writeBytesLE(i * sizeof(T), arr[writtenValues + i])
+        lastChunk.writeBytesLE(i * sizeof(T), arr[writtenValues + i])
       merkleizer.addChunk lastChunk
 
   getFinalHash(merkleizer)


### PR DESCRIPTION
UintN arrays were incorrectly merkleized on big-endian. This was fixed
by making sure to use the correct buffer to store the final chunk.