### PR TITLE
Remove all Defect raises to avoid unnecessary warnings

### DIFF
--- a/eth/common/eth_types.nim
+++ b/eth/common/eth_types.nim
@@ -268,8 +268,8 @@ func destination*(tx: Transaction): EthAddress =
   if tx.to.isSome:
     return tx.to.get
 
-func init*(T: type BlockHashOrNumber, str: string): T
-          {.raises: [ValueError, Defect].} =
+func init*(
+    T: type BlockHashOrNumber, str: string): T {.raises: [ValueError].} =
   if str.startsWith "0x":
     if str.len != sizeof(default(T).hash.data) * 2 + 2:
       raise newException(ValueError, "Block hash has incorrect length")

--- a/eth/common/eth_types_json_serialization.nim
+++ b/eth/common/eth_types_json_serialization.nim
@@ -1,3 +1,9 @@
+# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   std/[times, net],
   json_serialization, nimcrypto/[hash, utils],
@@ -6,7 +12,7 @@ import
 export
   json_serialization
 
-{.push raises: [SerializationError, IOError, Defect].}
+{.push raises: [SerializationError, IOError].}
 
 proc writeValue*(w: var JsonWriter, a: MDigest) =
   w.writeValue a.data.toHex(true)

--- a/eth/db/kvstore_sqlite3.nim
+++ b/eth/db/kvstore_sqlite3.nim
@@ -1,6 +1,6 @@
 ## Implementation of KvStore based on sqlite3
 
-{.push raises: [Defect].}
+{.push raises: [].}
 {.pragma: callback, gcsafe, raises: [].}
 
 import

