### PR TITLE
Allow distance of 256 in lookupDistances

### DIFF
--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -620,7 +620,7 @@ proc lookupDistances*(target, dest: NodeId): seq[uint16] =
   result.add(td)
   var i = 1
   while result.len < lookupRequestLimit:
-    if tdAsInt + i < 256:
+    if tdAsInt + i <= 256:
       result.add(td + uint16(i))
     if tdAsInt - i > 0:
       result.add(td - uint16(i))

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -581,6 +581,9 @@ suite "Discovery v5 Tests":
       check test.len == 1
 
   test "Calculate lookup distances":
+    let rng = newRng()
+    let node = generateNode(PrivateKey.random(rng[]))
+
     # Log distance between zeros is zero
     let dist = lookupDistances(u256(0), u256(0))
     check dist == @[0'u16, 1, 2]
@@ -588,6 +591,22 @@ suite "Discovery v5 Tests":
     # Log distance between zero and one is one
     let dist1 = lookupDistances(u256(0), u256(1))
     check dist1 == @[1'u16, 2, 3]
+
+    # Ensure that distances are in expected order
+    let dist2 = lookupDistances(node.id, idAtDistance(node.id, 128))
+    check dist2 == @[128'u16, 129, 127]
+
+    # Test target distance of 256
+    let dist3 = lookupDistances(node.id, idAtDistance(node.id, 256))
+    check dist3 == @[256'u16, 255, 254]
+
+    # Test target distance of 255
+    let dist4 = lookupDistances(node.id, idAtDistance(node.id, 255))
+    check dist4 == @[255'u16, 256, 254]
+
+    # Test target distance of 254
+    let dist5 = lookupDistances(node.id, idAtDistance(node.id, 254))
+    check dist5 == @[254'u16, 255, 253]
 
   asyncTest "Handshake cleanup: different ids":
     # Node to test the handshakes on.


### PR DESCRIPTION
Noticed that lookupDistances for FINDNODE requests didn't consider 256 a valid distance.

Associated with this issue in go-ethereum, which looks to have inspired this implementation:

* https://github.com/ethereum/go-ethereum/pull/26087