### PR TITLE
extend `BlockHeader` for EIP-4844

### DIFF
--- a/eth/common/eth_types.nim
+++ b/eth/common/eth_types.nim
@@ -121,6 +121,7 @@ type
     # `baseFee` is the get/set of `fee`
     fee*:             Option[UInt256]   # EIP-1559
     withdrawalsRoot*: Option[Hash256]   # EIP-4895
+    excessDataGas*:   Option[GasInt]    # EIP-4844
 
   BlockBody* = object
     transactions*:  seq[Transaction]

--- a/eth/common/eth_types_rlp.nim
+++ b/eth/common/eth_types_rlp.nim
@@ -321,7 +321,7 @@ proc append*(w: var RlpWriter, h: BlockHeader) =
   if h.excessDataGas.isSome: inc len
   w.startList(len)
   for k, v in fieldPairs(h):
-    when k notin ["fee", "withdrawalsRoot"]:
+    when v isnot Option:
       w.append(v)
   if h.fee.isSome:
     w.append(h.fee.get())
@@ -339,7 +339,7 @@ proc read*(rlp: var Rlp, T: type BlockHeader): T =
 
   rlp.tryEnterList()
   for k, v in fieldPairs(result):
-    when k isnot Option:
+    when v isnot Option:
       v = rlp.read(type v)
 
   if len >= 16:

--- a/tests/rlp/test_common.nim
+++ b/tests/rlp/test_common.nim
@@ -97,11 +97,27 @@ proc suite2() =
     for i in 0..<10:
       loadFile(i)
 
-    test "rlp roundtrip EIP1559":
+    test "rlp roundtrip EIP1559 / EIP4895 / EIP4844":
+      proc doTest(h: BlockHeader) =
+        let xy = rlp.encode(h)
+        let hh = rlp.decode(xy, BlockHeader)
+        check h == hh
+
       var h: BlockHeader
-      let xy = rlp.encode(h)
-      let hh = rlp.decode(xy, BlockHeader)
-      check h == hh
+      doTest h
+
+      # EIP-1559
+      h.fee = some 1234.u256
+      doTest h
+
+      # EIP-4895
+      h.withdrawalsRoot = some Hash256.fromHex(
+        "0x7a64245f7f95164f6176d90bd4903dbdd3e5433d555dd1385e81787f9672c588")
+      doTest h
+
+      # EIP-4844
+      h.excessDataGas = some GasInt(1337)
+      doTest h
 
 suite1()
 suite2()


### PR DESCRIPTION
Extends `BlockHeader` with `excessDataGas` according to EIP-4844 (used by Nimbus-CL in empty block prod fallback).