### PR TITLE
Don't use exceptions for enr get call

### DIFF
--- a/tests/p2p/test_enr.nim
+++ b/tests/p2p/test_enr.nim
@@ -123,14 +123,14 @@ suite "ENR":
       let updated = r.update(pk, [newField])
       check updated.isOk()
       check:
-        r.get("test", uint) == 123
+        r.get("test", uint).get() == 123
         r.seqNum == 2
 
     block: # Insert same k:v pair, no update of seqNum should occur.
       let updated = r.update(pk, [newField])
       check updated.isOk()
       check:
-        r.get("test", uint) == 123
+        r.get("test", uint).get() == 123
         r.seqNum == 2
 
     block: # Insert k:v pair with changed value, update of seqNum should occur.
@@ -138,7 +138,7 @@ suite "ENR":
       let updated = r.update(pk, [updatedField])
       check updated.isOk()
       check:
-        r.get("test", uint) == 1234
+        r.get("test", uint).get() == 1234
         r.seqNum == 3
 
   test "ENR update sorted":


### PR DESCRIPTION
The ENR code used to be solely exception based, and these
exceptions are a left-over of that. They are useless as later
calls use Result anyhow.

Additionally, they cause quite the performance loss because they
are used in the "common path" for the toTypedRecord call, e.g.
when reading the fields of ip6, tcp6 and udp6.

I actually noticed that I could clean-up these useless "in-between" exceptions still when I was quickly checking something else by profiling dcli and noticed higher values on `toTypedRecord` than I would expect. I guess a good example of how much exceptions can hurt in the "common" code path. See `toTypedRecord` difference.

```
# Before                                                                                                                          
-   98.01%     0.33%  dcli     dcli                       [.] poll__YNjd8fE6xG8CRNwfLnrx0g_2                                                                                                                  ◆
   - 97.68% poll__YNjd8fE6xG8CRNwfLnrx0g_2                                                                                                                                                                    ▒
      + 68.43% readDatagramLoop__QkUxpTva3CxYlsCYUABq4Q                                                                                                                                                       ▒
      - 20.24% colonanonymous___Y2mHi049a09c3vMnWs3ahEPw                                                                                                                                                      ▒
         - 20.23% findNode__Ztqhdbg9aZQnjdwp9aPzpaUA_3                                                                                                                                                        ▒
            - 18.85% verifyNodesRecords__PVJo4CxDmSP3R8uChSOWEA                                                                                                                                               ▒
               - 18.83% verifyNodesRecords__A5NJdItxpma2BwV9b8KA2Ow                                                                                                                                           ▒
                  - 18.54% newNode__2WRG7ytUa9bIBAcUto2SgVg                                                                                                                                                   ▒
                     - 13.96% toTypedRecord__hME9bJzRVaF9ccBJXEQKzBuA                                                                                                                                         ▒
                        - 7.83% tryGet__jIIrrYBYjC8dkZnw0x87vA                                                                                                                                                ▒
                           - 7.76% get__9bgDqwnEEDAOLCCt69bFMiqA                                                                                                                                              ▒
                              - 7.62% get__9bgDqwnEEDAOLCCt69bFMiqA                                                                                                                                           ▒
                                 - 7.23% raiseExceptionEx                                                                                                                                                     ▒
                                    - rawWriteStackTrace__zo0sKsXK7oXYz0ERc41mPw (inlined)                                                                                                                    ▒
                                    - auxWriteStackTraceWithOverride__YCnAssGg1QBM8fY9cwYka9aQ                                                                                                                ▒
                                       - 5.86% getProgramCounters__Jaci89bc2C7sCKeQ6g9cs9bZQ                                                                                                                  ▒
                                          - 5.61% get_program_counters_c                                                                                                                                      ▒
                                             + 5.50% backtrace_simple                                                                                                                                         ▒
                                         0.96% genericAssignAux__69cRBG8C28ydeYlu49a9aOJCQ                                                                                                                    ▒
                        - 4.85% tryGet__BIDdcpyNceT8lGgSU9aXYiA                                                                                                                                               ▒
                           - 4.83% get__Z4NlzQp78d0ZTxuI1TyLaQ                                                                                                                                                ▒
                              + 4.56% raiseExceptionEx                                                                                                                                                        ▒
                     + 2.94% get__1c0DahV4PW6jYK47hYZRDg                                                                                                                                                      ▒
                     + 0.94% toNodeId__e46kglxlaqztrRGoDAWW4Q (inlined)                                                                                                                                       ▒
                     + 0.62% genericSeqAssign                                                                                                                                                                 ▒
            + 0.71% get__vawPDe5gUDNyjJLeGFCp2Qresults (inlined)                                                                                                                                              ▒
      + 2.44% colonanonymous___f71d07OTUevmWZ2xN8f6AA                                                                                                                                                         ▒
      + 2.43% colonanonymous___pzAPEp7Zj22WPP0Dcnux3Q                                                                                                                                                         ▒
      + 1.05% colonanonymous___9ahUH3E0dUW7xEfBuG2PAYg                                                                                                                                                        ▒
      + 1.02% selectInto__8Wrt3417b5BNn9coa9b5w8lA                                                                                                                                                            ▒
      + 0.50% colonanonymous___1Ud6e9at7dQSj5FCoMmYcnw                                                                                                                                                        

# After
-   98.13%     0.32%  dcli     dcli                [.] poll__YNjd8fE6xG8CRNwfLnrx0g_2                                                                                                                         ◆
   - 97.81% poll__YNjd8fE6xG8CRNwfLnrx0g_2                                                                                                                                                                    ▒
      + 80.17% readDatagramLoop__QkUxpTva3CxYlsCYUABq4Q                                                                                                                                                       ▒
      - 8.26% colonanonymous___WZV74FNB9cluIEpFCe7U1qg                                                                                                                                                        ▒
         - findNode__Ztqhdbg9aZQnjdwp9aPzpaUA_3                                                                                                                                                               ▒
            - 7.07% verifyNodesRecords__PVJo4CxDmSP3R8uChSOWEA                                                                                                                                                ▒
               - verifyNodesRecords__A5NJdItxpma2BwV9b8KA2Ow                                                                                                                                                  ▒
                  - 6.70% newNode__2WRG7ytUa9bIBAcUto2SgVg                                                                                                                                                    ▒
                     + 3.06% get__1c0DahV4PW6jYK47hYZRDg                                                                                                                                                      ▒
                       1.69% toTypedRecord__hME9bJzRVaF9ccBJXEQKzBuA                                                                                                                                          ▒
                     + 1.13% toNodeId__e46kglxlaqztrRGoDAWW4Q (inlined)                                                                                                                                       ▒
                     + 0.72% genericSeqAssign                                                                                                                                                                 ▒
            + 0.58% internalRead__7rGgYbj62BDud6uumus05wasyncloop (inlined)                                                                                                                                   ▒
      + 2.54% colonanonymous___ureg9azBF1eJQiQmwAdJiEA                                                                                                                                                        ▒
      + 2.42% colonanonymous___kBtvrgwc5KNFAMI9aq58Vkw                                                                                                                                                        ▒
      + 1.13% selectInto__8Wrt3417b5BNn9coa9b5w8lA                                                                                                                                                            ▒
      + 1.09% colonanonymous___9aRdBh6011q9c9biOJ2oIVCNQ                            
```
