### PR TITLE
Replace exception with assertion in rlp.append of BlockHeader

### DIFF
--- a/eth/common/eth_types_rlp.nim
+++ b/eth/common/eth_types_rlp.nim
@@ -318,14 +318,11 @@ proc append*(w: var RlpWriter, h: BlockHeader) =
   var len = 15
   if h.fee.isSome: inc len
   if h.withdrawalsRoot.isSome:
-    if h.fee.isNone:
-      raise newException(RlpError, "baseFee expected")
+    doAssert(h.fee.isSome, "baseFee expected")
     inc len
   if h.excessDataGas.isSome:
-    if h.fee.isNone:
-      raise newException(RlpError, "baseFee expected")
-    if h.withdrawalsRoot.isNone:
-      raise newException(RlpError, "withdrawalsRoot expected")
+    doAssert(h.fee.isSome, "baseFee expected")
+    doAssert(h.withdrawalsRoot.isSome, "withdrawalsRoot expected")
     inc len
   w.startList(len)
   for k, v in fieldPairs(h):

--- a/tests/rlp/test_rlp_codec.nim
+++ b/tests/rlp/test_rlp_codec.nim
@@ -2,7 +2,7 @@
 
 import
   std/[os, strutils],
-  stew/[io2, results],
+  stew/[io2, results, shims/stddefects],
   unittest2,
   ../../eth/[rlp, common]
 
@@ -67,7 +67,7 @@ suite "BlockHeader roundtrip test":
   
   test "Header + none(baseFee) + some(withdrawalsRoot)":
     let h = BlockHeader(withdrawalsRoot: some(Hash256()))
-    expect RlpError:
+    expect AssertionDefect:
       roundTrip(h)
   
   test "Header + none(baseFee) + some(withdrawalsRoot) + some(excessDataGas)":
@@ -75,14 +75,14 @@ suite "BlockHeader roundtrip test":
       withdrawalsRoot: some(Hash256()), 
       excessDataGas: some(1.u256)
     )
-    expect RlpError:
+    expect AssertionDefect:
       roundTrip(h)
   
   test "Header + none(baseFee) + none(withdrawalsRoot) + some(excessDataGas)":
     let h = BlockHeader(      
       excessDataGas: some(1.u256)
     )
-    expect RlpError:
+    expect AssertionDefect:
       roundTrip(h)
   
   test "Header + some(baseFee) + none(withdrawalsRoot) + some(excessDataGas)":
@@ -90,7 +90,7 @@ suite "BlockHeader roundtrip test":
       fee: some(2.u256),
       excessDataGas: some(1.u256)
     )
-    expect RlpError:
+    expect AssertionDefect:
       roundTrip(h)
       
   test "Header + some(baseFee) + some(withdrawalsRoot)":


### PR DESCRIPTION
Using exception in rlp.append turn out creates more problem than it solve. `blockHash` operation is literally everywhere in nimbus-eth1, nimbus-eth2, and fluffy-code. The compiler begins to complain about unlisted exception. Rlp bytes coming from network and test vectors already verified by the decoder. So, any invalid optional fields of blockheader that come into rlp.append means programming error. Assertion will be more apropiate in this situation and less problematic.