### PR TITLE
Handle the decodeAuthMessage error case separatly and log to trace 

### DIFF
--- a/eth/p2p/auth.nim
+++ b/eth/p2p/auth.nim
@@ -95,12 +95,11 @@ proc `xor`[N: static int](a, b: array[N, byte]): array[N, byte] =
 proc mapErrTo[T, E](r: Result[T, E], v: static AuthError): AuthResult[T] =
   r.mapErr(proc (e: E): AuthError = v)
 
-proc tryInit*(
+proc init*(
     T: type Handshake, rng: var BrHmacDrbgContext, host: KeyPair,
     flags: set[HandshakeFlag] = {Initiator},
-    version: uint8 = SupportedRlpxVersion): AuthResult[T] =
+    version: uint8 = SupportedRlpxVersion): T =
   ## Create new `Handshake` object.
-
   var
     initiatorNonce: Nonce
     responderNonce: Nonce
@@ -114,7 +113,7 @@ proc tryInit*(
     expectedLength = AuthMessageV4Length
     brHmacDrbgGenerate(rng, responderNonce)
 
-  return ok(T(
+  return T(
     version: version,
     flags: flags,
     host: host,
@@ -122,7 +121,7 @@ proc tryInit*(
     initiatorNonce: initiatorNonce,
     responderNonce: responderNonce,
     expectedLength: expectedLength
-  ))
+  )
 
 proc authMessagePreEIP8(h: var Handshake,
                         rng: var BrHmacDrbgContext,

--- a/eth/p2p/discovery.nim
+++ b/eth/p2p/discovery.nim
@@ -44,12 +44,14 @@ type
     cmdPong = 2
     cmdFindNode = 3
     cmdNeighbours = 4
+    cmdENRRequest = 5
+    cmdENRResponse = 6
 
   DiscProtocolError* = object of CatchableError
 
   DiscResult*[T] = Result[T, cstring]
 
-const MinListLen: array[CommandId, int] = [4, 3, 2, 2]
+const MinListLen: array[CommandId, int] = [4, 3, 2, 2, 1, 2]
 
 proc append*(w: var RlpWriter, a: IpAddress) =
   case a.family
@@ -267,6 +269,9 @@ proc receive*(d: DiscoveryProtocol, a: Address, msg: openArray[byte])
           d.recvNeighbours(node, payload)
         of cmdFindNode:
           d.recvFindNode(node, payload)
+        of cmdENRRequest, cmdENRResponse:
+          # TODO: Implement EIP-868
+          discard
       else:
         trace "Received msg already expired", cmdId, a
     else:

--- a/tests/p2p/test_auth.nim
+++ b/tests/p2p/test_auth.nim
@@ -221,7 +221,7 @@ suite "Ethereum P2P handshake test suite":
     proc newTestHandshake(flags: set[HandshakeFlag]): Handshake =
       if Initiator in flags:
         let pk = PrivateKey.fromHex(testValue("initiator_private_key"))[]
-        result = Handshake.tryInit(rng[], pk.toKeyPair(), flags)[]
+        result = Handshake.init(rng[], pk.toKeyPair(), flags)
 
         let epki = testValue("initiator_ephemeral_private_key")
         result.ephemeral = PrivateKey.fromHex(epki)[].toKeyPair()
@@ -229,7 +229,7 @@ suite "Ethereum P2P handshake test suite":
         result.initiatorNonce[0..^1] = nonce[0..^1]
       elif Responder in flags:
         let pk = PrivateKey.fromHex(testValue("receiver_private_key"))[]
-        result = Handshake.tryInit(rng[], pk.toKeyPair(), flags)[]
+        result = Handshake.init(rng[], pk.toKeyPair(), flags)
         let epkr = testValue("receiver_ephemeral_private_key")
         result.ephemeral = PrivateKey.fromHex(epkr)[].toKeyPair()
         let nonce = fromHex(stripSpaces(testValue("receiver_nonce")))
@@ -333,7 +333,7 @@ suite "Ethereum P2P handshake test suite":
     proc newTestHandshake(flags: set[HandshakeFlag]): Handshake =
       if Initiator in flags:
         let pk = PrivateKey.fromHex(testE8Value("initiator_private_key"))[]
-        result = Handshake.tryInit(rng[], pk.toKeyPair(), flags)[]
+        result = Handshake.init(rng[], pk.toKeyPair(), flags)
 
         let esec = testE8Value("initiator_ephemeral_private_key")
         result.ephemeral = PrivateKey.fromHex(esec)[].toKeyPair()
@@ -341,7 +341,7 @@ suite "Ethereum P2P handshake test suite":
         result.initiatorNonce[0..^1] = nonce[0..^1]
       elif Responder in flags:
         let pk = PrivateKey.fromHex(testE8Value("receiver_private_key"))[]
-        result = Handshake.tryInit(rng[], pk.toKeyPair(), flags)[]
+        result = Handshake.init(rng[], pk.toKeyPair(), flags)
 
         let esec = testE8Value("receiver_ephemeral_private_key")
         result.ephemeral = PrivateKey.fromHex(esec)[].toKeyPair()

--- a/tests/p2p/test_crypt.nim
+++ b/tests/p2p/test_crypt.nim
@@ -95,14 +95,14 @@ suite "Ethereum RLPx encryption/decryption test suite":
   proc newTestHandshake(flags: set[HandshakeFlag]): Handshake =
     if Initiator in flags:
       let pk = PrivateKey.fromHex(testValue("initiator_private_key"))[]
-      result = Handshake.tryInit(rng[], pk.toKeyPair(), flags)[]
+      result = Handshake.init(rng[], pk.toKeyPair(), flags)
       let epki = testValue("initiator_ephemeral_private_key")
       result.ephemeral = PrivateKey.fromHex(epki)[].toKeyPair()
       let nonce = fromHex(stripSpaces(testValue("initiator_nonce")))
       result.initiatorNonce[0..^1] = nonce[0..^1]
     elif Responder in flags:
       let pk = PrivateKey.fromHex(testValue("receiver_private_key"))[]
-      result = Handshake.tryInit(rng[], pk.toKeyPair(), flags)[]
+      result = Handshake.init(rng[], pk.toKeyPair(), flags)
       let epkr = testValue("receiver_ephemeral_private_key")
       result.ephemeral = PrivateKey.fromHex(epkr)[].toKeyPair()
       let nonce = fromHex(stripSpaces(testValue("receiver_nonce")))


### PR DESCRIPTION
It was reported by @jakubgs that our nimbus-eth1 node running on Goerli is mostly writing `Unexpected exception in rlpxAccept         topics="rlpx" tid=268070 file=rlpx.nim:1404 exc=ResultError err="auth: ECIES encryption/decryption error"` to the logs.

Set to trace now as this is likely to be mostly garbage data on the TCP port.