### PR TITLE
Add DiscoveryConfig to tune routing table ip limits and bitPerHops

### DIFF
--- a/tests/p2p/discv5_test_helper.nim
+++ b/tests/p2p/discv5_test_helper.nim
@@ -9,26 +9,31 @@ export net
 proc localAddress*(port: int): Address =
   Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(port))
 
-proc initDiscoveryNode*(rng: ref BrHmacDrbgContext, privKey: PrivateKey,
-                        address: Address,
-                        bootstrapRecords: openArray[Record] = [],
-                        localEnrFields: openArray[(string, seq[byte])] = [],
-                        previousRecord = none[enr.Record]()):
-                        discv5_protocol.Protocol =
+proc initDiscoveryNode*(
+    rng: ref BrHmacDrbgContext,
+    privKey: PrivateKey,
+    address: Address,
+    bootstrapRecords: openArray[Record] = [],
+    localEnrFields: openArray[(string, seq[byte])] = [],
+    previousRecord = none[enr.Record]()):
+    discv5_protocol.Protocol =
   # set bucketIpLimit to allow bucket split
-  let tableIpLimits = TableIpLimits(tableIpLimit: 1000,  bucketIpLimit: 24)
+  let config = DiscoveryConfig.init(1000, 24, 5)
 
-  result = newProtocol(privKey,
-                       some(address.ip),
-                       some(address.port), some(address.port),
-                       bindPort = address.port,
-                       bootstrapRecords = bootstrapRecords,
-                       localEnrFields = localEnrFields,
-                       previousRecord = previousRecord,
-                       tableIpLimits = tableIpLimits,
-                       rng = rng)
+  let protocol = newProtocol(
+    privKey,
+    some(address.ip),
+    some(address.port), some(address.port),
+    bindPort = address.port,
+    bootstrapRecords = bootstrapRecords,
+    localEnrFields = localEnrFields,
+    previousRecord = previousRecord,
+    config = config,
+    rng = rng)
 
-  result.open()
+  protocol.open()
+
+  protocol
 
 proc nodeIdInNodes*(id: NodeId, nodes: openArray[Node]): bool =
   for n in nodes:

--- a/tests/utp/test_discv5_protocol.nim
+++ b/tests/utp/test_discv5_protocol.nim
@@ -14,31 +14,8 @@ import
   ../../eth/p2p/discoveryv5/[enr, node, routing_table],
   ../../eth/p2p/discoveryv5/protocol as discv5_protocol,
   ../../eth/utp/utp_discv5_protocol,
-  ../../eth/keys
-
-proc localAddress*(port: int): Address =
-  Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(port))
-
-proc initDiscoveryNode*(rng: ref BrHmacDrbgContext,
-    privKey: PrivateKey,
-    address: Address,
-    bootstrapRecords: openArray[Record] = [],
-    localEnrFields: openArray[(string, seq[byte])] = [],
-    previousRecord = none[enr.Record]()): discv5_protocol.Protocol =
-  # set bucketIpLimit to allow bucket split
-  let tableIpLimits = TableIpLimits(tableIpLimit: 1000,  bucketIpLimit: 24)
-
-  result = newProtocol(privKey,
-    some(address.ip),
-    some(address.port), some(address.port),
-    bindPort = address.port,
-    bootstrapRecords = bootstrapRecords,
-    localEnrFields = localEnrFields,
-    previousRecord = previousRecord,
-    tableIpLimits = tableIpLimits,
-    rng = rng)
-
-  result.open()
+  ../../eth/keys,
+  ../p2p/discv5_test_helper
 
 proc generateByteArray(rng: var BrHmacDrbgContext, length: int): seq[byte] =
   var bytes = newSeq[byte](length)


### PR DESCRIPTION
Adding `DiscoveryConfig` for more "tunable" parameters.
Can in the future for example add the Session cache size there and rate limits when they get added.

Could work with some builder system like libp2p switch instead, but I think I prefer to have a config specifically for values that default don't need to be touched (such builder could still be added for general parameters if deemed useful).
