### PR TITLE
Quickfix for a potential double future completion in rlpx

### DIFF
--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -148,8 +148,10 @@ proc requestResolver[MsgType](msg: pointer, future: FutureBase) {.gcsafe.} =
 
 proc linkSendFailureToReqFuture[S, R](sendFut: Future[S], resFut: Future[R]) =
   sendFut.addCallback() do (arg: pointer):
-    if not sendFut.error.isNil:
-      resFut.fail(sendFut.error)
+    # Avoiding potentially double future completions
+    if not resFut.finished:
+      if sendFut.failed:
+        resFut.fail(sendFut.error)
 
 proc messagePrinter[MsgType](msg: pointer): string {.gcsafe.} =
   result = ""


### PR DESCRIPTION
Attempt to quick fix crash reported by @mjfh 

```
TRC 2022-10-06 04:44:57.621+01:00 Bonded with candidates                     topics="discovery" tid=757799 file=kademlia.nim:460 count=12
TRC 2022-10-06 04:44:57.621+01:00 Bonded with candidates                     topics="discovery" tid=757799 file=kademlia.nim:460 count=9
TRC 2022-10-06 04:44:57.621+01:00 Bonded with candidates                     topics="discovery" tid=757799 file=kademlia.nim:460 count=14
TRC 2022-10-06 04:44:57.622+01:00 Bonded with candidates                     topics="discovery" tid=757799 file=kademlia.nim:460 count=14
TRC 2022-10-06 04:44:57.622+01:00 Connection dropped in rlpxConnect          topics="rlpx" tid=757799 file=rlpx.nim:1295 remote=Node[52.221.218.166:30303]
TRC 2022-10-06 04:44:57.622+01:00 Connection dropped in rlpxAccept           topics="rlpx" tid=757799 file=rlpx.nim:1412 remote=Node[local]
TRC 2022-10-06 04:44:57.622+01:00 Received msg already expired               topics="discovery" tid=757799 file=discovery.nim:268 cmdId=cmdFindNode a=88.198.27.13:30303:30303
TRC 2022-10-06 04:44:57.623+01:00 Connection dropped in rlpxAccept           topics="rlpx" tid=757799 file=rlpx.nim:1412 remote=Node[local]
TRC 2022-10-06 04:44:57.623+01:00 Received msg already expired               topics="discovery" tid=757799 file=discovery.nim:268 cmdId=cmdFindNode a=3.88.141.173:30303:30303
TRC 2022-10-06 04:44:57.623+01:00 Node lookup; querying                      topics="discovery" tid=757799 file=kademlia.nim:532 nodesToAsk="@[Node[65.108.79.57:30303], Node[34.229.181.187:30303], Node[152.32.168.35:30303]]"
TRC 2022-10-06 04:44:57.623+01:00 >>> find_node to                           topics="discovery" tid=757799 file=discovery.nim:128 n=Node[65.108.79.57:30303]
TRC 2022-10-06 04:44:57.623+01:00 >>> find_node to                           topics="discovery" tid=757799 file=discovery.nim:128 n=Node[34.229.181.187:30303]
TRC 2022-10-06 04:44:57.629+01:00 >>> find_node to                           topics="discovery" tid=757799 file=discovery.nim:128 n=Node[152.32.168.35:30303]
TRC 2022-10-06 04:44:57.629+01:00 Kademlia lookup finished                   topics="discovery" tid=757799 file=kademlia.nim:550 target=b0625fb951cd0a612eb58f678956d84baeb5d9d43b0592c23440ddeb4ec2bea4 closest="@[Node[35.77.72.83:30303], Node[65.21.74.94:30303], Node[35.230.162.124:30422], Node[15.204.197.98:1234], Node[51.75.68.189:39797], Node[188.34.152.212:30300], Node[35.92.75.103:30303], Node[167.235.4.186:30303], Node[18.222.112.193:29888], Node[108.61.184.51:39797], Node[45.63.82.176:30311], Node[157.230.10.229:30300], Node[161.97.126.20:39797], Node[38.242.132.89:30300], Node[172.99.190.233:33011], Node[15.161.168.112:30303]]"
TRC 2022-10-06 04:44:57.629+01:00 Node lookup; querying                      topics="discovery" tid=757799 file=kademlia.nim:532 nodesToAsk=@[Node[194.163.187.15:30300]]
TRC 2022-10-06 04:44:57.629+01:00 >>> find_node to                           topics="discovery" tid=757799 file=discovery.nim:128 n=Node[194.163.187.15:30300]
~/nimbus-eth1/nimbus/p2p/chain/chain_desc.nim(506) main
~/nimbus-eth1/nimbus/p2p/chain/chain_desc.nim(499) NimMain
~/nimbus-eth1/nimbus/nimbus.nim(432) process
~/nimbus-eth1/vendor/nim-chronos/chronos/asyncloop.nim(288) poll
Error: unhandled exception: An attempt was made to complete a Future more than once. Details:
  Future ID: 11264402
  Creation location:
    p2p_protocol_dsl.nim(153)    [unspecified]
  First completion location:
    rlpx.nim(121)    [unspecified]
  Second completion location:
    rlpx.nim(152)    [unspecified]

 [FutureDefect]
```

I did not further investigate if this `resFut` finished with a fail or not (which could/would indicate the code to be conceptually flawed) as I would need to be able to reproduce the issue or dig into understanding the full possible flow of this code.