### PR TITLE
extend `BlockHeader` for Capella

### DIFF
--- a/eth/common/eth_types.nim
+++ b/eth/common/eth_types.nim
@@ -96,24 +96,31 @@ type
     status*: TransactionStatus
     data*: Blob
 
+  Withdrawal* = object  # EIP-4895
+    index*         : uint64
+    validatorIndex*: uint64
+    address*       : EthAddress
+    amount*        : UInt256
+
   BlockHeader* = object
-    parentHash*:    Hash256
-    ommersHash*:    Hash256
-    coinbase*:      EthAddress
-    stateRoot*:     Hash256
-    txRoot*:        Hash256
-    receiptRoot*:   Hash256
-    bloom*:         BloomFilter
-    difficulty*:    DifficultyInt
-    blockNumber*:   BlockNumber
-    gasLimit*:      GasInt
-    gasUsed*:       GasInt
-    timestamp*:     EthTime
-    extraData*:     Blob
-    mixDigest*:     Hash256
-    nonce*:         BlockNonce
+    parentHash*:      Hash256
+    ommersHash*:      Hash256
+    coinbase*:        EthAddress
+    stateRoot*:       Hash256
+    txRoot*:          Hash256
+    receiptRoot*:     Hash256
+    bloom*:           BloomFilter
+    difficulty*:      DifficultyInt
+    blockNumber*:     BlockNumber
+    gasLimit*:        GasInt
+    gasUsed*:         GasInt
+    timestamp*:       EthTime
+    extraData*:       Blob
+    mixDigest*:       Hash256
+    nonce*:           BlockNonce
     # `baseFee` is the get/set of `fee`
-    fee*:           Option[UInt256]   # EIP-1559
+    fee*:             Option[UInt256]   # EIP-1559
+    withdrawalsRoot*: Option[Hash256]   # EIP-4895
 
   BlockBody* = object
     transactions*:  seq[Transaction]

--- a/eth/common/eth_types_rlp.nim
+++ b/eth/common/eth_types_rlp.nim
@@ -315,7 +315,10 @@ proc append*(rlpWriter: var RlpWriter, t: Time) {.inline.} =
   rlpWriter.append(t.toUnix())
 
 proc append*(w: var RlpWriter, h: BlockHeader) =
-  w.startList(if h.fee.isSome: 16 else: 15)
+  var len = 15
+  if h.fee.isSome: inc len
+  if h.withdrawalsRoot.isSome: inc len
+  w.startList(len)
   for k, v in fieldPairs(h):
     when k notin ["fee", "withdrawalsRoot"]:
       w.append(v)

--- a/eth/common/eth_types_rlp.nim
+++ b/eth/common/eth_types_rlp.nim
@@ -113,6 +113,13 @@ proc append*(w: var RlpWriter, tx: Transaction) =
   of TxEip1559:
     w.appendTxEip1559(tx)
 
+proc append*(w: var RlpWriter, withdrawal: Withdrawal) =
+  w.startList(4)
+  w.append(withdrawal.index)
+  w.append(withdrawal.validatorIndex)
+  w.append(withdrawal.address)
+  w.append(withdrawal.amount)
+
 template read[T](rlp: var Rlp, val: var T)=
   val = rlp.read(type val)
 

--- a/tests/rlp/test_common.nim
+++ b/tests/rlp/test_common.nim
@@ -79,6 +79,19 @@ proc suite1() =
       check aa == a
       check bb == b
 
+    test "EIP 4895 roundtrip":
+      let a = Withdrawal(
+        index: 1,
+        validatorIndex: 2,
+        address: EthAddress [
+          0.byte, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+          11, 12, 13, 14, 15, 16, 17, 18, 19],
+        amount: 4.u256 * 1_000_000_000.u256)
+
+      let abytes = rlp.encode(a)
+      let aa = rlp.decode(abytes, Withdrawal)
+      check aa == a
+
 proc suite2() =
   suite "eip 2718 transaction":
     for i in 0..<10:

--- a/tests/rlp/test_object_serialization.nim
+++ b/tests/rlp/test_object_serialization.nim
@@ -84,5 +84,6 @@ proc suite() =
         Bar.rlpFieldsCount == 2
         Foo.rlpFieldsCount == 3
         Transaction.rlpFieldsCount == 3
+        Withdrawal.rlpFieldsCount == 4
 
 suite()

--- a/tests/rlp/test_object_serialization.nim
+++ b/tests/rlp/test_object_serialization.nim
@@ -84,6 +84,5 @@ proc suite() =
         Bar.rlpFieldsCount == 2
         Foo.rlpFieldsCount == 3
         Transaction.rlpFieldsCount == 3
-        Withdrawal.rlpFieldsCount == 4
 
 suite()


### PR DESCRIPTION
Adds `Withdrawal` type according to EIP-4895, and extends `BlockHeader` accordingly. Also adds RLP encoding support for `Withdrawal` to enable building `BlockHeader` (used by Nimbus-CL in empty block prod fallback).