### PR TITLE
Default compile all tests and binaries with TRACE log level

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -24,25 +24,28 @@ let styleCheckStyle =
   else:
     "error"
 
-let commonParams = " --verbosity:0 --hints:off --skipUserCfg:on " &
-  "--warning[ObservableStores]:off --styleCheck:usages --styleCheck:" &
-  styleCheckStyle & " " & getEnv("NIMFLAGS") & " "
+let commonParams =
+  " --skipUserCfg:on" &
+  " --verbosity:0 --hints:off" &
+  " --warning[ObservableStores]:off " &
+  " --styleCheck:usages --styleCheck:" & styleCheckStyle &
+  " " & getEnv("NIMFLAGS") &
+  " -d:chronosStrictException" &
+  " -d:chronicles_log_level=TRACE"
 
-proc runTest(path: string, release: bool = true, chronosStrict = true) =
+proc runTest(path: string, release: bool = true) =
   echo "\nBuilding and running: ", path
-  let releaseMode = if release: "-d:release" else: ""
-  let chronosMode =
-    if chronosStrict: "-d:chronosStrictException" else: ""
-  exec "nim c -r " & releaseMode & " " & chronosMode &
-    " -d:chronicles_log_level=ERROR " & commonParams & path
+  let releaseMode = if release: " -d:release" else: ""
+
+  exec "nim c -r" &
+    releaseMode & commonParams & " " & path
   rmFile path
 
 proc buildBinary(path: string) =
   echo "\nBuilding: ", path
-  exec "nim c -d:release -d:chronosStrictException " &
-    "-d:chronicles_log_level=TRACE --threads:on " & commonParams &
-    "--warning[CaseTransition]:off --warning[ObservableStores]:off " &
-    path
+  exec "nim c -d:release" & commonParams &
+    " --warning[CaseTransition]:off" &
+    " " & path
 
 task test_keyfile, "Run keyfile tests":
   runTest("tests/keyfile/all_tests")

--- a/eth/p2p/discoveryv5/dcli.nim.cfg
+++ b/eth/p2p/discoveryv5/dcli.nim.cfg
@@ -1,1 +1,3 @@
+--threads:on
+
 -d:"chronicles_runtime_filtering=on"

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -3,6 +3,8 @@
 # rocksdb init does this type of assignment
 --define:nimOldCaseObjects
 
+-d:"chronicles_runtime_filtering=on"
+
 # Avoid some rare stack corruption while using exceptions with a SEH-enabled
 # toolchain: https://github.com/status-im/nimbus-eth2/issues/3121
 @if windows and not vcc:

--- a/tests/p2p/test_discovery.nim
+++ b/tests/p2p/test_discovery.nim
@@ -12,7 +12,8 @@
 import
   std/sequtils,
   chronos, stew/byteutils, nimcrypto, testutils/unittests,
-  ../../eth/keys, ../../eth/p2p/[discovery, kademlia, enode]
+  ../../eth/keys, ../../eth/p2p/[discovery, kademlia, enode],
+  ../stubloglevel
 
 proc localAddress(port: int): Address =
   let port = Port(port)

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -8,6 +8,7 @@ import
   ../../eth/p2p/discoveryv5/[enr, node, routing_table, encoding, sessions,
     messages, nodes_verification],
   ../../eth/p2p/discoveryv5/protocol as discv5_protocol,
+  ../stubloglevel,
   ./discv5_test_helper
 
 suite "Discovery v5 Tests":

--- a/tests/p2p/test_discoveryv5_encoding.nim
+++ b/tests/p2p/test_discoveryv5_encoding.nim
@@ -5,7 +5,8 @@ import
   unittest2,
   stint, stew/byteutils, stew/shims/net,
   ../../eth/keys,
-  ../../eth/p2p/discoveryv5/[messages_encoding, encoding, enr, node, sessions]
+  ../../eth/p2p/discoveryv5/[messages_encoding, encoding, enr, node, sessions],
+  ../stubloglevel
 
 let rng = newRng()
 

