### PR TITLE
disc: updateExternalIp()

### DIFF
--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -842,6 +842,20 @@ proc refreshLoop(d: Protocol) {.async.} =
   except CancelledError:
     trace "refreshLoop canceled"
 
+proc updateExternalIp*(d: Protocol, extIp: ValidIpAddress, udpPort: Port) =
+  let
+    previous = d.localNode.address
+    res = d.localNode.update(d.privateKey,
+      ip = some(extIp), udpPort = some(udpPort))
+
+  if res.isErr:
+    warn "Failed updating ENR with newly discovered external address",
+      previous, newExtIp = extIp, newUdpPort = udpPort, error = res.error
+  else:
+    discovery_enr_auto_update.inc()
+    info "Updated ENR with newly discovered external address",
+      previous, newExtIp = extIp, newUdpPort = udpPort, uri = toURI(d.localNode.record)
+
 proc ipMajorityLoop(d: Protocol) {.async.} =
   ## When `enrAutoUpdate` is enabled, the IP:port combination returned
   ## by the majority will be used to update the local ENR.
@@ -869,15 +883,7 @@ proc ipMajorityLoop(d: Protocol) {.async.} =
           let address = majority.get()
           let previous = d.localNode.address
           if d.enrAutoUpdate:
-            let res = d.localNode.update(d.privateKey,
-              ip = some(address.ip), udpPort = some(address.port))
-            if res.isErr:
-              warn "Failed updating ENR with newly discovered external address",
-                majority, previous, error = res.error
-            else:
-              discovery_enr_auto_update.inc()
-              info "Updated ENR with newly discovered external address",
-                majority, previous, uri = toURI(d.localNode.record)
+            d.updateExternalIp(address.ip, address.port)
           else:
             warn "Discovered new external address but ENR auto update is off",
               majority, previous


### PR DESCRIPTION
New public proc that can be used to inform the discovery subsystem about
a changed external IP (as reported by UPnP/NAT-PMP in some other module).