### PR TITLE
persist discovered ENRs from the discv5 into CSV 

### DIFF
--- a/eth/p2p/discoveryv5/dcli.nim
+++ b/eth/p2p/discoveryv5/dcli.nim
@@ -168,7 +168,7 @@ proc discover(d: discv5_protocol.Protocol, psFile: string) {.async.} =
         bits.inc(countOnes(byt.uint)) 
 
       let str = "$#,$#,$#,$#,$#,$#\n"
-      let newLine = str % [key.get().toHex, dNode.id.toHex, forkDigest[0..4].toHex, $dNode.address.get(), attnets.get().toHex, $bits] 
+      let newLine = str % [key.get().toHex, dNode.id.toHex, forkDigest[0..3].toHex, $dNode.address.get(), attnets.get().toHex, $bits] 
 
       ps.write(newLine)
     await sleepAsync(1000) # 1 sec of delay

--- a/eth/p2p/discoveryv5/dcli.nim
+++ b/eth/p2p/discoveryv5/dcli.nim
@@ -1,7 +1,7 @@
 import
-  std/[options, strutils, tables],
+  std/[options, strutils, tables, sets, times],
   confutils, confutils/std/net, chronicles, chronicles/topics_registry,
-  chronos, metrics, metrics/chronos_httpserver, stew/byteutils,
+  chronos, metrics, metrics/chronos_httpserver, stew/byteutils, stew/bitops2,
   ../../keys, ../../net/nat,
   "."/[enr, node],
   "."/protocol as discv5_protocol
@@ -28,6 +28,11 @@ type
       defaultValue: defaultListenAddress(config)
       desc: "Listening address for the Discovery v5 traffic"
       name: "listen-address" }: ValidIpAddress
+
+    persistingFile* {.
+      defaultValue: "peerstore.csv",
+      desc: "File where the tool will keep the discovered records"
+      name: "persisting-file" .}: string
 
     bootnodes* {.
       desc: "ENR URI of node to bootstrap discovery with. Argument may be repeated"
@@ -132,11 +137,42 @@ proc parseCmdArg*(T: type PrivateKey, p: string): T =
 proc completeCmdArg*(T: type PrivateKey, val: string): seq[string] =
   return @[]
 
-proc discover(d: discv5_protocol.Protocol) {.async.} =
+proc discover(d: discv5_protocol.Protocol, psFile: string) {.async.} =
+  echo "starting peer-discovery in Etherum - persisting peers at: ", psFile
+
+  var ethNodes: HashSet[seq[byte]]
+
+  let ps = open(psFile, fmWrite)
+  defer: ps.close()
+  ps.write("pubkey,node_id,fork_digest,ip:port,attnets,count\n")
+ 
   while true:
+    let iTime = getTime()
     let discovered = await d.queryRandom()
-    info "Lookup finished", nodes = discovered.len
-    await sleepAsync(30.seconds)
+    let qDuration = getTime() - iTime
+    info "Lookup finished",  query_time = qDuration.inSeconds, new_nodes = discovered.len, tot_peers=len(ethNodes)
+    
+    for dNode in discovered:
+      let eth2 = dNode.record.tryGet("eth2", seq[byte]) 
+      let key = dNode.record.tryGet("secp256k1", seq[byte])
+      let attnets = dNode.record.tryGet("attnets", seq[byte])
+      if eth2.isNone or attnets.isNone or key.isNone: continue
+
+      if key.get() in ethNodes: continue
+      ethNodes.incl(key.get())
+      
+      let forkDigest = eth2.get()
+
+      var bits = 0
+      for byt in attnets.get():
+        bits.inc(countOnes(byt.uint)) 
+
+      let str = "$#,$#,$#,$#,$#,$#\n"
+      let newLine = str % [key.get().toHex, dNode.id.toHex, forkDigest[0..4].toHex, $dNode.address.get(), attnets.get().toHex, $bits] 
+
+      ps.write(newLine)
+    await sleepAsync(1000) # 1 sec of delay
+  
 
 proc run(config: DiscoveryConf) =
   let
@@ -188,7 +224,7 @@ proc run(config: DiscoveryConf) =
       echo "No Talk Response message returned"
   of noCommand:
     d.start()
-    waitFor(discover(d))
+    waitFor(discover(d, config.persistingFile))
 
 when isMainModule:
   let config = DiscoveryConf.load()

--- a/eth/p2p/discoveryv5/dcli.nim
+++ b/eth/p2p/discoveryv5/dcli.nim
@@ -138,7 +138,7 @@ proc completeCmdArg*(T: type PrivateKey, val: string): seq[string] =
   return @[]
 
 proc discover(d: discv5_protocol.Protocol, psFile: string) {.async.} =
-  echo "starting peer-discovery in Etherum - persisting peers at: ", psFile
+  info "Starting peer-discovery in Ethereum - persisting peers at: ", psFile
 
   var ethNodes: HashSet[seq[byte]]
 


### PR DESCRIPTION
This PR proposes a slight modification in the [`dcli.nim`](https://github.com/status-im/nim-eth/blob/master/eth/p2p/discoveryv5/dcli.nim) client to persist into a `.csv` file the ENRs of the nodes discovered in the Ethereum CL network.

The ENRs are parsed and then persisted in the CSV file under the following structure:
```
pubkey,node_id,fork_digest,ip:port,attnets,count
``` 
This modification makes the `dcli` act as a light-crawler, which helps estimate the size of the different CL networks.

Let me know if I can improve anything from the code (I'm a newbie with `nim` 😅 )  