### PR TITLE
update from deprecated to supported Ubuntu and macOS GitHub Actions CI images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-18.04
+            builder: ubuntu-20.04
             shell: bash
           - target:
               os: macos
-            builder: macos-10.15
+            builder: macos-11
             shell: bash
           - target:
               os: windows


### PR DESCRIPTION
macOS 10.15 to 11: https://github.com/actions/runner-images/issues/5583
Ubuntu 18.04 to 20.04: https://github.com/actions/runner-images/issues/6002