### PR TITLE
Remove unused async_utils import from discv5

### DIFF
--- a/doc/discv5.md
+++ b/doc/discv5.md
@@ -8,8 +8,8 @@ The implemented specification is Protocol version v5.1.
 This implementation does not support "Topic Advertisement" yet as this part of
 the specification is not complete.
 
-The implementation relies on other modules in the `eth` package, namely: `keys`,
-`rlp` and `async_utils`.
+The implementation depends on other modules in the `eth` package, namely: `keys`
+and `rlp`.
 
 ## How to use
 
@@ -53,7 +53,7 @@ Now within the application, manual queries or lookups can be done, for which
 the discovered nodes can be used. Nodes discovered during this process will be
 attempted to be added to the routing table. One can use the `query`, `queryRandom`
 or `lookup` calls for this. `randomNodes` can also be used to find nodes,
-but this will only look into the current routing table and not actively 
+but this will only look into the current routing table and not actively
 search for nodes on the network.
 
 Or, one can decide not to run `d.start()` and do this manually within its

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -84,7 +84,7 @@ import
   std/[tables, sets, options, math, sequtils, algorithm],
   stew/shims/net as stewNet, json_serialization/std/net,
   stew/[endians2, results], chronicles, chronos, stint, metrics,
-  ".."/../[rlp, keys, async_utils],
+  ".."/../[rlp, keys],
   "."/[messages, encoding, node, routing_table, enr, random2, sessions, ip_vote,
     nodes_verification]
 
@@ -836,7 +836,7 @@ proc revalidateLoop(d: Protocol) {.async.} =
       await sleepAsync(milliseconds(d.rng[].rand(revalidateMax)))
       let n = d.routingTable.nodeToRevalidate()
       if not n.isNil:
-        traceAsyncErrors d.revalidateNode(n)
+        asyncSpawn d.revalidateNode(n)
   except CancelledError:
     trace "revalidateLoop canceled"
 


### PR DESCRIPTION
It was never intended for `revalidateNode` to possibly raise so this shouldn't be needed.