### PR TITLE
avoid allocation in `hash(ValidIpAddress)`

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -4,7 +4,7 @@ description   = "Ethereum Common library"
 license       = "MIT"
 skipDirs      = @["tests"]
 
-requires "nim >= 1.2.0 & <= 1.2.12",
+requires "nim >= 1.2.0 & <= 1.2.14",
          "nimcrypto",
          "stint",
          "secp256k1",

--- a/eth/net/utils.nim
+++ b/eth/net/utils.nim
@@ -16,7 +16,10 @@ type
     limit*: uint
     ips: Table[ValidIpAddress, uint]
 
-func hash(ip: ValidIpAddress): Hash = hash($ip)
+func hash(ip: ValidIpAddress): Hash =
+  case ip.family
+  of IpAddressFamily.IPv6: hash(ip.address_v6)
+  of IpAddressFamily.IPv4: hash(ip.address_v4)
 
 func inc*(ipLimits: var IpLimits, ip: ValidIpAddress): bool =
   let val = ipLimits.ips.getOrDefault(ip, 0)


### PR DESCRIPTION
While casually browsing the profiler output, to my great surprise I
found that an allocating string conversion function (gasp!) in the hash
function for ip addresses - this PR carefully excises this evil
construct from the codebase.