### PR TITLE
Track send buffer and properly handle back pressoure when window is to small to process data

### DIFF
--- a/eth/utp/send_buffer_tracker.nim
+++ b/eth/utp/send_buffer_tracker.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Status Research & Development GmbH
+# Copyright (c) 2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -12,7 +12,7 @@ import
 # Internal Utp data structure to track send window and properly block when there is
 # no free space when trying to send more bytes
 type SendBufferTracker* = ref object
-  # number payload bytes in-flight (i.e not countig header sizes)
+  # number of payload bytes in-flight (i.e not counting header sizes)
   # packets that have not yet been sent do not count, packets
   # that are marked as needing to be re-sent (due to a timeout)
   # don't count either

--- a/eth/utp/send_buffer_tracker.nim
+++ b/eth/utp/send_buffer_tracker.nim
@@ -1,0 +1,76 @@
+# Copyright (c) 2020-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
+
+import
+  chronos
+
+# Internal Utp data structure to track send window and properly block when there is
+# no free space when trying to send more bytes
+type SendBufferTracker* = ref object
+  # number payload bytes in-flight (i.e not countig header sizes)
+  # packets that have not yet been sent do not count, packets
+  # that are marked as needing to be re-sent (due to a timeout)
+  # don't count either
+  currentWindow: uint32
+
+  # remote receive window updated based on packed wndSize field
+  maxRemoteWindow: uint32
+  waiters: seq[(uint32, Future[void])]
+
+proc new*(T: type SendBufferTracker, currentWindow: uint32,  maxRemoteWindow: uint32): T =
+  return SendBufferTracker(currentWindow: currentWindow, maxRemoteWindow: maxRemoteWindow, waiters: @[])
+
+proc currentFreeBytes(t: SendBufferTracker): uint32 =
+  let maxSend = t.maxRemoteWindow
+  if (maxSend <= t.currentWindow):
+    return 0
+  else:
+    return maxSend - t.currentWindow
+
+proc checkWaiters(t: SendBufferTracker) =
+  var i = 0
+  while i < len(t.waiters):
+    let freeSpace = t.currentFreeBytes()
+    let (required, fut) = t.waiters[i]
+    if (required <= freeSpace):
+      # in case future was cancelled
+      if (not fut.finished()):
+        t.currentWindow = t.currentWindow + required
+        fut.complete()
+      t.waiters.del(i)
+    else:
+      inc i
+
+proc updateMaxRemote*(t: SendBufferTracker, newRemoteWindow: uint32) =
+  t.maxRemoteWindow = newRemoteWindow
+  t.checkWaiters()
+
+proc decreaseCurrentWindow*(t: SendBufferTracker, value: uint32) =
+  doAssert(t.currentWindow >= value)
+  t.currentWindow = t.currentWindow - value
+  t.checkWaiters()
+
+proc reserveNBytesWait*(t: SendBufferTracker, n: uint32): Future[void] =
+  let fut = newFuture[void]()
+  let free = t.currentFreeBytes()
+  if (n <= free):
+    t.currentWindow = t.currentWindow + n
+    fut.complete()
+  else:
+    t.waiters.add((n, fut))
+  fut
+
+proc reserveNBytes*(t: SendBufferTracker, n: uint32): bool =
+  let free = t.currentFreeBytes()
+  if (n <= free):
+    t.currentWindow = t.currentWindow + n
+    return true
+  else:
+    return false
+
+proc currentBytesInFlight*(t: SendBufferTracker): uint32 = t.currentWindow

--- a/eth/utp/send_buffer_tracker.nim
+++ b/eth/utp/send_buffer_tracker.nim
@@ -16,10 +16,10 @@ type SendBufferTracker* = ref object
   # packets that have not yet been sent do not count, packets
   # that are marked as needing to be re-sent (due to a timeout)
   # don't count either
-  currentWindow: uint32
+  currentWindow*: uint32
 
   # remote receive window updated based on packed wndSize field
-  maxRemoteWindow: uint32
+  maxRemoteWindow*: uint32
   waiters: seq[(uint32, Future[void])]
 
 proc new*(T: type SendBufferTracker, currentWindow: uint32,  maxRemoteWindow: uint32): T =

