### PR TITLE
Add own node checks before sending ping

### DIFF
--- a/eth/p2p/kademlia.nim
+++ b/eth/p2p/kademlia.nim
@@ -443,7 +443,8 @@ proc findNode*(k: KademliaProtocol, nodesSeen: ref HashSet[Node],
 
     var bondedNodes: seq[Future[bool]] = @[]
     for node in candidates:
-      bondedNodes.add(k.bond(node))
+      if node != k.thisNode:
+        bondedNodes.add(k.bond(node))
 
     await allFutures(bondedNodes)
 
@@ -602,22 +603,25 @@ proc recvPing*(k: KademliaProtocol, n: Node, msgHash: any)
   k.wire.sendPong(n, msgHash)
 
   if getTime() - k.lastPongReceived(n) > BOND_EXPIRATION:
-    let pingId = pingId(n, k.ping(n))
+    # TODO: It is strange that this would occur, as it means our own node would
+    # have pinged us which should have caused an assert in the first place.
+    if n != k.thisNode:
+      let pingId = pingId(n, k.ping(n))
 
-    let fut = if pingId in k.pongFutures:
-                k.pongFutures[pingId]
-              else:
-                k.waitPong(n, pingId)
+      let fut = if pingId in k.pongFutures:
+                  k.pongFutures[pingId]
+                else:
+                  k.waitPong(n, pingId)
 
-    let cb = proc(data: pointer) {.gcsafe.} =
-               # fut.read == true if pingid exists
-               try:
-                 if fut.completed and fut.read:
-                   k.updateRoutingTable(n)
-               except CatchableError as ex:
-                 error "recvPing:WaitPong exception", msg=ex.msg
+      let cb = proc(data: pointer) {.gcsafe.} =
+                # fut.read == true if pingid exists
+                try:
+                  if fut.completed and fut.read:
+                    k.updateRoutingTable(n)
+                except CatchableError as ex:
+                  error "recvPing:WaitPong exception", msg=ex.msg
 
-    fut.addCallback cb
+      fut.addCallback cb
   else:
     k.updateRoutingTable(n)
 


### PR DESCRIPTION
Seems there are two occasions possible where we try to ping the own local node which causes an assert

- One via the bonding
- One via a received ping, which is strange in the first place but notice in a stack trace

Issue hit/reported by @mjfh, traces:
```
TRC 2022-10-24 13:29:56.061+01:00 Bonding to peer                            topics="discovery" tid=918631 file=kademlia.nim:476 n=Node[144.76.71.80:30137]
TRC 2022-10-24 13:29:56.062+01:00 >>> ping                                   topics="discovery" tid=918631 file=discovery.nim:114 n=Node[144.76.71.80:30137]
TRC 2022-10-24 13:29:56.062+01:00 Bonding to peer                            topics="discovery" tid=918631 file=kademlia.nim:476 n=Node[54.173.228.252:30303]
TRC 2022-10-24 13:29:56.062+01:00 >>> ping                                   topics="discovery" tid=918631 file=discovery.nim:114 n=Node[54.173.228.252:30303]
TRC 2022-10-24 13:29:56.062+01:00 <<< ping from                              topics="discovery" tid=918631 file=kademlia.nim:601 n=Node[93.95.229.214:30901]
TRC 2022-10-24 13:29:56.062+01:00 >>> pong                                   topics="discovery" tid=918631 file=discovery.nim:120 n=Node[93.95.229.214:30901]
./nimbus-eth1/nimbus/sync/protocol/eth/eth_types.nim(367) main
./nimbus-eth1/nimbus/sync/protocol/eth/eth_types.nim(360) NimMain
./nimbus-eth1/nimbus/nimbus.nim(434) process
./nimbus-eth1/vendor/nim-chronos/chronos/asyncloop.nim(295) poll
./nimbus-eth1/vendor/nim-chronos/chronos/transports/datagram.nim(450) readDatagramLoop
./nimbus-eth1/vendor/nim-eth/eth/p2p/discovery.nim(275) processClient
./nimbus-eth1/vendor/nim-chronos/chronos/asyncfutures2.nim(369) futureContinue
./nimbus-eth1/vendor/nim-eth/eth/p2p/discovery.nim(284) processClient
./nimbus-eth1/vendor/nim-eth/eth/p2p/discovery.nim(257) receive
./nimbus-eth1/vendor/nim-eth/eth/p2p/discovery.nim(176) recvPing
./nimbus-eth1/vendor/nim-eth/eth/p2p/kademlia.nim(605) recvPing
./nimbus-eth1/vendor/nim-eth/eth/p2p/kademlia.nim(383) ping
./nimbus-eth1/vendor/nimbus-build-system/vendor/Nim/lib/system/assertions.nim(29) failedAssertImpl
./nimbus-eth1/vendor/nimbus-build-system/vendor/Nim/lib/system/assertions.nim(22) raiseAssert
./nimbus-eth1/vendor/nimbus-build-system/vendor/Nim/lib/system/fatal.nim(49) sysFatal
[[reraised from:
./nimbus-eth1/nimbus/sync/protocol/eth/eth_types.nim(367) main
./nimbus-eth1/nimbus/sync/protocol/eth/eth_types.nim(360) NimMain
./nimbus-eth1/nimbus/nimbus.nim(434) process
./nimbus-eth1/vendor/nim-chronos/chronos/asyncloop.nim(295) poll
./nimbus-eth1/vendor/nim-chronos/chronos/transports/datagram.nim(450) readDatagramLoop
./nimbus-eth1/vendor/nim-eth/eth/p2p/discovery.nim(275) processClient
./nimbus-eth1/vendor/nim-chronos/chronos/asyncfutures2.nim(391) futureContinue
]]
Error: unhandled exception: ./nimbus-eth1/vendor/nim-eth/eth/p2p/kademlia.nim(383, 11) `
not (n == k.thisNode)`  [AssertionError]
```