--- a/tests/p2p/test_protocol_handlers.nim
+++ b/tests/p2p/test_protocol_handlers.nim
@@ -13,6 +13,7 @@ import
   std/tables,
   chronos, testutils/unittests,
   ../../eth/p2p,
+  ../stubloglevel,
   ./p2p_test_helper
 
 type

--- a/tests/p2p/test_rlpx_thunk.nim
+++ b/tests/p2p/test_rlpx_thunk.nim
@@ -5,6 +5,7 @@ import
   unittest2, stint,
   chronos, stew/byteutils,
   ../../eth/[p2p, common],
+  ../stubloglevel,
   ./p2p_test_helper,
   ./eth_protocol
 

--- a/tests/stubloglevel.nim
+++ b/tests/stubloglevel.nim
@@ -1,0 +1,6 @@
+import chronicles
+
+{.used.}
+
+when defined(chronicles_runtime_filtering):
+  setLogLevel(ERROR)

--- a/tests/utp/test_buffer.nim
+++ b/tests/utp/test_buffer.nim
@@ -11,7 +11,6 @@ import
   unittest2,
   ../../eth/utp/growable_buffer
 
-
 type TestObj = object
   foo: string
 
@@ -24,13 +23,13 @@ suite "Utp ring buffer":
 
   test "Buffer should be initialised to next power of two":
     var elemsCounter = 0
-    let buff = GrowableCircularBuffer[int].init(size = 17) 
+    let buff = GrowableCircularBuffer[int].init(size = 17)
     check:
       buff.len() == 32
 
     for i in buff.items:
-      inc elemsCounter  
-    
+      inc elemsCounter
+
     check:
       elemsCounter == 32
 
@@ -166,7 +165,7 @@ suite "Utp ring buffer":
       buff.get(2) == some(2)
       buff.get(3) == some(3)
       buff.len() == 8
-    
+
     var elemsCounter = 0
     for elem in buff.items:
       inc elemsCounter

--- a/tests/utp/test_discv5_protocol.nim
+++ b/tests/utp/test_discv5_protocol.nim
@@ -16,7 +16,8 @@ import
   ../../eth/utp/utp_discv5_protocol,
   ../../eth/keys,
   ../../eth/utp/utp_router as rt,
-  ../p2p/discv5_test_helper
+  ../p2p/discv5_test_helper,
+  ../stubloglevel
 
 procSuite "Utp protocol over discovery v5 tests":
   let rng = newRng()

--- a/tests/utp/test_packets.nim
+++ b/tests/utp/test_packets.nim
@@ -12,11 +12,8 @@ import
   ../../eth/utp/packets,
   ../../eth/keys
 
-suite "Utp packets encoding/decoding":
-
-  let rng = newRng()
-
-  test "Encode/decode syn packet":
+suite "uTP Packet Encoding":
+  test "Encode/decode SYN packet":
     let synPacket = synPacket(5, 10, 20)
     let encoded = encodePacket(synPacket)
     let decoded = decodePacket(encoded)
@@ -30,7 +27,7 @@ suite "Utp packets encoding/decoding":
     check:
       synPacketDec == synPacket
 
-  test "Encode/decode fin packet":
+  test "Encode/decode FIN packet":
     let finPacket = finPacket(5, 10, 20, 30, 40)
     let encoded = encodePacket(finPacket)
     let decoded = decodePacket(encoded)
@@ -44,7 +41,7 @@ suite "Utp packets encoding/decoding":
     check:
       finPacketDec == finPacket
 
-  test "Encode/decode reset packet":
+  test "Encode/decode RESET packet":
     let resetPacket = resetPacket(5, 10, 20)
     let encoded = encodePacket(resetPacket)
     let decoded = decodePacket(encoded)
@@ -58,7 +55,7 @@ suite "Utp packets encoding/decoding":
     check:
       resetPacketDec == resetPacket
 
-  test "Encode/decode ack packet without extensions":
+  test "Encode/decode ACK packet: without extensions":
     let ackPacket = ackPacket(5, 10, 20, 30, 40)
     let encoded = encodePacket(ackPacket)
     let decoded = decodePacket(encoded)
@@ -72,7 +69,7 @@ suite "Utp packets encoding/decoding":
     check:
       ackPacketDec == ackPacket
 
