### PR TITLE
Fix nim 1.4

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -24,13 +24,13 @@ proc runTest(path: string, release: bool = true, chronosStrict = true) =
   let chronosMode =
     if chronosStrict: "-d:chronosStrictException" else: ""
   exec "nim c -r " & releaseMode & " " & chronosMode &
-    " -d:chronicles_log_level=error --verbosity:0 --hints:off " & path
+    " -d:chronicles_log_level=ERROR --verbosity:0 --hints:off " & path
   rmFile path
 
 proc buildBinary(path: string) =
   echo "\nBuilding: ", path
   exec "nim c -d:release -d:chronosStrictException " &
-    "-d:chronicles_log_level=trace --verbosity:0 --hints:off --threads:on " &
+    "-d:chronicles_log_level=TRACE --verbosity:0 --hints:off --threads:on " &
     "--warning[CaseTransition]:off --warning[ObservableStores]:off " &
     path
 

--- a/eth.nimble
+++ b/eth.nimble
@@ -4,7 +4,7 @@ description   = "Ethereum Common library"
 license       = "MIT"
 skipDirs      = @["tests"]
 
-requires "nim >= 1.2.0 & <= 1.2.14",
+requires "nim >= 1.2.0",
          "nimcrypto",
          "stint",
          "secp256k1",


### PR DESCRIPTION
Fixes compilation and tests for Nim 1.4.

* fixes capitalization of chronicles log level (`ERROR` instead of `error`)
* ~~removes unused `NodeId.toBytes` function~~
   ~~(it wasn't seen by Nim 1.2.x, and leads to failing tests when it is seen by Nim 1.4.x)~~
   Fixed in #427
* removes restriction to Nim 1.2.x in nimble file

By the way: the fact that the `NodeId.toBytes` function was not seen by Nim 1.2.x might mean that there's a bug lurking in the [`logDistance`](https://github.com/status-im/nim-eth/blob/fe1bb4c4e75c9d20698e767427effa5fc29bbbc7/eth/p2p/discoveryv5/routing_table.nim#L107) function. In reality it is calculating the distance based on the platform endianness, but the existence of the NodeId.toBytes function seems to suggest that it should have used big endian instead.