### PR TITLE
Re-send acks for old duplicated packets

### DIFF
--- a/eth/utp/utp_router.nim
+++ b/eth/utp/utp_router.nim
@@ -163,7 +163,8 @@ proc processPacket[A](r: UtpRouter[A], p: Packet, sender: A) {.async.}=
       debug "Ignoring SYN for already existing connection"
     else:
       if (r.shouldAllowConnection(sender, p.header.connectionId)):
-        debug "Received SYN for new connection. Initiating incoming connection"
+        debug "Received SYN for new connection. Initiating incoming connection",
+          synSeqNr = p.header.seqNr
         # Initial ackNr is set to incoming packer seqNr
         let incomingSocket = newIncomingSocket[A](sender, r.sendCb, r.socketConfig ,p.header.connectionId, p.header.seqNr, r.rng[])
         r.registerUtpSocket(incomingSocket)

--- a/eth/utp/utp_socket.nim
+++ b/eth/utp/utp_socket.nim
@@ -1019,8 +1019,8 @@ proc processPacket*(socket: UtpSocket, p: Packet) {.async.} =
 
   debug "Process packet",
     socketKey = socket.socketKey,
-    socketAckNr= socket.ackNr,
-    socketSeqNr= socket.seqNr,
+    socketAckNr = socket.ackNr,
+    socketSeqNr = socket.seqNr,
     packetType = p.header.pType,
     seqNr = p.header.seqNr,
     ackNr = p.header.ackNr,

--- a/eth/utp/utp_socket.nim
+++ b/eth/utp/utp_socket.nim
@@ -1069,9 +1069,9 @@ proc processPacket*(socket: UtpSocket, p: Packet) {.async.} =
     # equals (due to wrapping) 65535
     # this means that remote most probably did not receive our ack, so we need to resend
     # it. We are doing it for last `reorderBufferMaxSize` packets
-    let isPossilbeDuplicatedOldPacket = pastExpected >= (int(uint16.high) + 1) - reorderBufferMaxSize
+    let isPossibleDuplicatedOldPacket = pastExpected >= (int(uint16.high) + 1) - reorderBufferMaxSize
 
-    if (isPossilbeDuplicatedOldPacket and p.header.pType != ST_STATE):
+    if (isPossibleDuplicatedOldPacket and p.header.pType != ST_STATE):
       asyncSpawn socket.sendAck()
 
     debug "Got an invalid packet sequence number, too far off",


### PR DESCRIPTION
Fix one bug when testing with 10% packet loss. In case where
1. `A` sends `DATA` packet
2. `B` receives it and send `STATE` packet
3. `STATE` packet is lost
4. `A` re-sends `DATA` packet
we did not re-sent `STATE` for this duplicated  `DATA` packet