### PR TITLE
allow `ElemType(XXX)` on inputs not called `T`

### DIFF
--- a/eth/ssz/types.nim
+++ b/eth/ssz/types.nim
@@ -164,8 +164,8 @@ template ElemType*(T: type array): untyped =
 template ElemType*(T: type seq): untyped =
   type(default(T)[0])
 
-template ElemType*(T: type List): untyped =
-  T.T
+template ElemType*(T0: type List): untyped =
+  T0.T
 
 func isFixedSize*(T0: type): bool {.compileTime.} =
   mixin toSszType, enumAllSerializedFields


### PR DESCRIPTION
Currently, `ElemType` can only be called on `List` types when they are
first assigned to a variable called `T`. The template has been adjusted
so that different variable names may be used. The template can now also
be applied to in-line computed types, e.g., `ElemType(typeof(x))`.