### PR TITLE
Change closing proc

### DIFF
--- a/tests/utp/test_utp_router.nim
+++ b/tests/utp/test_utp_router.nim
@@ -312,6 +312,8 @@ procSuite "Utp router unit tests":
 
     let connectResult = await connectFuture
 
+    await waitUntil(proc (): bool = router.len() == 0)
+    
     check:
       connectResult.isErr()
       connectResult.error().kind == ConnectionTimedOut


### PR DESCRIPTION
So as seen from CI run this pr does not solve Defect which is sometimes thrown from tests. But it fixes weird issue, that when both produced and consumer loops are canceled from consumer loops context only producer is cancelled and consumer is left hanging in weird state.

Most simple minimizer:
```
import 
  std/[deques, sequtils],
  chronos

type Foo = ref object
  q: AsyncQueue[int]
  pLoop: Future[void]
  cLoop: Future[void]

proc producerLoop(f: Foo): Future[void] {.async.} =
  try:
    var i = 0
    while true:
      await sleepAsync(milliseconds(500))
      echo "puting i = " & $i
      f.q.putNoWait(i)
      inc i
  except CancelledError as exc:
    echo "Producer Cancelled"
    raise exc


proc consumerLoop(f: Foo): Future[void] {.async.} =
  try:
    while true:
      let i = await f.q.get()
      echo "Hello i is " &  $i
      if i == 2:
        f.cLoop.cancel()
        f.pLoop.cancel()
  except CancelledError as exc:
    echo "Consumer Cancelled"
    raise exc


proc new(T: type Foo): T =
  let f = Foo(q: newAsyncQueue[int]())
  f.pLoop = producerLoop(f)
  f.cLoop = consumerLoop(f)
  return f

let s = Foo.new()

runForever()

```

Now I would expect to see in logs:
```
Consumer Cancelled
Producer Cancelled
```
but in only 
```
Producer Cancelled
```
shows up


tbh I am not sure if its intended behaviour for such case. Wdyt @kdeme ?




