### PR TITLE
typealias for allowing different RNG contexts

### DIFF
--- a/doc/discv5.md
+++ b/doc/discv5.md
@@ -15,7 +15,7 @@ and `rlp`.
 
 ```Nim
 let
-  rng = keys.newRng
+  rng = SecureRngContext.new()
   privKey = PrivateKey.random(rng[])
   (ip, tcpPort, udpPort) = setupNat(config) # Or fill in external IP/ports manually
   d = newProtocol(privKey, ip, tcpPort, udpPort, rng = rng)

--- a/eth/common/random2.nim
+++ b/eth/common/random2.nim
@@ -12,11 +12,6 @@ import bearssl/rand
 
 type SecureRngContext* = HmacDrbgContext
 
-proc newRng*(): ref SecureRngContext =
-  # You should only create one instance of the RNG per application / library
-  # Ref is used so that it can be shared between components
-  SecureRngContext.new()
-
 ## Random helpers: similar as in stdlib, but with SecureRngContext rng
 # TODO: Move these somewhere else?
 const randMax = 18_446_744_073_709_551_615'u64

--- a/eth/common/random2.nim
+++ b/eth/common/random2.nim
@@ -8,12 +8,14 @@
 
 {.push raises: [].}
 
-import
-  bearssl/rand
-
-export rand
+import bearssl/rand
 
 type SecureRngContext* = HmacDrbgContext
+
+proc newRng*(): ref SecureRngContext =
+  # You should only create one instance of the RNG per application / library
+  # Ref is used so that it can be shared between components
+  SecureRngContext.new()
 
 ## Random helpers: similar as in stdlib, but with SecureRngContext rng
 # TODO: Move these somewhere else?

--- a/eth/common/random2.nim
+++ b/eth/common/random2.nim
@@ -12,6 +12,8 @@ import bearssl/rand
 
 type SecureRngContext* = HmacDrbgContext
 
+export rand.generate
+
 ## Random helpers: similar as in stdlib, but with SecureRngContext rng
 # TODO: Move these somewhere else?
 const randMax = 18_446_744_073_709_551_615'u64

--- a/eth/keys.nim
+++ b/eth/keys.nim
@@ -16,13 +16,13 @@
 
 import
   std/strformat,
-  secp256k1, bearssl/hash as bhash, bearssl/rand,
+  secp256k1,
   stew/[byteutils, objects, results, ptrops],
-  ./common/eth_hash
+  ./common/[eth_hash, random2]
 
 from nimcrypto/utils import burnMem
 
-export secp256k1, results, rand
+export secp256k1, results, random2
 
 const
   KeyLength* = SkEcdhSecretSize
@@ -62,11 +62,6 @@ type
 
 template pubkey*(v: KeyPair): PublicKey = PublicKey(SkKeyPair(v).pubkey)
 template seckey*(v: KeyPair): PrivateKey = PrivateKey(SkKeyPair(v).seckey)
-
-proc newRng*(): ref SecureRngContext =
-  # You should only create one instance of the RNG per application / library
-  # Ref is used so that it can be shared between components
-  SecureRngContext.new()
 
 proc random*(T: type PrivateKey, rng: var SecureRngContext): T =
   let rngPtr = unsafeAddr rng # doesn't escape

--- a/eth/keys.nim
+++ b/eth/keys.nim
@@ -63,12 +63,12 @@ type
 template pubkey*(v: KeyPair): PublicKey = PublicKey(SkKeyPair(v).pubkey)
 template seckey*(v: KeyPair): PrivateKey = PrivateKey(SkKeyPair(v).seckey)
 
-proc newRng*(): ref HmacDrbgContext =
+proc newRng*(): ref SecureRngContext =
   # You should only create one instance of the RNG per application / library
   # Ref is used so that it can be shared between components
-  HmacDrbgContext.new()
+  SecureRngContext.new()
 
-proc random*(T: type PrivateKey, rng: var HmacDrbgContext): T =
+proc random*(T: type PrivateKey, rng: var SecureRngContext): T =
   let rngPtr = unsafeAddr rng # doesn't escape
   proc callRng(data: var openArray[byte]) =
     generate(rngPtr[], data)
@@ -109,7 +109,7 @@ func toRaw*(pubkey: PublicKey): array[RawPublicKeySize, byte] =
 
 func toRawCompressed*(pubkey: PublicKey): array[33, byte] {.borrow.}
 
-proc random*(T: type KeyPair, rng: var HmacDrbgContext): T =
+proc random*(T: type KeyPair, rng: var SecureRngContext): T =
   let seckey = SkSecretKey(PrivateKey.random(rng))
   KeyPair(SkKeyPair(
     seckey: seckey,

--- a/eth/p2p.nim
+++ b/eth/p2p.nim
@@ -10,7 +10,7 @@
 import
   std/[tables, algorithm, random, typetraits, strutils, net],
   chronos, chronos/timer, chronicles,
-  ./keys, ./p2p/private/p2p_types,
+  ./common/random2, ./keys, ./p2p/private/p2p_types,
   ./p2p/[kademlia, discovery, enode, peer_pool, rlpx]
 
 export
@@ -85,10 +85,8 @@ proc newEthereumNode*(
     bindUdpPort: Port,
     bindTcpPort: Port,
     bindIp = IPv4_any(),
-    rng = newRng()): EthereumNode =
-
-  if rng == nil: # newRng could fail
-    raise (ref Defect)(msg: "Cannot initialize RNG")
+    rng = SecureRngContext.new()): EthereumNode =
+  doAssert rng != nil, "Cannot initialize RNG"
 
   new result
   result.keys = keys

--- a/eth/p2p/auth.nim
+++ b/eth/p2p/auth.nim
@@ -110,7 +110,7 @@ proc mapErrTo[T, E](r: Result[T, E], v: static AuthError): AuthResult[T] =
   r.mapErr(proc (e: E): AuthError = v)
 
 proc init*(
-    T: type Handshake, rng: var HmacDrbgContext, host: KeyPair,
+    T: type Handshake, rng: var SecureRngContext, host: KeyPair,
     flags: set[HandshakeFlag] = {Initiator},
     version: uint8 = SupportedRlpxVersion): T =
   ## Create new `Handshake` object.
@@ -138,7 +138,7 @@ proc init*(
   )
 
 proc authMessagePreEIP8(h: var Handshake,
-                        rng: var HmacDrbgContext,
+                        rng: var SecureRngContext,
                         pubkey: PublicKey,
                         output: var openArray[byte],
                         outlen: var int,
@@ -177,7 +177,7 @@ proc authMessagePreEIP8(h: var Handshake,
   ok()
 
 proc authMessageEIP8(h: var Handshake,
-                     rng: var HmacDrbgContext,
+                     rng: var SecureRngContext,
                      pubkey: PublicKey,
                      output: var openArray[byte],
                      outlen: var int,
@@ -240,7 +240,7 @@ proc authMessageEIP8(h: var Handshake,
   ok()
 
 proc ackMessagePreEIP8(h: var Handshake,
-                       rng: var HmacDrbgContext,
+                       rng: var SecureRngContext,
                        output: var openArray[byte],
                        outlen: var int,
                        flag: byte = 0,
@@ -267,7 +267,7 @@ proc ackMessagePreEIP8(h: var Handshake,
   ok()
 
 proc ackMessageEIP8(h: var Handshake,
-                    rng: var HmacDrbgContext,
+                    rng: var SecureRngContext,
                     output: var openArray[byte],
                     outlen: var int,
                     flag: byte = 0,
@@ -327,7 +327,7 @@ template ackSize*(h: Handshake, encrypt: bool = true): int =
   else:
     if encrypt: (AckMessageV4Length) else: (PlainAckMessageV4Length)
 
-proc authMessage*(h: var Handshake, rng: var HmacDrbgContext,
+proc authMessage*(h: var Handshake, rng: var SecureRngContext,
                   pubkey: PublicKey,
                   output: var openArray[byte],
                   outlen: var int, flag: byte = 0,
@@ -339,7 +339,7 @@ proc authMessage*(h: var Handshake, rng: var HmacDrbgContext,
   else:
     authMessagePreEIP8(h, rng, pubkey, output, outlen, flag, encrypt)
 
-proc ackMessage*(h: var Handshake, rng: var HmacDrbgContext,
+proc ackMessage*(h: var Handshake, rng: var SecureRngContext,
                  output: var openArray[byte],
                  outlen: var int, flag: byte = 0,
                  encrypt: bool = true): AuthResult[void] =

--- a/eth/p2p/discovery.nim
+++ b/eth/p2p/discovery.nim
@@ -11,7 +11,7 @@ import
   std/[times, net],
   chronos, stint, nimcrypto/keccak, chronicles,
   stew/[objects, results],
-  ".."/[keys, rlp],
+  ../common/random2, ../rlp,
   "."/[kademlia, enode]
 
 export
@@ -154,7 +154,9 @@ proc newDiscoveryProtocol*(
     privKey: PrivateKey, address: Address,
     bootstrapNodes: openArray[ENode],
     bindPort: Port, bindIp = IPv4_any(),
-    rng = newRng()): DiscoveryProtocol =
+    rng = SecureRngContext.new()): DiscoveryProtocol =
+  doAssert rng != nil, "Cannot initialize RNG"
+
   let
     localNode = newNode(privKey.toPublicKey(), address)
     discovery = DiscoveryProtocol(

--- a/eth/p2p/discoveryv5/encoding.nim
+++ b/eth/p2p/discoveryv5/encoding.nim
@@ -17,7 +17,7 @@ import
   std/[tables, options, hashes, net],
   nimcrypto/[bcmode, rijndael, sha2], stint, chronicles,
   stew/[results, byteutils], metrics,
-  ".."/../[rlp, keys],
+  ../../common/random2, ".."/../[rlp, keys],
   "."/[messages_encoding, node, enr, hkdf, sessions]
 
 from stew/objects import checkedEnumAssign

--- a/eth/p2p/discoveryv5/encoding.nim
+++ b/eth/p2p/discoveryv5/encoding.nim
@@ -199,7 +199,7 @@ proc encodeStaticHeader*(flag: Flag, nonce: AESGCMNonce, authSize: int):
   # TODO: assert on authSize of > 2^16?
   result.add((uint16(authSize)).toBytesBE())
 
-proc encodeMessagePacket*(rng: var HmacDrbgContext, c: var Codec,
+proc encodeMessagePacket*(rng: var SecureRngContext, c: var Codec,
     toId: NodeId, toAddr: Address, message: openArray[byte]):
     (seq[byte], AESGCMNonce) =
   let
@@ -244,7 +244,7 @@ proc encodeMessagePacket*(rng: var HmacDrbgContext, c: var Codec,
 
   return (packet, nonce)
 
-proc encodeWhoareyouPacket*(rng: var HmacDrbgContext, c: var Codec,
+proc encodeWhoareyouPacket*(rng: var SecureRngContext, c: var Codec,
     toId: NodeId, toAddr: Address, requestNonce: AESGCMNonce, recordSeq: uint64,
     pubkey: Option[PublicKey]): seq[byte] =
   let
@@ -285,7 +285,7 @@ proc encodeWhoareyouPacket*(rng: var HmacDrbgContext, c: var Codec,
 
   return packet
 
-proc encodeHandshakePacket*(rng: var HmacDrbgContext, c: var Codec,
+proc encodeHandshakePacket*(rng: var SecureRngContext, c: var Codec,
     toId: NodeId, toAddr: Address, message: openArray[byte],
     whoareyouData: WhoareyouData, pubkey: PublicKey): seq[byte] =
   let

--- a/eth/p2p/discoveryv5/messages.nim
+++ b/eth/p2p/discoveryv5/messages.nim
@@ -104,7 +104,7 @@ template messageKind*(T: typedesc[SomeMessage]): MessageKind =
   elif T is TalkReqMessage: talkReq
   elif T is TalkRespMessage: talkResp
 
-func init*(T: type RequestId, rng: var HmacDrbgContext): T =
+func init*(T: type RequestId, rng: var SecureRngContext): T =
   var reqId = RequestId(id: newSeq[byte](8)) # RequestId must be <= 8 bytes
   rng.generate(reqId.id)
   reqId

--- a/eth/p2p/discoveryv5/node.nim
+++ b/eth/p2p/discoveryv5/node.nim
@@ -86,7 +86,7 @@ func `==`*(a, b: Node): bool =
 func hash*(id: NodeId): Hash =
   hash(id.toByteArrayBE)
 
-proc random*(T: type NodeId, rng: var HmacDrbgContext): T =
+proc random*(T: type NodeId, rng: var SecureRngContext): T =
   rng.generate(T)
 
 func `$`*(id: NodeId): string =

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -149,7 +149,7 @@ type
     # overkill here, use sequence
     handshakeTimeout: Duration
     responseTimeout: Duration
-    rng*: ref HmacDrbgContext
+    rng*: ref SecureRngContext
 
   PendingRequest = object
     node: Node

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -963,8 +963,9 @@ proc newProtocol*(
     bindIp = IPv4_any(),
     enrAutoUpdate = false,
     config = defaultDiscoveryConfig,
-    rng = newRng()):
+    ng = SecureRngContext.new()):
     Protocol =
+  doAssert rng != nil, "Cannot initialize RNG"
   # TODO: Tried adding bindPort = udpPort as parameter but that gave
   # "Error: internal error: environment misses: udpPort" in nim-beacon-chain.
   # Anyhow, nim-beacon-chain would also require some changes to support port

--- a/eth/p2p/discoveryv5/random2.nim
+++ b/eth/p2p/discoveryv5/random2.nim
@@ -13,11 +13,13 @@ import
 
 export rand
 
-## Random helpers: similar as in stdlib, but with HmacDrbgContext rng
+type SecureRngContext* = HmacDrbgContext
+
+## Random helpers: similar as in stdlib, but with SecureRngContext rng
 # TODO: Move these somewhere else?
 const randMax = 18_446_744_073_709_551_615'u64
 
-proc rand*(rng: var HmacDrbgContext, max: Natural): int =
+proc rand*(rng: var SecureRngContext, max: Natural): int =
   if max == 0: return 0
 
   var x: uint64
@@ -26,10 +28,10 @@ proc rand*(rng: var HmacDrbgContext, max: Natural): int =
     if x < randMax - (randMax mod (uint64(max) + 1'u64)): # against modulo bias
       return int(x mod (uint64(max) + 1'u64))
 
-proc sample*[T](rng: var HmacDrbgContext, a: openArray[T]): T =
+proc sample*[T](rng: var SecureRngContext, a: openArray[T]): T =
   a[rng.rand(a.high)]
 
-proc shuffle*[T](rng: var HmacDrbgContext, a: var openArray[T]) =
+proc shuffle*[T](rng: var SecureRngContext, a: var openArray[T]) =
   for i in countdown(a.high, 1):
     let j = rng.rand(i)
     swap(a[i], a[j])

--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -46,7 +46,7 @@ type
     ipLimits: IpLimits ## IP limits for total routing table: all buckets and
     ## replacement caches.
     distanceCalculator: DistanceCalculator
-    rng: ref HmacDrbgContext
+    rng: ref SecureRngContext
 
   KBucket = ref object
     istart, iend: NodeId ## Range of NodeIds this KBucket covers. This is not a
@@ -264,7 +264,7 @@ proc computeSharedPrefixBits(nodes: openArray[NodeId]): int =
   doAssert(false, "Unable to calculate number of shared prefix bits")
 
 proc init*(T: type RoutingTable, localNode: Node, bitsPerHop = DefaultBitsPerHop,
-    ipLimits = DefaultTableIpLimits, rng: ref HmacDrbgContext,
+    ipLimits = DefaultTableIpLimits, rng: ref SecureRngContext,
     distanceCalculator = XorDistanceCalculator): T =
   ## Initialize the routing table for provided `Node` and bitsPerHop value.
   ## `bitsPerHop` is default set to 5 as recommended by original Kademlia paper.

--- a/eth/p2p/ecies.nim
+++ b/eth/p2p/ecies.nim
@@ -94,7 +94,7 @@ proc kdf*(data: openArray[byte]): array[KeyLength, byte] {.noinit.} =
   ctx.clear() # clean ctx
   copyMem(addr result[0], addr storage[0], KeyLength)
 
-proc eciesEncrypt*(rng: var HmacDrbgContext, input: openArray[byte],
+proc eciesEncrypt*(rng: var SecureRngContext, input: openArray[byte],
                    output: var openArray[byte], pubkey: PublicKey,
                    sharedmac: openArray[byte] = emptyMac): EciesResult[void] =
   ## Encrypt data with ECIES method using given public key `pubkey`.

--- a/eth/p2p/kademlia.nim
+++ b/eth/p2p/kademlia.nim
@@ -32,7 +32,7 @@ type
     pongFutures: Table[seq[byte], Future[bool]]
     pingFutures: Table[Node, Future[bool]]
     neighboursCallbacks: Table[Node, proc(n: seq[Node]) {.gcsafe, raises: [].}]
-    rng: ref HmacDrbgContext
+    rng: ref SecureRngContext
     pingPongTime: OrderedTable[TimeKey, int64] # int64 -> unix time
 
   NodeId* = UInt256

--- a/eth/p2p/kademlia.nim
+++ b/eth/p2p/kademlia.nim
@@ -10,7 +10,7 @@
 import
   std/[tables, hashes, times, algorithm, sets, sequtils],
   chronos, chronicles, stint, nimcrypto/keccak, metrics,
-  ../keys, ./discoveryv5/random2,
+  ../common/random2, ../keys,
   ./enode
 
 export sets # TODO: This should not be needed, but compilation fails otherwise
@@ -344,8 +344,9 @@ proc len(r: RoutingTable): int =
   for b in r.buckets: result += b.len
 
 proc newKademliaProtocol*[Wire](
-    thisNode: Node, wire: Wire, rng = newRng()): KademliaProtocol[Wire] =
-  if rng == nil: raiseAssert "Need an RNG" # doAssert gives compile error on mac
+    thisNode: Node, wire: Wire,
+    rng = SecureRngContext.new()): KademliaProtocol[Wire] =
+  doAssert rng != nil, "Cannot initialize RNG"
 
   result.new()
   result.thisNode = thisNode

--- a/eth/p2p/private/p2p_types.nim
+++ b/eth/p2p/private/p2p_types.nim
@@ -37,7 +37,7 @@ type
     discovery*: DiscoveryProtocol
     when useSnappy:
       protocolVersion*: uint
-    rng*: ref HmacDrbgContext
+    rng*: ref SecureRngContext
 
   Peer* = ref object
     remote*: Node

--- a/eth/utp/packets.nim
+++ b/eth/utp/packets.nim
@@ -76,11 +76,11 @@ proc getMonoTimestamp*(): TimeStampInfo =
   TimeStampInfo(moment: currentMoment, timestamp: timestamp)
 
 # Simple generator, not useful for cryptography
-proc randUint16*(rng: var HmacDrbgContext): uint16 =
+proc randUint16*(rng: var SecureRngContext): uint16 =
   uint16(rand(rng, int(high(uint16))))
 
 # Simple generator, not useful for cryptography
-proc randUint32*(rng: var HmacDrbgContext): uint32 =
+proc randUint32*(rng: var SecureRngContext): uint32 =
   uint32(rand(rng, int(high(uint32))))
 
 func encodeTypeVer(h: PacketHeaderV1): uint8 =

--- a/eth/utp/utp_protocol.nim
+++ b/eth/utp/utp_protocol.nim
@@ -84,9 +84,10 @@ proc new*(
     socketConfig: SocketConfig = SocketConfig.init(),
     allowConnectionCb: AllowConnectionCallback[TransportAddress] = nil,
     sendCallbackBuilder: SendCallbackBuilder = nil,
-    rng = newRng()): UtpProtocol {.raises: [CatchableError].} =
+    rng = SecureRngContext.new()): UtpProtocol {.raises: [CatchableError].} =
 
   doAssert(not(isNil(acceptConnectionCb)))
+  doAssert rng != nil, "Cannot initialize RNG"
 
   let router = UtpRouter[TransportAddress].new(
     acceptConnectionCb,
@@ -113,7 +114,9 @@ proc new*(
     socketConfig: SocketConfig = SocketConfig.init(),
     allowConnectionCb: AllowConnectionCallback[TransportAddress] = nil,
     sendCallbackBuilder: SendCallbackBuilder = nil,
-    rng = newRng()): UtpProtocol {.raises: [CatchableError].} =
+    rng = SecureRngContext.new()): UtpProtocol {.raises: [CatchableError].} =
+  doAssert rng != nil, "Cannot initialize RNG"
+  
   GC_ref(udata)
   UtpProtocol.new(
     acceptConnectionCb,

--- a/eth/utp/utp_router.nim
+++ b/eth/utp/utp_router.nim
@@ -57,7 +57,7 @@ type
    sendCb*: SendCallback[A]
    allowConnection*: AllowConnectionCallback[A]
    udata: pointer
-   rng*: ref HmacDrbgContext
+   rng*: ref SecureRngContext
 
 const
   # Maximal number of tries to generate unique socket while establishing

--- a/eth/utp/utp_router.nim
+++ b/eth/utp/utp_router.nim
@@ -118,8 +118,9 @@ proc new*[A](
     allowConnectionCb: AllowConnectionCallback[A],
     udata: pointer,
     socketConfig: SocketConfig = SocketConfig.init(),
-    rng = newRng()): UtpRouter[A] =
+    rng = SecureRngContext.new()): UtpRouter[A] =
   doAssert(not(isNil(acceptConnectionCb)))
+  doAssert rng != nil, "Cannot initialize RNG"
   UtpRouter[A](
     sockets: initTable[UtpSocketKey[A], UtpSocket[A]](),
     acceptConnection: acceptConnectionCb,
@@ -133,7 +134,8 @@ proc new*[A](
     T: type UtpRouter[A],
     acceptConnectionCb: AcceptConnectionCallback[A],
     socketConfig: SocketConfig = SocketConfig.init(),
-    rng = newRng()): UtpRouter[A] =
+    rng = SecureRngContext.new()): UtpRouter[A] =
+  doAssert rng != nil, "Cannot initialize RNG"
   UtpRouter[A].new(acceptConnectionCb, nil, nil, socketConfig, rng)
 
 proc new*[A](
@@ -142,8 +144,9 @@ proc new*[A](
     allowConnectionCb: AllowConnectionCallback[A],
     udata: ref,
     socketConfig: SocketConfig = SocketConfig.init(),
-    rng = newRng()): UtpRouter[A] =
+    rng = SecureRngContext.new()): UtpRouter[A] =
   doAssert(not(isNil(acceptConnectionCb)))
+  doAssert rng != nil, "Cannot initialize RNG"
   GC_ref(udata)
   UtpRouter[A].new(
     acceptConnectionCb, allowConnectionCb,
@@ -154,7 +157,8 @@ proc new*[A](
     acceptConnectionCb: AcceptConnectionCallback[A],
     udata: ref,
     socketConfig: SocketConfig = SocketConfig.init(),
-    rng = newRng()): UtpRouter[A] =
+    rng = SecureRngContext.new()): UtpRouter[A] =
+  doAssert rng != nil, "Cannot initialize RNG"
   UtpRouter[A].new(acceptConnectionCb, nil, udata, socketConfig, rng)
 
 proc getUserData*[A, T](router: UtpRouter[A]): T =

--- a/eth/utp/utp_socket.nim
+++ b/eth/utp/utp_socket.nim
@@ -1939,7 +1939,7 @@ proc newOutgoingSocket*[A](
   snd: SendCallback[A],
   cfg: SocketConfig,
   rcvConnectionId: uint16,
-  rng: var HmacDrbgContext
+  rng: var SecureRngContext
 ): UtpSocket[A] =
   let sndConnectionId = rcvConnectionId + 1
   let initialSeqNr = randUint16(rng)
@@ -1964,7 +1964,7 @@ proc newIncomingSocket*[A](
   cfg: SocketConfig,
   connectionId: uint16,
   ackNr: uint16,
-  rng: var HmacDrbgContext
+  rng: var SecureRngContext
 ): UtpSocket[A] =
   let initialSeqNr = randUint16(rng)
 

--- a/tests/fuzzing/discoveryv5/fuzz_decode_packet.nim
+++ b/tests/fuzzing/discoveryv5/fuzz_decode_packet.nim
@@ -7,7 +7,7 @@ init:
     nodeAKey = "0xeef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f"
     nodeBKey = "0x66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb1cde628"
   let
-    rng = newRng()
+    rng = SecureRngContext.new()
     privKeyA = PrivateKey.fromHex(nodeAKey)[] # sender -> encode
     privKeyB = PrivateKey.fromHex(nodeBKey)[] # receive -> decode
 

--- a/tests/fuzzing/enr/generate.nim
+++ b/tests/fuzzing/enr/generate.nim
@@ -9,7 +9,7 @@ const inputsDir = sourceDir / "corpus"
 
 proc generate() =
   let
-    rng = newRng()
+    rng = SecureRngContext.new()
     privKey = PrivateKey.random(rng[])
     ip = some(ValidIpAddress.init("127.0.0.1"))
     port = some(Port(20301))

--- a/tests/fuzzing/rlpx/thunk.nim
+++ b/tests/fuzzing/rlpx/thunk.nim
@@ -9,7 +9,7 @@ var
   node2: EthereumNode
   peer: Peer
 
-let rng = newRng()
+let rng = SecureRngContext.new()
 # This is not a good example of a fuzzing test and it would be much better
 # to mock more to get rid of anything sockets, async, etc.
 # However, it can and has provided reasonably quick results anyhow.

--- a/tests/keyfile/test_keyfile.nim
+++ b/tests/keyfile/test_keyfile.nim
@@ -17,7 +17,7 @@ import
 # Test vectors copied from
 # https://github.com/ethereum/tests/blob/develop/KeyStoreTests/basic_tests.json
 
-let rng = newRng()
+let rng = SecureRngContext.new()
 
 var TestVectors = [
   %*{

--- a/tests/keys/test_keys.nim
+++ b/tests/keys/test_keys.nim
@@ -25,7 +25,7 @@ proc compare(x: openArray[byte], y: openArray[byte]): bool =
         break
 
 let message = "message".toBytes()
-let rng = newRng()
+let rng = SecureRngContext.new()
 
 const
   pkbytes = "58d23b55bc9cdce1f18c2500f40ff4ab7245df9a89505e9b1fa4851f623d241d"

--- a/tests/p2p/discv5_test_helper.nim
+++ b/tests/p2p/discv5_test_helper.nim
@@ -10,7 +10,7 @@ proc localAddress*(port: int): Address =
   Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(port))
 
 proc initDiscoveryNode*(
-    rng: ref HmacDrbgContext,
+    rng: ref SecureRngContext,
     privKey: PrivateKey,
     address: Address,
     bootstrapRecords: openArray[Record] = [],
@@ -47,14 +47,14 @@ proc generateNode*(privKey: PrivateKey, port: int = 20302,
     some(port), some(port), localEnrFields).expect("Properly initialized private key")
   result = newNode(enr).expect("Properly initialized node")
 
-proc generateNRandomNodes*(rng: var HmacDrbgContext, n: int): seq[Node] =
+proc generateNRandomNodes*(rng: var SecureRngContext, n: int): seq[Node] =
   var res = newSeq[Node]()
   for i in 1..n:
     let node = generateNode(PrivateKey.random(rng))
     res.add(node)
   res
 
-proc nodeAndPrivKeyAtDistance*(n: Node, rng: var HmacDrbgContext, d: uint32,
+proc nodeAndPrivKeyAtDistance*(n: Node, rng: var SecureRngContext, d: uint32,
     ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): (Node, PrivateKey) =
   while true:
     let pk = PrivateKey.random(rng)
@@ -62,19 +62,19 @@ proc nodeAndPrivKeyAtDistance*(n: Node, rng: var HmacDrbgContext, d: uint32,
     if logDistance(n.id, node.id) == d:
       return (node, pk)
 
-proc nodeAtDistance*(n: Node, rng: var HmacDrbgContext, d: uint32,
+proc nodeAtDistance*(n: Node, rng: var SecureRngContext, d: uint32,
     ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): Node =
   let (node, _) = n.nodeAndPrivKeyAtDistance(rng, d, ip)
   node
 
 proc nodesAtDistance*(
-    n: Node, rng: var HmacDrbgContext, d: uint32, amount: int,
+    n: Node, rng: var SecureRngContext, d: uint32, amount: int,
     ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): seq[Node] =
   for i in 0..<amount:
     result.add(nodeAtDistance(n, rng, d, ip))
 
 proc nodesAtDistanceUniqueIp*(
-    n: Node, rng: var HmacDrbgContext, d: uint32, amount: int,
+    n: Node, rng: var SecureRngContext, d: uint32, amount: int,
     ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): seq[Node] =
   var ta = initTAddress(ip, Port(0))
   for i in 0..<amount:

--- a/tests/p2p/p2p_test_helper.nim
+++ b/tests/p2p/p2p_test_helper.nim
@@ -11,7 +11,7 @@ proc localAddress*(port: int): Address =
                    ip: parseIpAddress("127.0.0.1"))
 
 proc setupTestNode*(
-    rng: ref HmacDrbgContext,
+    rng: ref SecureRngContext,
     capabilities: varargs[ProtocolInfo, `protocolInfo`]): EthereumNode {.gcsafe.} =
   # Don't create new RNG every time in production code!
   let keys1 = KeyPair.random(rng[])

--- a/tests/p2p/test_auth.nim
+++ b/tests/p2p/test_auth.nim
@@ -202,7 +202,7 @@ const eip8data = [
    "0c7ec6340062cc46f5e9f1e3cf86f8c8c403c5a0964f5df0ebd34a75ddc86db5")
 ]
 
-let rng = newRng()
+let rng = SecureRngContext.new()
 
 proc testValue(s: string): string =
   for item in data:

--- a/tests/p2p/test_crypt.nim
+++ b/tests/p2p/test_crypt.nim
@@ -83,7 +83,7 @@ const data = [
       e7c301a0c05559f4c25db65e36820b4b909a226171a60ac6cb7beea09376d6d8""")
 ]
 
-let rng = newRng()
+let rng = SecureRngContext.new()
 
 proc testValue(s: string): string =
   for item in data:

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -13,7 +13,7 @@ import
 
 suite "Discovery v5 Tests":
   setup:
-    let rng = newRng()
+    let rng = SecureRngContext.new()
 
   asyncTest "GetNode":
     # TODO: This could be tested in just a routing table only context
@@ -645,7 +645,7 @@ suite "Discovery v5 Tests":
       check test.len == 1
 
   test "Calculate lookup distances":
-    let rng = newRng()
+    let rng = SecureRngContext.new()
     let node = generateNode(PrivateKey.random(rng[]))
 
     # Log distance between zeros is zero

--- a/tests/p2p/test_discoveryv5_encoding.nim
+++ b/tests/p2p/test_discoveryv5_encoding.nim
@@ -8,7 +8,7 @@ import
   ../../eth/p2p/discoveryv5/[messages_encoding, encoding, enr, node, sessions],
   ../stubloglevel
 
-let rng = newRng()
+let rng = SecureRngContext.new()
 
 suite "Discovery v5.1 Protocol Message Encodings":
   test "Ping Request":

--- a/tests/p2p/test_ecies.nim
+++ b/tests/p2p/test_ecies.nim
@@ -26,7 +26,7 @@ proc compare[A, B](x: openArray[A], y: openArray[B], s: int = 0): bool =
 template offsetOf(a, b): int =
   cast[int](cast[uint](unsafeAddr b) - cast[uint](unsafeAddr a))
 
-let rng = newRng()
+let rng = SecureRngContext.new()
 
 suite "ECIES test suite":
   test "ECIES structures alignment":

--- a/tests/p2p/test_enr.nim
+++ b/tests/p2p/test_enr.nim
@@ -12,7 +12,7 @@ import
   stew/shims/net,
   ../../eth/p2p/discoveryv5/enr, ../../eth/[keys, rlp]
 
-let rng = newRng()
+let rng = SecureRngContext.new()
 
 suite "ENR":
   test "Serialization":

--- a/tests/p2p/test_ip_vote.nim
+++ b/tests/p2p/test_ip_vote.nim
@@ -6,7 +6,7 @@ import
   ../../eth/keys, ../../eth/p2p/discoveryv5/[node, ip_vote]
 
 suite "IP vote":
-  let rng = newRng()
+  let rng = SecureRngContext.new()
 
   test "Majority vote":
     var

--- a/tests/p2p/test_protocol_handlers.nim
+++ b/tests/p2p/test_protocol_handlers.nim
@@ -59,7 +59,7 @@ p2pProtocol hah(version = 1,
 
 suite "Testing protocol handlers":
   asyncTest "Failing disconnection handler":
-    let rng = newRng()
+    let rng = SecureRngContext.new()
 
     var node1 = setupTestNode(rng, abc, xyz)
     var node2 = setupTestNode(rng, abc, xyz)
@@ -79,7 +79,7 @@ suite "Testing protocol handlers":
       node1.protocolState(xyz).count == 0
 
   asyncTest "Failing connection handler":
-    let rng = newRng()
+    let rng = SecureRngContext.new()
 
     var node1 = setupTestNode(rng, hah)
     var node2 = setupTestNode(rng, hah)
@@ -91,7 +91,7 @@ suite "Testing protocol handlers":
       node1.protocolState(hah).count == 0
 
   test "Override network state":
-    let rng = newRng()
+    let rng = SecureRngContext.new()
     var node = setupTestNode(rng, hah)
     node.addCapability(hah, network(count: 3))
     check node.protocolState(hah).count == 3

--- a/tests/p2p/test_rlpx_thunk.nim
+++ b/tests/p2p/test_rlpx_thunk.nim
@@ -9,7 +9,7 @@ import
   ./p2p_test_helper,
   ./eth_protocol
 
-let rng = newRng()
+let rng = SecureRngContext.new()
 
 var
   node1 = setupTestNode(rng, eth)

--- a/tests/p2p/test_routing_table.nim
+++ b/tests/p2p/test_routing_table.nim
@@ -20,7 +20,7 @@ func customIdAdDist*(id: NodeId, dist: uint16): NodeId =
   id + u256(dist)
 
 suite "Routing Table Tests":
-  let rng = newRng()
+  let rng = SecureRngContext.new()
 
   # Used for testing. Could also at runtime check whether the address is the
   # loopback address as these are only allowed to be added when coming from

--- a/tests/utp/test_discv5_protocol.nim
+++ b/tests/utp/test_discv5_protocol.nim
@@ -20,7 +20,7 @@ import
   ../stubloglevel
 
 procSuite "Utp protocol over discovery v5 tests":
-  let rng = newRng()
+  let rng = SecureRngContext.new()
   let utpProtId = "test-utp".toBytes()
 
   proc registerIncomingSocketCallback(serverSockets: AsyncQueue): AcceptConnectionCallback[NodeAddress] =

--- a/tests/utp/test_protocol.nim
+++ b/tests/utp/test_protocol.nim
@@ -121,7 +121,7 @@ proc close(s: TwoClientsServerScenario) {.async.} =
   await s.utp3.shutdownWait()
 
 procSuite "Utp protocol over udp tests":
-  let rng = newRng()
+  let rng = SecureRngContext.new()
 
   asyncTest "Success connect to remote host":
     let server1Called = newAsyncEvent()

--- a/tests/utp/test_protocol_integration.nim
+++ b/tests/utp/test_protocol_integration.nim
@@ -52,7 +52,7 @@ proc getServerSocket(
     return some(srvSocket)
 
 procSuite "Utp protocol over udp tests with loss and delays":
-  let rng = newRng()
+  let rng = SecureRngContext.new()
 
   proc sendBuilder(maxDelay: int, packetDropRate: int): SendCallbackBuilder =
     return (

--- a/tests/utp/test_utils.nim
+++ b/tests/utp/test_utils.nim
@@ -86,7 +86,7 @@ proc generateDataPackets*(
   initialSeqNr: uint16,
   connectionId: uint16,
   ackNr: uint16,
-  rng: var HmacDrbgContext): seq[Packet] =
+  rng: var SecureRngContext): seq[Packet] =
   let packetSize = 100
   var packets = newSeq[Packet]()
   var i = 0'u16

--- a/tests/utp/test_utp_router.nim
+++ b/tests/utp/test_utp_router.nim
@@ -26,7 +26,7 @@ type
   TestError* = object of CatchableError
 
 procSuite "Utp router unit tests":
-  let rng = newRng()
+  let rng = SecureRngContext.new()
   let testSender = 1
   let testSender2 = 2
   let testBufferSize = 1024'u32

--- a/tests/utp/test_utp_socket.nim
+++ b/tests/utp/test_utp_socket.nim
@@ -18,7 +18,7 @@ import
   ../stubloglevel
 
 procSuite "Utp socket unit test":
-  let rng = newRng()
+  let rng = SecureRngContext.new()
   let testAddress = initTAddress("127.0.0.1", 9079)
   let testBufferSize = 1024'u32
   let defaultRcvOutgoingId = 314'u16
@@ -1627,4 +1627,3 @@ procSuite "Utp socket unit test":
       bytesReceivedByRemote == largeDataToWrite
 
     await outgoingSocket.destroyWait()
-

--- a/tests/utp/test_utp_socket_sack.nim
+++ b/tests/utp/test_utp_socket_sack.nim
@@ -19,7 +19,7 @@ import
   ../stubloglevel
 
 procSuite "Utp socket selective acks unit test":
-  let rng = newRng()
+  let rng = SecureRngContext.new()
   let testAddress = initTAddress("127.0.0.1", 9079)
   let defaultBufferSize = 1024'u32
 

--- a/tools/dcli.nim
+++ b/tools/dcli.nim
@@ -53,7 +53,7 @@ type
 
     nodeKey* {.
       desc: "P2P node private key as hex",
-      defaultValue: PrivateKey.random(keys.newRng()[])
+      defaultValue: PrivateKey.random(SecureRngContext.new()[])
       name: "nodekey" .}: PrivateKey
 
     metricsEnabled* {.
@@ -168,7 +168,7 @@ proc discover(d: discv5_protocol.Protocol, psFile: string) {.async.} =
         bits.inc(countOnes(byt.uint))
 
       let str = "$#,$#,$#,$#,$#,$#\n"
-      let newLine = str % [pubkey.get().toHex, dNode.id.toHex, forkDigest[0..3].toHex, $dNode.address.get(), attnets.get().toHex, $bits] 
+      let newLine = str % [pubkey.get().toHex, dNode.id.toHex, forkDigest[0..3].toHex, $dNode.address.get(), attnets.get().toHex, $bits]
 
       ps.write(newLine)
     await sleepAsync(1000) # 1 sec of delay


### PR DESCRIPTION
Instead of requiring the BearSSL based `HmacDrbgContext`, take a generic `SecureRngContext` instead. For now, it is aliased to `HmacDrbgContext`, but this change allows using different RNG where BearSSL is unavailable.