### PR TITLE
Adjust logging when node is not reachable but enrAutoUpdate is on

### DIFF
--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -911,7 +911,11 @@ proc newProtocol*(privKey: PrivateKey,
   info "ENR initialized", ip = enrIp, tcp = enrTcpPort, udp = enrUdpPort,
     seqNum = record.seqNum, uri = toURI(record)
   if enrIp.isNone():
-    warn "No external IP provided for the ENR, this node will not be discoverable"
+    if enrAutoUpdate:
+      notice "No external IP provided for the ENR, this node will not be " &
+        "discoverable until the ENR is updated with the discovered external IP address"
+    else:
+      warn "No external IP provided for the ENR, this node will not be discoverable"
 
   let node = newNode(record).expect("Properly initialized record")
 


### PR DESCRIPTION
Separate the logging when the node is not reachable and
enrAutoUpdate is on or off to avoid confusion whether or not the
node might still become reachable.

Was pointed out by user Yorick