### PR TITLE
fix discovery v4 ping pong handler

### DIFF
--- a/eth/p2p/discovery.nim
+++ b/eth/p2p/discovery.nim
@@ -39,14 +39,6 @@ type
     bindIp: IpAddress
     bindPort: Port
 
-  CommandId = enum
-    cmdPing = 1
-    cmdPong = 2
-    cmdFindNode = 3
-    cmdNeighbours = 4
-    cmdENRRequest = 5
-    cmdENRResponse = 6
-
   DiscProtocolError* = object of CatchableError
 
   DiscResult*[T] = Result[T, cstring]


### PR DESCRIPTION
The goal of this PR is to fix missing additional ping in [ping handler](https://github.com/ethereum/devp2p/blob/master/discv4.md#ping-packet-0x01). 

The spec says after recv ping, should respond with pong and additional ping if last pong received exceeds BOND_EXPIRATION(12h). This PR add the missing additional ping.

The additional ping also paired with a pong matcher to prevent invalid pong hash amplification attack. 

With this PR, the disc v4 test suite in hive is cleared.
    