### PR TITLE
avoid invalid codegen/UB by avoiding case object discriminant assignment

### DIFF
--- a/eth/common/eth_types.nim
+++ b/eth/common/eth_types.nim
@@ -244,19 +244,19 @@ func toBlockNonce*(n: uint64): BlockNonce =
 func toUint*(n: BlockNonce): uint64 =
   uint64.fromBytesBE(n)
 
-proc newAccount*(nonce: AccountNonce = 0, balance: UInt256 = 0.u256): Account =
+func newAccount*(nonce: AccountNonce = 0, balance: UInt256 = 0.u256): Account =
   result.nonce = nonce
   result.balance = balance
   result.storageRoot = EMPTY_ROOT_HASH
   result.codeHash = EMPTY_CODE_HASH
 
-proc hasStatus*(rec: Receipt): bool {.inline.} =
+func hasStatus*(rec: Receipt): bool {.inline.} =
   rec.isHash == false
 
-proc hasStateRoot*(rec: Receipt): bool {.inline.} =
+func hasStateRoot*(rec: Receipt): bool {.inline.} =
   rec.isHash == true
 
-proc stateRoot*(rec: Receipt): Hash256 {.inline.} =
+func stateRoot*(rec: Receipt): Hash256 {.inline.} =
   doAssert(rec.hasStateRoot)
   rec.hash
 
@@ -272,14 +272,14 @@ func destination*(tx: Transaction): EthAddress =
 func init*(T: type BlockHashOrNumber, str: string): T
           {.raises: [ValueError, Defect].} =
   if str.startsWith "0x":
-    if str.len != sizeof(result.hash.data) * 2 + 2:
+    if str.len != sizeof(default(T).hash.data) * 2 + 2:
       raise newException(ValueError, "Block hash has incorrect length")
 
-    result.isHash = true
-    hexToByteArray(str, result.hash.data)
+    var res = T(isHash: true)
+    hexToByteArray(str, res.hash.data)
+    res
   else:
-    result.isHash = false
-    result.number = parseBiggestUInt str
+    T(isHash: false, number: parseBiggestUInt str)
 
 func `$`*(x: BlockHashOrNumber): string =
   if x.isHash:


### PR DESCRIPTION
https://github.com/nim-lang/Nim/issues/20972 characterizes one way in which using old-style case object kind reassignment creates UB through invalid C code generation when using `refc`, so avoid it when it's not particularly performance-costly to do so.

The `else` branch just assigns the fields regardless, so it's no worse to do so in a case object-compatible way. The non-`else` branch effectively does something similar -- either before or after, the sequence Nim uses is (a) set the return value memory to all-zeros; (b) set the kind; (c) set the hash.

Furthermore, this is an init function, not used in any hot loop, but rather sparingly.