### PR TITLE
avoid func call when merkleizing UintN arrays

### DIFF
--- a/eth/ssz/merkleization.nim
+++ b/eth/ssz/merkleization.nim
@@ -443,13 +443,15 @@ func chunkedHashTreeRootForBasicTypes[T](merkleizer: var SszMerkleizerImpl,
                                          arr: openArray[T]): Digest =
   static:
     doAssert T is BasicType
+    doAssert bytesPerChunk mod sizeof(T) == 0
 
   if arr.len == 0:
     return getFinalHash(merkleizer)
 
-  when T is byte:
+  when sizeof(T) == 1 or cpuEndian == littleEndian:
     var
-      remainingBytes = arr.len
+      remainingBytes = when sizeof(T) == 1: arr.len
+                                      else: arr.len * sizeof(T)
       pos = cast[ptr byte](unsafeAddr arr[0])
 
     while remainingBytes >= bytesPerChunk:
@@ -460,17 +462,7 @@ func chunkedHashTreeRootForBasicTypes[T](merkleizer: var SszMerkleizerImpl,
     if remainingBytes > 0:
       merkleizer.addChunk(makeOpenArray(pos, remainingBytes))
 
-  elif T is bool or cpuEndian == littleEndian:
-    let
-      baseAddr = cast[ptr byte](unsafeAddr arr[0])
-      len = arr.len * sizeof(T)
-    return chunkedHashTreeRootForBasicTypes(merkleizer, makeOpenArray(baseAddr, len))
-
   else:
-    static:
-      doAssert T is UintN
-      doAssert bytesPerChunk mod sizeof(T) == 0
-
     const valuesPerChunk = bytesPerChunk div sizeof(T)
 
     var writtenValues = 0


### PR DESCRIPTION
This gets rid of an unnecessary function call when merkleizing `UintN`
arrays on `littleEndian` architectures.