--- a/eth/keyfile/keyfile.nim
+++ b/eth/keyfile/keyfile.nim
@@ -7,7 +7,7 @@
 #  Apache License, version 2.0, (LICENSE-APACHEv2)
 #              MIT license (LICENSE-MIT)
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[strutils, json],
@@ -480,7 +480,8 @@ proc loadKeyFile*(pathname: string,
     data = json.parseFile(pathname)
   except JsonParsingError:
     return err(JsonError)
-  except Exception: # json raises Exception
+  except Exception:
+    # json parseFile also raises IOError, ValueError and raw Exception
     return err(OsError)
 
   decodeKeyFileJson(data, password)

--- a/eth/keyfile/uuid.nim
+++ b/eth/keyfile/uuid.nim
@@ -16,7 +16,7 @@
 ## - ``FreeBSD``, ``OpenBSD``, ``NetBSD``,
 ##   ``DragonflyBSD`` - using `uuid_create()`.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import stew/[byteutils, endians2, results]
 

--- a/eth/keys.nim
+++ b/eth/keys.nim
@@ -1,5 +1,5 @@
-# Nim Ethereum Keys (nim-eth-keys)
-# Copyright (c) 2020 Status Research & Development GmbH
+# Nim Ethereum Keys
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed under either of
 # - Apache License, version 2.0, (LICENSE-APACHEv2)
 # - MIT license (LICENSE-MIT)
@@ -12,7 +12,7 @@
 # * Shared secrets are serialized in raw format without the initial byte
 # * distinct types are used to avoid confusion with the "standard" secp types
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/strformat,

--- a/eth/net/nat.nim
+++ b/eth/net/nat.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 Status Research & Development GmbH
+# Copyright (c) 2019-2023 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -6,7 +6,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[options, os, strutils, times],
@@ -204,7 +204,7 @@ var
   natThread: Thread[PortMappingArgs]
   natCloseChan: Channel[bool]
 
-proc repeatPortMapping(args: PortMappingArgs) {.thread, raises: [Defect, ValueError].} =
+proc repeatPortMapping(args: PortMappingArgs) {.thread, raises: [ValueError].} =
   ignoreSignalsInThread()
   let
     (tcpPort, udpPort, description) = args
@@ -323,7 +323,7 @@ type
       of true: extIp*: ValidIpAddress
       of false: nat*: NatStrategy
 
-func parseCmdArg*(T: type NatConfig, p: string): T {.raises: [Defect, ConfigurationError].} =
+func parseCmdArg*(T: type NatConfig, p: string): T {.raises: [ConfigurationError].} =
   case p.toLowerAscii:
     of "any":
       NatConfig(hasExtIp: false, nat: NatAny)

--- a/eth/net/utils.nim
+++ b/eth/net/utils.nim
@@ -1,11 +1,11 @@
 # nim-eth
-# Copyright (c) 2020-2021 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[tables, hashes],

--- a/eth/p2p.nim
+++ b/eth/p2p.nim
@@ -1,11 +1,11 @@
 # nim-eth
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[tables, algorithm, random, typetraits, strutils, net],
@@ -134,7 +134,7 @@ proc processIncoming(server: StreamServer,
 proc listeningAddress*(node: EthereumNode): ENode =
   node.toENode()
 
-proc startListening*(node: EthereumNode) {.raises: [CatchableError, Defect].} =
+proc startListening*(node: EthereumNode) {.raises: [CatchableError].} =
   # TODO: allow binding to both IPv4 & IPv6
   let ta = initTAddress(node.bindIp, node.bindPort)
   if node.listeningServer == nil:
@@ -165,7 +165,7 @@ proc connectToNetwork*(
     trace "Waiting for more peers", peers = node.peerPool.connectedNodes.len
     await sleepAsync(500.milliseconds)
 
-proc stopListening*(node: EthereumNode) {.raises: [CatchableError, Defect].} =
+proc stopListening*(node: EthereumNode) {.raises: [CatchableError].} =
   node.listeningServer.stop()
 
 iterator peers*(node: EthereumNode): Peer =

--- a/eth/p2p/auth.nim
+++ b/eth/p2p/auth.nim
@@ -1,6 +1,6 @@
 #
 #                 Ethereum P2P
-#              (c) Copyright 2018-2022
+#              (c) Copyright 2018-2023
 #       Status Research & Development GmbH
 #
 #            Licensed under either of
@@ -10,7 +10,7 @@
 
 ## This module implements Ethereum RLPx authentication
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   nimcrypto/[rijndael, keccak, utils],

--- a/eth/p2p/discoveryv5/encoding.nim
+++ b/eth/p2p/discoveryv5/encoding.nim
@@ -1,5 +1,5 @@
 # nim-eth - Node Discovery Protocol v5
-# Copyright (c) 2020-2021 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -11,7 +11,7 @@
 ## https://github.com/ethereum/devp2p/blob/master/discv5/discv5-theory.md#sessions
 ##
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[tables, options, hashes, net],

--- a/eth/p2p/discoveryv5/enr.nim
+++ b/eth/p2p/discoveryv5/enr.nim
@@ -1,5 +1,5 @@
 # nim-eth - Node Discovery Protocol v5
-# Copyright (c) 2020-2021 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -8,7 +8,7 @@
 ## ENR implementation according to specification in EIP-778:
 ## https://github.com/ethereum/EIPs/blob/master/EIPS/eip-778.md
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[strutils, macros, algorithm, options],
@@ -394,7 +394,7 @@ func verifySignatureV4(
   else:
     false
 
-func verifySignature(r: Record): bool {.raises: [RlpError, Defect].} =
+func verifySignature(r: Record): bool {.raises: [RlpError].} =
   var rlp = rlpFromBytes(r.raw)
   let sz = rlp.listLen
   if not rlp.enterList:
@@ -420,7 +420,7 @@ func verifySignature(r: Record): bool {.raises: [RlpError, Defect].} =
     # No Identity Scheme provided
     false
 
-func fromBytesAux(r: var Record): bool {.raises: [RlpError, Defect].} =
+func fromBytesAux(r: var Record): bool {.raises: [RlpError].} =
   if r.raw.len > maxEnrSize:
     return false
 
@@ -546,7 +546,7 @@ func `==`*(a, b: Record): bool = a.raw == b.raw
 
 func read*(
     rlp: var Rlp, T: type Record):
-    T {.raises: [RlpError, ValueError, Defect].} =
+    T {.raises: [RlpError, ValueError].} =
   var res: T
   if not rlp.hasData() or not res.fromBytes(rlp.rawData):
     # TODO: This could also just be an invalid signature, would be cleaner to

--- a/eth/p2p/discoveryv5/hkdf.nim
+++ b/eth/p2p/discoveryv5/hkdf.nim
@@ -1,9 +1,20 @@
+# nim-eth
+# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+#
+
+{.push raises: [].}
+
 import
   nimcrypto/[hmac, hash]
 
 export hmac, hash
 
-proc hkdf*(HashType: typedesc, ikm, salt, info: openArray[byte],
+proc hkdf*(
+    HashType: typedesc, ikm, salt, info: openArray[byte],
     output: var openArray[byte]) =
   var ctx: HMAC[HashType]
   ctx.init(salt)

--- a/eth/p2p/discoveryv5/ip_vote.nim
+++ b/eth/p2p/discoveryv5/ip_vote.nim
@@ -1,5 +1,5 @@
 # nim-eth - Node Discovery Protocol v5
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -15,7 +15,7 @@
 ## To select the right address, a majority count is done. This is done over a
 ## sort of moving window as votes expire after `IpVoteTimeout`.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[tables, options],

--- a/eth/p2p/discoveryv5/lru.nim
+++ b/eth/p2p/discoveryv5/lru.nim
@@ -1,6 +1,14 @@
-import std/[tables, lists, options]
+# nim-eth
+# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+#
 
-{.push raises: [Defect].}
+{.push raises: [].}
+
+import std/[tables, lists, options]
 
 type
   LRUCache*[K, V] = object of RootObj

--- a/eth/p2p/discoveryv5/messages.nim
+++ b/eth/p2p/discoveryv5/messages.nim
@@ -1,5 +1,5 @@
 # nim-eth - Node Discovery Protocol v5
-# Copyright (c) 2020-2021 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,7 +9,7 @@
 ## https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md#protocol-messages
 ##
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[hashes, net],

--- a/eth/p2p/discoveryv5/messages_encoding.nim
+++ b/eth/p2p/discoveryv5/messages_encoding.nim
@@ -1,5 +1,5 @@
 # nim-eth - Node Discovery Protocol v5
-# Copyright (c) 2020-2022 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -7,7 +7,7 @@
 #
 ## Discovery v5 Protocol Messages RLP Encoding
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/net,
@@ -20,7 +20,7 @@ from stew/objects import checkedEnumAssign
 export messages, rlp, results
 
 func read*(rlp: var Rlp, T: type RequestId): T
-    {.raises: [ValueError, RlpError, Defect].} =
+    {.raises: [ValueError, RlpError].} =
   mixin read
   var reqId: RequestId
   reqId.id = rlp.toBytes()
@@ -34,7 +34,7 @@ func append*(writer: var RlpWriter, value: RequestId) =
   writer.append(value.id)
 
 func read*(rlp: var Rlp, T: type IpAddress): T
-    {.raises: [RlpError, Defect].} =
+    {.raises: [RlpError].} =
   let ipBytes = rlp.toBytes()
   rlp.skipElem()
 
@@ -93,7 +93,7 @@ func decodeMessage*(body: openArray[byte]): Result[Message, cstring] =
       return err("Invalid request-id")
 
     func decode[T](rlp: var Rlp, v: var T)
-        {.nimcall, raises:[RlpError, ValueError, Defect].} =
+        {.nimcall, raises: [RlpError, ValueError].} =
       for k, v in v.fieldPairs:
         v = rlp.read(typeof(v))
 

--- a/eth/p2p/discoveryv5/node.nim
+++ b/eth/p2p/discoveryv5/node.nim
@@ -1,11 +1,11 @@
 # nim-eth - Node Discovery Protocol v5
-# Copyright (c) 2020-2021 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/hashes,

--- a/eth/p2p/discoveryv5/nodes_verification.nim
+++ b/eth/p2p/discoveryv5/nodes_verification.nim
@@ -6,7 +6,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[sets, options],

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -1,5 +1,5 @@
 # nim-eth - Node Discovery Protocol v5
-# Copyright (c) 2020-2022 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -78,7 +78,7 @@
 ## When distance 0 is provided in the requested list of distances, only the own
 ## ENR will be returned.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[tables, sets, options, math, sequtils, algorithm],
@@ -158,7 +158,7 @@ type
   TalkProtocolHandler* = proc(
     p: TalkProtocol, request: seq[byte],
     fromId: NodeId, fromUdpAddress: Address): seq[byte]
-    {.gcsafe, raises: [Defect].}
+    {.gcsafe, raises: [].}
 
   TalkProtocol* = ref object of RootObj
     protocolHandler*: TalkProtocolHandler
@@ -1016,7 +1016,7 @@ proc newProtocol*(
 template listeningAddress*(p: Protocol): Address =
   p.bindAddress
 
-proc open*(d: Protocol) {.raises: [Defect, CatchableError].} =
+proc open*(d: Protocol) {.raises: [CatchableError].} =
   info "Starting discovery node", node = d.localNode,
     bindAddress = d.bindAddress
 

--- a/eth/p2p/discoveryv5/random2.nim
+++ b/eth/p2p/discoveryv5/random2.nim
@@ -1,3 +1,13 @@
+# nim-eth
+# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+#
+
+{.push raises: [].}
+
 import
   bearssl/rand
 

--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -1,11 +1,11 @@
 # nim-eth - Node Discovery Protocol v5
-# Copyright (c) 2020-2021 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[algorithm, times, sequtils, bitops, sets, options],
@@ -20,9 +20,12 @@ declarePublicGauge routing_table_nodes,
   "Discovery routing table nodes", labels = ["state"]
 
 type
-  DistanceProc* = proc(a, b: NodeId): NodeId {.raises: [Defect], gcsafe, noSideEffect.}
-  LogDistanceProc* = proc(a, b: NodeId): uint16 {.raises: [Defect], gcsafe, noSideEffect.}
-  IdAtDistanceProc* = proc (id: NodeId, dist: uint16): NodeId {.raises: [Defect], gcsafe, noSideEffect.}
+  DistanceProc* =
+    proc(a, b: NodeId): NodeId {.raises: [], gcsafe, noSideEffect.}
+  LogDistanceProc* =
+    proc(a, b: NodeId): uint16 {.raises: [], gcsafe, noSideEffect.}
+  IdAtDistanceProc* =
+    proc (id: NodeId, dist: uint16): NodeId {.raises: [], gcsafe, noSideEffect.}
 
   DistanceCalculator* = object
     calculateDistance*: DistanceProc

--- a/eth/p2p/discoveryv5/sessions.nim
+++ b/eth/p2p/discoveryv5/sessions.nim
@@ -1,5 +1,5 @@
 # nim-eth - Node Discovery Protocol v5
-# Copyright (c) 2020-2021 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,7 +9,7 @@
 ## https://github.com/ethereum/devp2p/blob/master/discv5/discv5-theory.md#session-cache
 ##
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/options,

--- a/eth/p2p/ecies.nim
+++ b/eth/p2p/ecies.nim
@@ -1,6 +1,6 @@
 #
 #                 Ethereum P2P
-#              (c) Copyright 2018-2022
+#              (c) Copyright 2018-2023
 #       Status Research & Development GmbH
 #
 #            Licensed under either of
@@ -10,7 +10,7 @@
 
 ## This module implements ECIES method encryption/decryption.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   stew/[results, endians2],

--- a/eth/p2p/enode.nim
+++ b/eth/p2p/enode.nim
@@ -1,6 +1,6 @@
 #
 #                 Ethereum P2P
-#              (c) Copyright 2018-2020
+#              (c) Copyright 2018-2023
 #       Status Research & Development GmbH
 #
 #            Licensed under either of
@@ -8,7 +8,7 @@
 #            MIT license (LICENSE-MIT)
 #
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[uri, strutils, net],

--- a/eth/p2p/p2p_backends_helpers.nim
+++ b/eth/p2p/p2p_backends_helpers.nim
@@ -29,11 +29,11 @@ template networkState*(connection: Peer, Protocol: type): untyped =
   protocolState(connection.network, Protocol)
 
 proc initProtocolState*[T](state: T, x: Peer|EthereumNode)
-    {.gcsafe, raises: [Defect].} =
+    {.gcsafe, raises: [].} =
   discard
 
 proc initProtocolStates(peer: Peer, protocols: openArray[ProtocolInfo])
-    {.raises: [Defect].} =
+    {.raises: [].} =
   # Initialize all the active protocol states
   newSeq(peer.protocolStates, allProtocols.len)
   for protocol in protocols:

--- a/eth/p2p/p2p_protocol_dsl.nim
+++ b/eth/p2p/p2p_protocol_dsl.nim
@@ -1,4 +1,4 @@
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[options, sequtils],

--- a/eth/p2p/peer_pool.nim
+++ b/eth/p2p/peer_pool.nim
@@ -1,5 +1,5 @@
 # nim-eth
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -8,7 +8,7 @@
 # PeerPool attempts to keep connections to at least min_peers
 # on the given network.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[os, tables, times, random, sequtils, options],

--- a/eth/p2p/private/p2p_types.nim
+++ b/eth/p2p/private/p2p_types.nim
@@ -1,9 +1,11 @@
 # nim-eth
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
 
 import
   std/[deques, tables],
@@ -74,8 +76,8 @@ type
     observers*: Table[int, PeerObserver]
 
   PeerObserver* = object
-    onPeerConnected*: proc(p: Peer) {.gcsafe, raises: [Defect].}
-    onPeerDisconnected*: proc(p: Peer) {.gcsafe, raises: [Defect].}
+    onPeerConnected*: proc(p: Peer) {.gcsafe, raises: [].}
+    onPeerDisconnected*: proc(p: Peer) {.gcsafe, raises: [].}
     protocol*: ProtocolInfo
 
   Capability* = object
@@ -152,19 +154,19 @@ type
   # Private types:
   MessageHandlerDecorator* = proc(msgId: int, n: NimNode): NimNode
   ThunkProc* = proc(x: Peer, msgId: int, data: Rlp): Future[void]
-    {.gcsafe, raises: [RlpError, Defect].}
+    {.gcsafe, raises: [RlpError].}
   MessageContentPrinter* = proc(msg: pointer): string
-    {.gcsafe, raises: [Defect].}
+    {.gcsafe, raises: [].}
   RequestResolver* = proc(msg: pointer, future: FutureBase)
-    {.gcsafe, raises: [Defect].}
+    {.gcsafe, raises: [].}
   NextMsgResolver* = proc(msgData: Rlp, future: FutureBase)
-    {.gcsafe, raises: [RlpError, Defect].}
-  PeerStateInitializer* = proc(peer: Peer): RootRef {.gcsafe, raises: [Defect].}
+    {.gcsafe, raises: [RlpError].}
+  PeerStateInitializer* = proc(peer: Peer): RootRef {.gcsafe, raises: [].}
   NetworkStateInitializer* = proc(network: EthereumNode): RootRef
-    {.gcsafe, raises: [Defect].}
-  HandshakeStep* = proc(peer: Peer): Future[void] {.gcsafe, raises: [Defect].}
+    {.gcsafe, raises: [].}
+  HandshakeStep* = proc(peer: Peer): Future[void] {.gcsafe, raises: [].}
   DisconnectionHandler* = proc(peer: Peer, reason: DisconnectionReason):
-    Future[void] {.gcsafe, raises: [Defect].}
+    Future[void] {.gcsafe, raises: [].}
 
   ConnectionState* = enum
     None,

--- a/eth/p2p/rlpxcrypt.nim
+++ b/eth/p2p/rlpxcrypt.nim
@@ -1,6 +1,6 @@
 #
 #                 Ethereum P2P
-#              (c) Copyright 2018
+#              (c) Copyright 2018-2023
 #       Status Research & Development GmbH
 #
 #            Licensed under either of
@@ -10,7 +10,7 @@
 
 ## This module implements RLPx cryptography
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   nimcrypto/[bcmode, keccak, rijndael, utils], stew/results

--- a/eth/trie/db.nim
+++ b/eth/trie/db.nim
@@ -1,4 +1,12 @@
-{.push raises: [Defect].}
+# nim-eth
+# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+
+{.push raises: [].}
 
 import
   std/[options, tables, hashes, sets],
@@ -15,17 +23,17 @@ type
 
   # XXX: poor's man vtref types
   PutProc = proc (db: RootRef, key, val: openArray[byte]) {.
-    gcsafe, raises: [Defect].}
+    gcsafe, raises: [].}
 
   GetProc = proc (db: RootRef, key: openArray[byte]): seq[byte] {.
-    gcsafe, raises: [Defect].}
+    gcsafe, raises: [].}
     ## The result will be empty seq if not found
 
   DelProc = proc (db: RootRef, key: openArray[byte]): bool {.
-    gcsafe, raises: [Defect].}
+    gcsafe, raises: [].}
 
   ContainsProc = proc (db: RootRef, key: openArray[byte]): bool {.
-    gcsafe, raises: [Defect].}
+    gcsafe, raises: [].}
 
   TrieDatabaseRef* = ref object
     obj: RootRef

--- a/eth/trie/hexary_proof_verification.nim
+++ b/eth/trie/hexary_proof_verification.nim
@@ -1,11 +1,11 @@
 # proof verification
-# Copyright (c) 2022 Status Research & Development GmbH
+# Copyright (c) 2022-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[tables, options, sequtils],

--- a/eth/utp/clock_drift_calculator.nim
+++ b/eth/utp/clock_drift_calculator.nim
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   chronos

--- a/eth/utp/delay_histogram.nim
+++ b/eth/utp/delay_histogram.nim
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   chronos,

--- a/eth/utp/ledbat_congestion_control.nim
+++ b/eth/utp/ledbat_congestion_control.nim
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   chronos,

--- a/eth/utp/packets.nim
+++ b/eth/utp/packets.nim
@@ -7,7 +7,7 @@
 # uTP packet format as specified in:
 # https://www.bittorrent.org/beps/bep_0029.html
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   faststreams,

--- a/eth/utp/utp.nim
+++ b/eth/utp/utp.nim
@@ -1,10 +1,10 @@
-# Copyright (c) 2020-2021 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   chronos, stew/[results, byteutils],
@@ -12,8 +12,9 @@ import
   ./utp_socket,
   ./utp_protocol
 
-# Exemple application to interact with reference implementation server to help with implementation
-# To run lib utp server:
+# Example application to interact with the reference implementation server
+# to be able to test against the reference implementation.
+# To run libutp server:
 # 1. git clone https://github.com/bittorrent/libutp.git
 # 2. cd libutp
 # 3. make
@@ -21,7 +22,9 @@ import
 when isMainModule:
   proc echoIncomingSocketCallBack(): AcceptConnectionCallback[TransportAddress] =
     return (
-      proc (server: UtpRouter[TransportAddress], client: UtpSocket[TransportAddress]): Future[void] {.gcsafe, raises: [Defect].} =
+      proc (server: UtpRouter[TransportAddress],
+          client: UtpSocket[TransportAddress]):
+          Future[void] {.gcsafe, raises: [].} =
         echo "received incoming connection"
         let fakeFuture = newFuture[void]()
         fakeFuture.complete()

--- a/eth/utp/utp_discv5_protocol.nim
+++ b/eth/utp/utp_discv5_protocol.nim
@@ -1,10 +1,10 @@
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[hashes, sugar],

--- a/eth/utp/utp_protocol.nim
+++ b/eth/utp/utp_protocol.nim
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[tables, options, hashes, math],
@@ -23,7 +23,9 @@ type
     transport: DatagramTransport
     utpRouter: UtpRouter[TransportAddress]
 
-  SendCallbackBuilder* = proc (d: DatagramTransport): SendCallback[TransportAddress] {.gcsafe, raises: [Defect].}
+  SendCallbackBuilder* =
+    proc (d: DatagramTransport):
+      SendCallback[TransportAddress] {.gcsafe, raises: [].}
 
 # This should probably be defined in TransportAddress module, as hash function should
 # be consistent with equality function
@@ -82,7 +84,7 @@ proc new*(
     socketConfig: SocketConfig = SocketConfig.init(),
     allowConnectionCb: AllowConnectionCallback[TransportAddress] = nil,
     sendCallbackBuilder: SendCallbackBuilder = nil,
-    rng = newRng()): UtpProtocol {.raises: [Defect, CatchableError].} =
+    rng = newRng()): UtpProtocol {.raises: [CatchableError].} =
 
   doAssert(not(isNil(acceptConnectionCb)))
 
@@ -111,7 +113,7 @@ proc new*(
     socketConfig: SocketConfig = SocketConfig.init(),
     allowConnectionCb: AllowConnectionCallback[TransportAddress] = nil,
     sendCallbackBuilder: SendCallbackBuilder = nil,
-    rng = newRng()): UtpProtocol {.raises: [Defect, CatchableError].} =
+    rng = newRng()): UtpProtocol {.raises: [CatchableError].} =
   GC_ref(udata)
   UtpProtocol.new(
     acceptConnectionCb,

--- a/eth/utp/utp_router.nim
+++ b/eth/utp/utp_router.nim
@@ -4,7 +4,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[tables, options, sugar],
@@ -38,12 +38,12 @@ type
   # ``server`` - UtpProtocol object.
   # ``client`` - accepted client utp socket.
   AcceptConnectionCallback*[A] = proc(server: UtpRouter[A],
-    client: UtpSocket[A]): Future[void] {.gcsafe, raises: [Defect].}
+    client: UtpSocket[A]): Future[void] {.gcsafe, raises: [].}
 
   # Callback to act as firewall for incoming peers. Should return true if peer
   # is allowed to connect.
   AllowConnectionCallback*[A] = proc(r: UtpRouter[A], remoteAddress: A,
-    connectionId: uint16): bool {.gcsafe, raises: [Defect], noSideEffect.}
+    connectionId: uint16): bool {.gcsafe, raises: [], noSideEffect.}
 
   # Object responsible for creating and maintaining table of utp sockets.
   # Caller should use `processIncomingBytes` proc to feed it with incoming byte

