### PR TITLE
Add `eth` topic to all the chronicles log topics

### DIFF
--- a/eth/net/nat.nim
+++ b/eth/net/nat.nim
@@ -45,7 +45,7 @@ var
   externalUdpPort: Port
 
 logScope:
-  topics = "nat"
+  topics = "eth net nat"
 
 ## Also does threadvar initialisation.
 ## Must be called before redirectPorts() in each thread.

--- a/eth/p2p.nim
+++ b/eth/p2p.nim
@@ -16,6 +16,10 @@ import
 export
   p2p_types, rlpx, enode, kademlia
 
+logScope:
+  topics = "eth p2p"
+
+
 proc addCapability*(node: var EthereumNode,
                     p: ProtocolInfo,
                     networkState: RootRef = nil) =

--- a/eth/p2p/discovery.nim
+++ b/eth/p2p/discovery.nim
@@ -18,7 +18,7 @@ export
   Node, results
 
 logScope:
-  topics = "discovery"
+  topics = "eth p2p discovery"
 
 const
   # UDP packet constants.

--- a/eth/p2p/discoveryv5/encoding.nim
+++ b/eth/p2p/discoveryv5/encoding.nim
@@ -29,7 +29,7 @@ declareCounter discovery_session_lru_cache_misses, "Session LRU cache misses"
 declareCounter discovery_session_decrypt_failures, "Session decrypt failures"
 
 logScope:
-  topics = "discv5"
+  topics = "eth p2p discv5"
 
 # Support overriding the default discv5 protocol version and protocol id
 #  via compile time defines (e.g., '-d:discv5_protocol_id=d5waku')

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -101,7 +101,7 @@ declareCounter discovery_enr_auto_update,
   "Amount of discovery IP:port address ENR auto updates"
 
 logScope:
-  topics = "discv5"
+  topics = "eth p2p discv5"
 
 const
   alpha = 3 ## Kademlia concurrency factor

--- a/eth/p2p/kademlia.nim
+++ b/eth/p2p/kademlia.nim
@@ -16,7 +16,7 @@ import
 export sets # TODO: This should not be needed, but compilation fails otherwise
 
 logScope:
-  topics = "kademlia"
+  topics = "eth p2p kademlia"
 
 type
   # 32 bytes NodeId | 16 bytes ip | 1 byte mode

--- a/eth/p2p/peer_pool.nim
+++ b/eth/p2p/peer_pool.nim
@@ -16,6 +16,10 @@ import
   ".."/[keys, common],
   ./private/p2p_types, "."/[discovery, kademlia, rlpx, enode]
 
+logScope:
+  topics = "eth p2p peer_pool"
+
+
 const
   lookupInterval = 5
   connectLoopSleep = chronos.milliseconds(2000)

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -37,7 +37,7 @@ export
 declarePublicGauge connected_peers, "number of peers in the pool"
 
 logScope:
-  topics = "rlpx"
+  topics = "eth p2p rlpx"
 
 type
   ResponderWithId*[MsgType] = object

--- a/eth/utp/utp_discv5_protocol.nim
+++ b/eth/utp/utp_discv5_protocol.nim
@@ -16,7 +16,7 @@ import
 export utp_router, protocol
 
 logScope:
-  topics = "utp_discv5_protocol"
+  topics = "eth utp utp_discv5_protocol"
 
 type
   NodeAddress* = object

--- a/eth/utp/utp_protocol.nim
+++ b/eth/utp/utp_protocol.nim
@@ -13,7 +13,7 @@ import
   ../keys
 
 logScope:
-  topics = "utp"
+  topics = "eth utp"
 
 type
   # For now utp protocol is tied to udp transport, but ultimately we would like to

--- a/eth/utp/utp_router.nim
+++ b/eth/utp/utp_router.nim
@@ -16,7 +16,7 @@ import
 export utp_socket
 
 logScope:
-  topics = "utp_router"
+  topics = "eth utp utp_router"
 
 declareCounter utp_received_packets,
   "All correct received uTP packets"

--- a/eth/utp/utp_socket.nim
+++ b/eth/utp/utp_socket.nim
@@ -21,7 +21,7 @@ export
   chronicles
 
 logScope:
-  topics = "utp_socket"
+  topics = "eth utp utp_socket"
 
 type
   ConnectionState* = enum


### PR DESCRIPTION
In nwaku, we are working on enabling structured logging (https://github.com/waku-org/nwaku/issues/1195). 

Since `nim-eth` does not support the JSON serialization of certain types (e.g., `PublicKey`), we would like to disable all chronicles logs generated by the library at compile time via `chronicles_disabled_topics` option. 

This PR adds to all the chronicle's `logScope` topics a shared topic: `eth`.