### PR TITLE
sqlite: support read-only kvstores

### DIFF
--- a/eth/db/kvstore_sqlite3.nim
+++ b/eth/db/kvstore_sqlite3.nim
@@ -581,7 +581,7 @@ proc hasTable*(db: SqStoreRef, name: string): KvResult[bool] =
 
 proc openKvStore*(
     db: SqStoreRef, name = "kvstore", withoutRowid = false,
-    readOnly = db.readOnly): KvResult[SqKeyspaceRef] =
+    readOnly = false): KvResult[SqKeyspaceRef] =
   ## Open a new Key-Value store in the SQLite database
   ##
   ## withoutRowid: Create the table without rowid - this is more efficient when
@@ -589,10 +589,7 @@ proc openKvStore*(
   ##               rows (the row being the sum of key and value) - see
   ##               https://www.sqlite.org/withoutrowid.html
   ##
-  if db.readOnly and not readOnly:
-    return err("sqlite: cannot create writable kvstore in read-only database")
-
-  let hasTable = if readOnly:
+  let hasTable = if db.readOnly or readOnly:
     ? db.hasTable(name)
   else:
     let createSql = """

--- a/tests/db/test_kvstore_sqlite3.nim
+++ b/tests/db/test_kvstore_sqlite3.nim
@@ -16,6 +16,14 @@ procSuite "SqStoreRef":
 
     testKvStore(kvStore kv.get(), true)
 
+  test "Readonly kvstore with no table":
+    let db = SqStoreRef.init("", "test", inMemory = true, readOnly = true)[]
+    defer: db.close()
+    let kv = db.openKvStore().expect("working db")
+
+    check not kv.get([byte 0, 1, 2], nil).expect("ok to query data")
+    defer: kv[].close()
+
   test "Prepare and execute statements":
     let db = SqStoreRef.init("", "test", inMemory = true)[]
     defer: db.close()
@@ -274,10 +282,10 @@ procSuite "SqStoreRef":
 
     discard sumKeyVal.exec do (res: seq[byte]):
       sums.add(res)
-    
+
     check:
       len(sums) == 1
-    
+
     let sum = uint32.fromBytesBE(sums[0])
 
     check:

--- a/tests/db/test_kvstore_sqlite3.nim
+++ b/tests/db/test_kvstore_sqlite3.nim
@@ -21,7 +21,11 @@ procSuite "SqStoreRef":
     defer: db.close()
     let kv = db.openKvStore().expect("working db")
 
-    check not kv.get([byte 0, 1, 2], nil).expect("ok to query data")
+    check:
+      not kv.get([byte 0, 1, 2], nil).expect("ok to query data")
+      kv.find([byte 0, 1, 2], nil).expect("ok") == 0
+      kv.put([byte 0, 1, 2], []).isErr
+      kv.del([byte 0, 1, 2]).isOk
     defer: kv[].close()
 
   test "Prepare and execute statements":


### PR DESCRIPTION
in a read-only database, we cannot create the table but we can still reason about elements in it - they simply don't exist