--- a/eth/utp/utp_socket.nim
+++ b/eth/utp/utp_socket.nim
@@ -4,7 +4,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/[sugar, deques],
@@ -49,7 +49,7 @@ type
 
   # Socket callback to send data to remote peer
   SendCallback*[A] =
-    proc (to: A, data: seq[byte]): Future[void] {.gcsafe, raises: [Defect]}
+    proc (to: A, data: seq[byte]): Future[void] {.gcsafe, raises: []}
 
   SocketConfig* = object
     # This is configurable (in contrast to reference impl), as with standard 2
@@ -297,7 +297,7 @@ type
 
   # User driven call back to be called whenever socket is permanently closed i.e
   # reaches destroy state
-  SocketCloseCallback* = proc (): void {.gcsafe, raises: [Defect].}
+  SocketCloseCallback* = proc (): void {.gcsafe, raises: [].}
 
   ConnectionError* = object of CatchableError
 

--- a/eth/utp/utp_utils.nim
+++ b/eth/utp/utp_utils.nim
@@ -1,10 +1,10 @@
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   chronos

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -793,7 +793,7 @@ suite "Discovery v5 Tests":
     proc handler(
         protocol: TalkProtocol, request: seq[byte],
         fromId: NodeId, fromUdpAddress: Address):
