### PR TITLE
Change info log to debug in uTP router connect

### DIFF
--- a/eth/utp/utp_router.nim
+++ b/eth/utp/utp_router.nim
@@ -261,7 +261,7 @@ proc innerConnect[A](s: UtpSocket[A]): Future[ConnectionResult[A]] {.async.} =
       raise exc
 
 proc connect[A](s: UtpSocket[A]): Future[ConnectionResult[A]] =
-  info "Initiating connection", dst = s.socketKey
+  debug "Initiating connection", dst = s.socketKey
 
   # Create inner future, to make sure we are installing cancelCallback
   # on whole connection future, and not only part of it


### PR DESCRIPTION
These uTP logs are common and should be under debug,
else they spam on application level.
Probably accidentally changed in https://github.com/status-im/nim-eth/pull/508