--- a/eth/utp/utp_socket.nim
+++ b/eth/utp/utp_socket.nim
@@ -485,7 +485,8 @@ proc handleDataWrite(socket: UtpSocket, data: seq[byte], writeFut: Future[WriteR
         bytesWritten = bytesWritten + len(dataSlice)
         i = lastOrEnd + 1
 
-      # in case future got cancelled or finished
+      # Before completeing future with success (as all data was sent sucessfuly)
+      # we need to check if user did not cancel write on his end
       if (not writeFut.finished()):
         writeFut.complete(Result[int, WriteError].ok(bytesWritten))
 

--- a/eth/utp/utp_socket.nim
+++ b/eth/utp/utp_socket.nim
@@ -64,8 +64,8 @@ type
     # state and will be able to transfer data.
     incomingSocketReceiveTimeout*: Option[Duration]
 
-    # Timeout afer which send window will be reset to it minimal value if it drops
-    # zero i.e we will receive packet from remote peer with wndSize set to 0
+    # Timeout after which the send window will be reset to its minimal value after it dropped
+    # to zero. i.e when we received a packet from remote peer with `wndSize` set to 0.
     remoteWindowResetTimeout*: Duration
 
   WriteErrorType* = enum
@@ -243,13 +243,13 @@ const
   # considered suspicious and ignored
   allowedAckWindow*: uint16 = 3
 
-  # Timeout afer which send window will be reset to it minimal value if it drops
-  # zero i.e we will receive packet from remote peer with wndSize set to 0
+  # Timeout after which the send window will be reset to its minimal value after it dropped
+  # to zero. i.e when we received a packet from remote peer with `wndSize` set to 0.
   defaultResetWindowTimeout = seconds(15)
 
-  # If remote peer window will drops to zero, then after some time we will reset it 
+  # If remote peer window drops to zero, then after some time we will reset it 
   # to this value even if we do not receive any more messages from remote peers.
-  # Reset period is configures in SocketConfig
+  # Reset period is configured in `SocketConfig`
   minimalRemoteWindow: uint32 = 1500
 
   reorderBufferMaxSize = 1024
@@ -485,7 +485,7 @@ proc handleDataWrite(socket: UtpSocket, data: seq[byte], writeFut: Future[WriteR
         bytesWritten = bytesWritten + len(dataSlice)
         i = lastOrEnd + 1
 
-      # in case future got cancelled
+      # in case future got cancelled or finished
       if (not writeFut.finished()):
         writeFut.complete(Result[int, WriteError].ok(bytesWritten))
 

--- a/tests/utp/test_utp_socket.nim
+++ b/tests/utp/test_utp_socket.nim
@@ -61,6 +61,7 @@ procSuite "Utp socket unit test":
   template connectOutGoingSocket(
     initialRemoteSeq: uint16,
     q: AsyncQueue[Packet],
+    remoteReceiveBuffer: uint32 = testBufferSize,
     cfg: SocketConfig = SocketConfig.init()): (UtpSocket[TransportAddress], Packet) =
     let sock1 = newOutgoingSocket[TransportAddress](testAddress, initTestSnd(q), cfg, defaultRcvOutgoingId, rng[])
     asyncSpawn sock1.startOutgoingSocket()
@@ -69,7 +70,7 @@ procSuite "Utp socket unit test":
     check:
       initialPacket.header.pType == ST_SYN
 
-    let responseAck = ackPacket(initialRemoteSeq, initialPacket.header.connectionId, initialPacket.header.seqNr, testBufferSize)
+    let responseAck = ackPacket(initialRemoteSeq, initialPacket.header.connectionId, initialPacket.header.seqNr, remoteReceiveBuffer)
 
     await sock1.processPacket(responseAck)
 
@@ -564,7 +565,7 @@ procSuite "Utp socket unit test":
     let initialRcvBufferSize = 10'u32
     let data = @[1'u8, 2'u8, 3'u8]
     let sCfg = SocketConfig.init(optRcvBuffer = initialRcvBufferSize)
-    let (outgoingSocket, initialPacket) = connectOutGoingSocket(initialRemoteSeqNr, q, sCfg)
+    let (outgoingSocket, initialPacket) = connectOutGoingSocket(initialRemoteSeqNr, q, testBufferSize, sCfg)
 
     let dataP1 = dataPacket(initialRemoteSeqNr, initialPacket.header.connectionId, initialPacket.header.seqNr, testBufferSize, data)
     
@@ -601,7 +602,7 @@ procSuite "Utp socket unit test":
     let initialRcvBufferSize = 10'u32
     let data = @[1'u8, 2'u8, 3'u8]
     let sCfg = SocketConfig.init(optRcvBuffer = initialRcvBufferSize)
-    let (outgoingSocket, initialPacket) = connectOutGoingSocket(initalRemoteSeqNr, q, sCfg)
+    let (outgoingSocket, initialPacket) = connectOutGoingSocket(initalRemoteSeqNr, q, testBufferSize, sCfg)
 
     let dataP1 = dataPacket(initalRemoteSeqNr, initialPacket.header.connectionId, initialPacket.header.seqNr, testBufferSize, data)
     

--- a/tests/utp/test_utp_socket.nim
+++ b/tests/utp/test_utp_socket.nim
@@ -561,7 +561,7 @@ procSuite "Utp socket unit test":
 
     let (outgoingSocket, initialPacket) = connectOutGoingSocket(initialRemoteSeq, q)
 
-    await outgoingSocket.close()
+    outgoingSocket.close()
 
     let sendFin = await q.get()
 
@@ -576,7 +576,7 @@ procSuite "Utp socket unit test":
 
     let (outgoingSocket, initialPacket) = connectOutGoingSocket(initialRemoteSeq, q)
 
-    let closeF = outgoingSocket.close()
+    outgoingSocket.close()
 
     let sendFin = await q.get()
 
@@ -587,8 +587,6 @@ procSuite "Utp socket unit test":
 
     await outgoingSocket.processPacket(responseAck)
     
-    await closeF
-
     check:
       not outgoingSocket.isConnected()
     
@@ -619,7 +617,7 @@ procSuite "Utp socket unit test":
 
     let (outgoingSocket, initialPacket) = connectOutGoingSocket(initialRemoteSeq, q)
 
-    await outgoingSocket.close()
+    outgoingSocket.close()
 
     let writeResult = await outgoingSocket.write(@[1'u8])
 
@@ -660,7 +658,7 @@ procSuite "Utp socket unit test":
       sentData.header.pType == ST_DATA
       sentData.header.wndSize == initialRcvBufferSize - uint32(len(data))
 
-    await outgoingSocket.close()
+    outgoingSocket.close()
 
     let sentFin = await q.get()
 


### PR DESCRIPTION
Pr add several improvements necessary to properly handle changing size of sending window. 

Main design requirement here is that writing data larger than current send window should asynchronously block the caller while the write is progressing. That way caller can just call `write` proc and the whole flow control will be under control of the library.

To that end it is necessary to introduce writeLoop to properly track all caller writes, and progress them one by one

Current window send window is sized only by the remote peer window.