-        seq[byte] {.gcsafe, raises: [Defect].} =
+        seq[byte] {.gcsafe, raises: [].} =
       request
 
     let echoProtocol = TalkProtocol(protocolHandler: handler)
@@ -820,7 +820,7 @@ suite "Discovery v5 Tests":
     proc handler(
         protocol: TalkProtocol, request: seq[byte],
         fromId: NodeId, fromUdpAddress: Address):
-        seq[byte] {.gcsafe, raises: [Defect].} =
+        seq[byte] {.gcsafe, raises: [].} =
       request
 
     let echoProtocol = TalkProtocol(protocolHandler: handler)
@@ -844,7 +844,7 @@ suite "Discovery v5 Tests":
     proc handler(
         protocol: TalkProtocol, request: seq[byte],
         fromId: NodeId, fromUdpAddress: Address):
-        seq[byte] {.gcsafe, raises: [Defect].} =
+        seq[byte] {.gcsafe, raises: [].} =
       request
 
     let echoProtocol = TalkProtocol(protocolHandler: handler)
@@ -883,7 +883,7 @@ suite "Discovery v5 Tests":
     proc handler(
         protocol: TalkProtocol, request: seq[byte],
         fromId: NodeId, fromUdpAddress: Address):
-        seq[byte] {.gcsafe, raises: [Defect].} =
+        seq[byte] {.gcsafe, raises: [].} =
       # Return the request + same protocol id + 2 bytes, to make it 1 byte
       # bigger than the request
       request & "echo12".toBytes()

