### PR TITLE
In the incomplete-db node-existence check, don't use contains.

### DIFF
--- a/eth/trie/hexary.nim
+++ b/eth/trie/hexary.nim
@@ -31,6 +31,9 @@ proc expectHash(r: Rlp): seq[byte] =
     raise newException(RlpTypeMismatch,
       "RLP expected to be a Keccak hash value, but has an incorrect length")
 
+when (NimMajor, NimMinor, NimPatch) < (1, 4, 0):
+  type AssertionDefect = AssertionError
+
 type MissingNodeError* = ref object of AssertionDefect
   path*: NibblesSeq
   nodeHashBytes*: seq[byte]

--- a/eth/trie/hexary.nim
+++ b/eth/trie/hexary.nim
@@ -37,8 +37,6 @@ type MissingNodeError* = ref object of Defect
 
 proc dbGet(db: DB, data: openArray[byte]): seq[byte]
   {.gcsafe, raises: [Defect].} =
-  # Useful for debugging:
-  # doAssert(db.contains(data), "dbGet, db must contain the data")
   db.get(data)
 
 proc dbGet(db: DB, key: Rlp): seq[byte] =
@@ -54,15 +52,11 @@ proc dbPut(db: DB, data: openArray[byte]): TrieNodeKey
 # where it's needed.
 proc getPossiblyMissingNode(db: DB, data: openArray[byte], fullPath: NibblesSeq, pathIndex: int): seq[byte]
   {.gcsafe, raises: [Defect].} =
-  # FIXME-Adam: This causes some tests to fail in nimbus-eth1; I'm not
-  # sure why. I need to figure it out, though, because we need this
-  # behaviour.
-  #
-  # if db.contains(data):
-  #   db.get(data)
-  # else:
-  #   raise MissingNodeError(path: fullPath.slice(0, pathIndex), nodeHashBytes: @data)
-  db.get(data)
+  let nodeBytes = db.get(data)
+  if nodeBytes.len > 0:
+    nodeBytes
+  else:
+    raise MissingNodeError(path: fullPath.slice(0, pathIndex), nodeHashBytes: @data)
 
 proc getPossiblyMissingNode(db: DB, key: Rlp, fullPath: NibblesSeq, pathIndex: int): seq[byte] =
   getPossiblyMissingNode(db, key.expectHash, fullPath, pathIndex)

--- a/eth/trie/hexary.nim
+++ b/eth/trie/hexary.nim
@@ -52,8 +52,8 @@ proc dbPut(db: DB, data: openArray[byte]): TrieNodeKey
 # where it's needed.
 proc getPossiblyMissingNode(db: DB, data: openArray[byte], fullPath: NibblesSeq, pathIndex: int): seq[byte]
   {.gcsafe, raises: [Defect].} =
-  let nodeBytes = db.get(data)
-  if nodeBytes.len > 0:
+  let nodeBytes = db.get(data)  # need to call this before the call to contains, otherwise CaptureDB complains
+  if db.contains(data):
     nodeBytes
   else:
     raise MissingNodeError(path: fullPath.slice(0, pathIndex), nodeHashBytes: @data)

--- a/eth/trie/hexary.nim
+++ b/eth/trie/hexary.nim
@@ -31,7 +31,7 @@ proc expectHash(r: Rlp): seq[byte] =
     raise newException(RlpTypeMismatch,
       "RLP expected to be a Keccak hash value, but has an incorrect length")
 
-type MissingNodeError* = ref object of Defect
+type MissingNodeError* = ref object of AssertionDefect
   path*: NibblesSeq
   nodeHashBytes*: seq[byte]
 
@@ -53,7 +53,7 @@ proc dbPut(db: DB, data: openArray[byte]): TrieNodeKey
 proc getPossiblyMissingNode(db: DB, data: openArray[byte], fullPath: NibblesSeq, pathIndex: int): seq[byte]
   {.gcsafe, raises: [Defect].} =
   let nodeBytes = db.get(data)  # need to call this before the call to contains, otherwise CaptureDB complains
-  if db.contains(data):
+  if nodeBytes.len > 0:
     nodeBytes
   else:
     raise MissingNodeError(path: fullPath.slice(0, pathIndex), nodeHashBytes: @data)


### PR DESCRIPTION
(Using contains led to a problem with CaptureDB.)