### PR TITLE
make some safe cstring conversions explicit

### DIFF
--- a/eth/db/kvstore_sqlite3.nim
+++ b/eth/db/kvstore_sqlite3.nim
@@ -522,7 +522,7 @@ proc init*(
     except OSError, IOError:
       return err("sqlite: cannot create database directory")
 
-  checkErr sqlite3_open_v2(name, addr env.val, flags.cint, nil)
+  checkErr sqlite3_open_v2(cstring name, addr env.val, flags.cint, nil)
 
   template checkWalPragmaResult(journalModePragma: ptr sqlite3_stmt) =
     if (let x = sqlite3_step(journalModePragma); x != SQLITE_ROW):
@@ -533,7 +533,7 @@ proc init*(
       discard sqlite3_finalize(journalModePragma)
       return err($sqlite3_errstr(x))
 
-    if (let x = sqlite3_column_text(journalModePragma, 0);
+    if (let x = cstring sqlite3_column_text(journalModePragma, 0);
         x != "memory" and x != "wal"):
       discard sqlite3_finalize(journalModePragma)
       return err("Invalid pragma result: " & $x)


### PR DESCRIPTION
These are Nim 1.6 warnings otherwise.

They both relate to direct interactions with the C ABI of sqlite3. 

The `sqlite3_open_v2` one genuinely takes the `string` `name` and passes it as a `cstring` to `sqlite3_open_v2`, but it never escapes the Nim scope it's live in, so it's safe.

`sqlite3_column_text` is defined as:
```nim
proc sqlite3_column_text*(a1: ptr sqlite3_stmt, iCol: cint): ptr cuchar {.impsqlite3C.}
```
And `ptr cuchar` is compatible with `cstring`.