### PR TITLE
kvstore: simplified stmt exec

### DIFF
--- a/eth/db/kvstore_sqlite3.nim
+++ b/eth/db/kvstore_sqlite3.nim
@@ -229,7 +229,6 @@ iterator exec*[Params, Res](s: SqliteStmt[Params, Res],
   else:
     if (let v = bindParam(s, 1, params); v != SQLITE_OK):
       res = KvResult[void].err($sqlite3_errstr(v))
-      done = true # Silly iterators
 
   defer:
     # release implicit transaction

--- a/tests/db/test_kvstore_sqlite3.nim
+++ b/tests/db/test_kvstore_sqlite3.nim
@@ -225,3 +225,11 @@ procSuite "SqStoreRef":
       check:
         selectRes.isOk and selectRes.get == true
         abc == val
+
+      var found = false
+      var row: selectStmt.Result
+      for rowRes in selectStmt.exec(row):
+        rowRes.expect("working db")
+        check abc == row
+        found = true
+      check found


### PR DESCRIPTION
iterator for `exec` - avoid callbacks etc for simplified row reading