--- a/tests/trie/test_branches_utils.nim
+++ b/tests/trie/test_branches_utils.nim
@@ -58,7 +58,7 @@ suite "branches utils":
           discard getBranch(db, trie.getRootHash(), key)
         except InvalidKeyError:
           check(true)
-        except:
+        except CatchableError:
           check(false)
 
   const trieNodesData = [

--- a/tests/trie/test_hexary_proof.nim
+++ b/tests/trie/test_hexary_proof.nim
@@ -1,5 +1,5 @@
 # proof verification
-# Copyright (c) 2022 Status Research & Development GmbH
+# Copyright (c) 2022-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -7,7 +7,7 @@
 
 {.used.}
 
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   unittest2,

--- a/tests/utp/test_buffer.nim
+++ b/tests/utp/test_buffer.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -67,17 +67,17 @@ suite "Utp ring buffer":
     let textIdx = 11'u32
 
     check:
-      not buff.exists(textIdx, x => x.foo == text)
+      not buff.exists(textIdx, x {.gcsafe, raises: [].} => x.foo == text)
 
     buff.put(textIdx, TestObj(foo: "old"))
 
     check:
-      not buff.exists(textIdx, x => x.foo == text)
+      not buff.exists(textIdx, x {.gcsafe, raises: [].} => x.foo == text)
 
     buff[textIdx].foo = text
 
     check:
-      buff.exists(textIdx, x => x.foo == text)
+      buff.exists(textIdx, x {.gcsafe, raises: [].} => x.foo == text)
 
   test "Deleting elements from buffer":
     var buff = GrowableCircularBuffer[int].init(size = 4)
@@ -144,7 +144,7 @@ suite "Utp ring buffer":
     buff.ensureSize(0, 1)
     buff.put(0, 0)
 
-    # index 2 will not fit in buffer of size 2 so it will need to be expanded to 4
+    # index 2 will not fit in buffer of size 2 so it needs to be expanded to 4
     buff.ensureSize(1, 2)
     buff.put(1, 1)
 

--- a/tests/utp/test_utils.nim
+++ b/tests/utp/test_utils.nim
@@ -4,7 +4,7 @@ import
   ../../eth/utp/packets,
   ../../eth/keys
 
-type AssertionCallback = proc(): bool {.gcsafe, raises: [Defect].}
+type AssertionCallback = proc(): bool {.gcsafe, raises: [].}
 
 let testBufferSize* = 1024'u32
 let defaultRcvOutgoingId = 314'u16


### PR DESCRIPTION
As this module dropped support for Nim versions < 1.6, all Defect raises can be removed to avoid unnecessary warnings