### PR TITLE
Dedicated RLP reader for `DisconnectionReason`

### DIFF
--- a/eth/p2p/private/p2p_types.nim
+++ b/eth/p2p/private/p2p_types.nim
@@ -214,8 +214,11 @@ proc to*(n: int; T: type DisconnectionReason): Result[T,string] =
   err(pfx & $n & ")")
 
 proc read*(rlp: var Rlp; T: type DisconnectionReason): T =
-  ## Rlp mixin: `DisconnectionReason` parser
+  ## Rlp mixin: `DisconnectionReason` parser. An enum parser is also provided
+  ## by the RLP package albeit with a different error message. A dedicated
+  ## parser and error message generator `to()` is handy here as there is no
+  ## default solution for decoding `array[1,DisconnectionReason])`.
   let rc = rlp.read(int).to(T)
   if rc.isErr:
-    raise newException(MalformedRlpError, rc.error)
+    raise newException(RlpTypeMismatch, rc.error)
   rc.value

--- a/eth/p2p/private/p2p_types.nim
+++ b/eth/p2p/private/p2p_types.nim
@@ -201,24 +201,3 @@ func `==`*(a, b: NetworkId): bool {.inline.} =
 
 func `$`*(x: NetworkId): string {.inline.} =
   `$`(uint(x))
-
-proc to*(n: int; T: type DisconnectionReason): Result[T,string] =
-  ## Savely map integer argument to `DisconnectionReason` enum type. Return
-  ## an error text if that fails.
-  if T.low.int <= n and n <= T.high.int:
-    return ok(n.T)
-  const
-    pfx = "Disconnect reason code out of bounds " &
-      $DisconnectionReason.low.int & ".." & $DisconnectionReason.high.int &
-      " (got: "
-  err(pfx & $n & ")")
-
-proc read*(rlp: var Rlp; T: type DisconnectionReason): T =
-  ## Rlp mixin: `DisconnectionReason` parser. An enum parser is also provided
-  ## by the RLP package albeit with a different error message. A dedicated
-  ## parser and error message generator `to()` is handy here as there is no
-  ## default solution for decoding `array[1,DisconnectionReason])`.
-  let rc = rlp.read(int).to(T)
-  if rc.isErr:
-    raise newException(RlpTypeMismatch, rc.error)
-  rc.value

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -61,7 +61,7 @@ proc read[T: DisconnectionReason](rlp: var Rlp; W: type array[1,T]): T
   # fixed-size array (aka blob), see function `eth/rlp.readImpl()`.
   let rc = rlp.read(array[1,int])[0].to(T)
   if rc.isErr:
-    raise newException(MalformedRlpError, rc.error)
+    raise newException(RlpTypeMismatch, rc.error)
   rc.value
 
 proc read(rlp: var Rlp; T: type DisconnectionReasonList): T

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -54,16 +54,6 @@ type
   DisconnectionReasonList = object
     value: DisconnectionReason
 
-proc read[T: DisconnectionReason](rlp: var Rlp; W: type array[1,T]): T
-    {.gcsafe, raises: [RlpError, Defect].} =
-  ## Rlp mixin: `array[1,DisconnectionReason]` parser
-  # Need to parse for an `int` type as a `byte` (or a `char`) would expect a
-  # fixed-size array (aka blob), see function `eth/rlp.readImpl()`.
-  let rc = rlp.read(array[1,int])[0].to(T)
-  if rc.isErr:
-    raise newException(RlpTypeMismatch, rc.error)
-  rc.value
-
 proc read(rlp: var Rlp; T: type DisconnectionReasonList): T
     {.gcsafe, raises: [RlpError, Defect].} =
   ## Rlp mixin: `DisconnectionReasonList` parser
@@ -73,7 +63,7 @@ proc read(rlp: var Rlp; T: type DisconnectionReasonList): T
     # accepts lists with at least one item. The array expression wants
     # exactly one item.
     return DisconnectionReasonList(
-      value: rlp.read(array[1,DisconnectionReason]))
+      value: rlp.read(array[1,DisconnectionReason])[0])
 
   # Also accepted: a single byte reason code. Is is typically used
   # by variants of the reference implementation `Geth`
@@ -87,7 +77,7 @@ proc read(rlp: var Rlp; T: type DisconnectionReasonList): T
   if subList.isList:
     # Ditto, see above.
     return DisconnectionReasonList(
-      value: subList.read(array[1,DisconnectionReason]))
+      value: subList.read(array[1,DisconnectionReason])[0])
 
   raise newException(RlpTypeMismatch, "Single entry list expected")
 

--- a/tests/p2p/test_rlpx_thunk.json
+++ b/tests/p2p/test_rlpx_thunk.json
@@ -59,6 +59,11 @@
     "error": "RlpTypeMismatch",
     "description": "listElem to assert on not a single entry list"
   },
+  "Listing single element list with entry off enum range": {
+    "payload": "01c116",
+    "error": "MalformedRlpError",
+    "description": "Disconnect reason code out of bounds 0..16 (got: 22)"
+  },
   "devp2p hello packet version 22 + additional list elements for EIP-8": {
     "payload": "00f87137916b6e6574682f76302e39312f706c616e39cdc5836574683dc6846d6f726b1682270fb840fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877c883666f6f836261720304"
   }

--- a/tests/p2p/test_rlpx_thunk.json
+++ b/tests/p2p/test_rlpx_thunk.json
@@ -61,7 +61,12 @@
   },
   "Listing single element list with entry off enum range": {
     "payload": "01c116",
-    "error": "MalformedRlpError",
+    "error": "RlpTypeMismatch",
+    "description": "Disconnect reason code out of bounds 0..16 (got: 22)"
+  },
+  "Listing single element off enum range": {
+    "payload": "0116",
+    "error": "RlpTypeMismatch",
     "description": "Disconnect reason code out of bounds 0..16 (got: 22)"
   },
   "devp2p hello packet version 22 + additional list elements for EIP-8": {


### PR DESCRIPTION
Currently, a program communicating via RLPX will crash when receiving out of bound reason codes disconnect message.

This happens in the RLP message parser. Out of bound value assignments to an enum causes a `RangeError`defect and consequently the program to terminate. This `RangeError` is avoided here and a catchable error raised.