### PR TITLE
allow EhereumNode network state override

### DIFF
--- a/tests/p2p/test_protocol_handlers.nim
+++ b/tests/p2p/test_protocol_handlers.nim
@@ -86,3 +86,9 @@ suite "Testing protocol handlers":
       peer.isNil == true
       # To check if the disconnection handler did not run
       node1.protocolState(hah).count == 0
+
+  test "Override network state":
+    let rng = newRng()
+    var node = setupTestNode(rng, hah)
+    node.addCapability(hah, network())
+    node.replaceNetworkState(hah, network())

--- a/tests/p2p/test_protocol_handlers.nim
+++ b/tests/p2p/test_protocol_handlers.nim
@@ -90,5 +90,7 @@ suite "Testing protocol handlers":
   test "Override network state":
     let rng = newRng()
     var node = setupTestNode(rng, hah)
-    node.addCapability(hah, network())
-    node.replaceNetworkState(hah, network())
+    node.addCapability(hah, network(count: 3))
+    check node.protocolState(hah).count == 3
+    node.replaceNetworkState(hah, network(count: 7))
+    check node.protocolState(hah).count == 7


### PR DESCRIPTION
This is useful in situation where we are using interface-like for protocol network state and then have multiple implementation. e.g. Eth67 can switch to post merge protocol handler during _runtime_ from pre merge protocol handler. or another scenario, switching between sync algorithm.

I know we can also modify  networkstate using `node.protocolState(Eth).blabla = something`, but this changes reduce indirection access.