### PR TITLE
nat.nim: breaking dependency with 'confutils'

### DIFF
--- a/eth/net/nat.nim
+++ b/eth/net/nat.nim
@@ -11,10 +11,11 @@
 import
   std/[options, os, strutils, times],
   stew/results, nat_traversal/[miniupnpc, natpmp],
-  chronicles, json_serialization/std/net, chronos, confutils,
+  chronicles, json_serialization/std/net, chronos,
   ../common/utils, ./utils as netutils
 
-export ConfigurationError
+type
+  ConfigurationError* = object of CatchableError
 
 type
   NatStrategy* = enum

--- a/eth/net/nat.nim
+++ b/eth/net/nat.nim
@@ -15,9 +15,6 @@ import
   ../common/utils, ./utils as netutils
 
 type
-  ConfigurationError* = object of CatchableError
-
-type
   NatStrategy* = enum
     NatAny
     NatUpnp
@@ -324,7 +321,7 @@ type
       of true: extIp*: ValidIpAddress
       of false: nat*: NatStrategy
 
-func parseCmdArg*(T: type NatConfig, p: string): T {.raises: [ConfigurationError].} =
+func parseCmdArg*(T: type NatConfig, p: string): T {.raises: [ValueError].} =
   case p.toLowerAscii:
     of "any":
       NatConfig(hasExtIp: false, nat: NatAny)
@@ -341,10 +338,10 @@ func parseCmdArg*(T: type NatConfig, p: string): T {.raises: [ConfigurationError
           NatConfig(hasExtIp: true, extIp: ip)
         except ValueError:
           let error = "Not a valid IP address: " & p[6..^1]
-          raise newException(ConfigurationError, error)
+          raise newException(ValueError, error)
       else:
         let error = "Not a valid NAT option: " & p
-        raise newException(ConfigurationError, error)
+        raise newException(ValueError, error)
 
 func completeCmdArg*(T: type NatConfig, val: string): seq[string] =
   return @[]


### PR DESCRIPTION
# Context
NWaku has a dependency with the module `eth/net/nat.nim`.
A problem arose when trying to generate a libwaku.so (nwaku dynamic library.) due to the `confutils` module not being suitable for generating dynamic libraries.

# Further detail
When building the `confutils` module, it has the [next](https://github.com/status-im/nim-confutils/blob/2028b41602b3abf7c9bf450744efde7b296707a2/confutils.nim#L89):
```
  proc commandLineParams(): seq[string] =
    for i in scriptNameParamIdx() + 1 .. paramCount():
      result.add paramStr(i)
```


 which leads to a compilation error when creating a dynamic library due to [this](https://github.com/status-im/Nim/blob/b1a0467ffd656f7ec5c2c18677a7efcb989d4600/lib/pure/os.nim#L3001):
 ```
else:
  proc commandLineParams*(): seq[string] {.error:
  "commandLineParams() unsupported by dynamic libraries".} =
    discard
```

# Suggested solution
Break the dependency with `confutils` module and raise a `ValueError` instead of a `ConfigurationError` exception.

 