### PR TITLE
temporary debugging extension of https://github.com/status-im/nim-eth…

### DIFF
--- a/eth/p2p.nim
+++ b/eth/p2p.nim
@@ -81,8 +81,8 @@ proc listeningAddress*(node: EthereumNode): ENode =
   node.toENode()
 
 proc startListening*(node: EthereumNode) {.raises: [CatchableError, Defect].} =
-  # TODO allow binding to specific IP / IPv6 / etc
-  let ta = initTAddress(IPv4_any(), node.address.tcpPort)
+  # Bind to un- or specific IP / IPv6 / etc
+  let ta = initTAddress(node.address.ip, node.address.tcpPort)
   if node.listeningServer == nil:
     node.listeningServer = createStreamServer(ta, processIncoming,
                                               {ReuseAddr},

--- a/eth/p2p/discovery.nim
+++ b/eth/p2p/discovery.nim
@@ -281,8 +281,8 @@ proc processClient(transp: DatagramTransport, raddr: TransportAddress):
     debug "Receive failed", exc = e.name, err = e.msg
 
 proc open*(d: DiscoveryProtocol) {.raises: [Defect, CatchableError].} =
-  # TODO allow binding to specific IP / IPv6 / etc
-  let ta = initTAddress(IPv4_any(), d.address.udpPort)
+  # Bind to un- or specific IP / IPv6 / etc
+  let ta = initTAddress(d.address.ip, d.address.udpPort)
   d.transp = newDatagramTransport(processClient, udata = d, local = ta)
 
 proc lookupRandom*(d: DiscoveryProtocol): Future[seq[Node]] =

--- a/tests/p2p/test_rlpx_thunk.json
+++ b/tests/p2p/test_rlpx_thunk.json
@@ -1,6 +1,6 @@
 {
-  "Invalid list when decoding for object": {
-    "payload": "03",
+  "Non-empty list when decoding for empty object": {
+    "payload": "03c20420",
     "error": "RlpTypeMismatch",
     "description": "Object parameters are expected to be encoded in an RLP list"
   },
@@ -49,10 +49,15 @@
     "error": "MalformedRlpError",
     "description": "listElem to error on invalid size encoding"
   },
-  "Listing elements when not a list": {
-    "payload": "010a",
+  "Listing single element list when having more entries": {
+    "payload": "01c20420",
     "error": "RlpTypeMismatch",
-    "description": "listElem to assert on not a list"
+    "description": "listElem to assert on not a single entry list"
+  },
+  "Listing single element list when having empty list": {
+    "payload": "01c0",
+    "error": "RlpTypeMismatch",
+    "description": "listElem to assert on not a single entry list"
   },
   "devp2p hello packet version 22 + additional list elements for EIP-8": {
     "payload": "00f87137916b6e6574682f76302e39312f706c616e39cdc5836574683dc6846d6f726b1682270fb840fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877c883666f6f836261720304"


### PR DESCRIPTION
…/pull/476

Mitigating RLP annoyance: NewPooledTransactionHashes

why:
  Talking to some Nethermind nodes is problematic because it sends 1k
  truncated NewPooledTransactionHashes datagrams. This is an attempt
  to fix that particular problem -- not meant to go in any main branch.