### PR TITLE
more specific type check in `encryptGCM`

### DIFF
--- a/eth/p2p/discoveryv5/encoding.nim
+++ b/eth/p2p/discoveryv5/encoding.nim
@@ -138,7 +138,7 @@ proc deriveKeys*(n1, n2: NodeID, priv: PrivateKey, pub: PublicKey,
     toOpenArray(res, 0, sizeof(secrets) - 1))
   secrets
 
-proc encryptGCM*(key, nonce, pt, authData: openarray[byte]): seq[byte] =
+proc encryptGCM*(key: AesKey, nonce, pt, authData: openarray[byte]): seq[byte] =
   var ectx: GCM[aes128]
   ectx.init(key, nonce, authData)
   result = newSeq[byte](pt.len + gcmTagSize)


### PR DESCRIPTION
Narrowed the type of `encryptGCM`'s `key` parameter from
`openarray[byte]` to `AesKey`, same as already used for `decryptGCM`.