-  test "Encode/decode ack packet with extensions":
+  test "Encode/decode ACK packet: with extensions":
     let bitMask: array[4, byte] = [1'u8, 2, 3, 4]
     let ackPacket = ackPacket(5, 10, 20, 30, 40, some(bitMask))
     let encoded = encodePacket(ackPacket)
@@ -117,7 +114,6 @@ suite "Utp packets encoding/decoding":
       err3.isErr()
       err3.error() == "Packet too short for selective ack extension"
 
-
     var encoded4 = encodePacket(ackPacket)
     # change change extension field to something other than 0 or 1
     encoded4[1] = 2
@@ -126,11 +122,11 @@ suite "Utp packets encoding/decoding":
       err4.isErr()
       err4.error() == "Invalid extension type"
 
-  test "Decode state packet":
+  test "Decode STATE packet":
     # Packet obtained by interaction with c reference implementation
     let pack: array[20, uint8] = [
-            0x21'u8, 0x0, 0x15, 0x72, 0x00, 0xBA, 0x4D, 0x71, 0x0, 0x0, 0x0, 0x0, 0x0, 0x10, 0x0,
-            0x0, 0x41, 0xA7, 0x00, 0x01]
+            0x21'u8, 0x0, 0x15, 0x72, 0x00, 0xBA, 0x4D, 0x71, 0x0, 0x0,
+            0x0, 0x0, 0x0, 0x10, 0x0, 0x0, 0x41, 0xA7, 0x00, 0x01]
     let decoded = decodePacket(pack)
 
     check:

--- a/tests/utp/test_protocol.nim
+++ b/tests/utp/test_protocol.nim
@@ -13,7 +13,8 @@ import
   ./test_utils,
   ../../eth/utp/utp_router as rt,
   ../../eth/utp/utp_protocol,
-  ../../eth/keys
+  ../../eth/keys,
+  ../stubloglevel
 
 proc setAcceptedCallback(event: AsyncEvent): AcceptConnectionCallback[TransportAddress] =
   return (

--- a/tests/utp/test_protocol_integration.nim
+++ b/tests/utp/test_protocol_integration.nim
@@ -13,7 +13,8 @@ import
   ../../eth/utp/utp_router,
   ../../eth/utp/utp_protocol,
   ../../eth/keys,
-  ../../eth/p2p/discoveryv5/random2
+  ../../eth/p2p/discoveryv5/random2,
+  ../stubloglevel
 
 proc connectTillSuccess(p: UtpProtocol, to: TransportAddress, maxTries: int = 20): Future[UtpSocket[TransportAddress]] {.async.} =
   var i = 0

--- a/tests/utp/test_utp_router.nim
+++ b/tests/utp/test_utp_router.nim
@@ -13,7 +13,8 @@ import
   ./test_utils,
   ../../eth/utp/utp_router,
   ../../eth/utp/packets,
-  ../../eth/keys
+  ../../eth/keys,
+  ../stubloglevel
 
 proc hash*(x: UtpSocketKey[int]): Hash =
   var h = 0

--- a/tests/utp/test_utp_socket.nim
+++ b/tests/utp/test_utp_socket.nim
@@ -14,7 +14,8 @@ import
   ../../eth/utp/utp_router,
   ../../eth/utp/utp_socket,
   ../../eth/utp/packets,
-  ../../eth/keys
+  ../../eth/keys,
+  ../stubloglevel
 
 procSuite "Utp socket unit test":
   let rng = newRng()

--- a/tests/utp/test_utp_socket_sack.nim
+++ b/tests/utp/test_utp_socket_sack.nim
@@ -15,7 +15,8 @@ import
   ../../eth/utp/utp_router,
   ../../eth/utp/utp_socket,
   ../../eth/utp/packets,
-  ../../eth/keys
+  ../../eth/keys,
+  ../stubloglevel
 
 procSuite "Utp socket selective acks unit test":
   let rng = newRng()


### PR DESCRIPTION
In order to avoid unused warning and more importantly to make sure all log statements work.

Other solution to https://github.com/status-im/nim-eth/pull/546