### PR TITLE
remove stddefects import

### DIFF
--- a/tests/rlp/test_rlp_codec.nim
+++ b/tests/rlp/test_rlp_codec.nim
@@ -2,7 +2,7 @@
 
 import
   std/[os, strutils],
-  stew/[io2, results, shims/stddefects],
+  stew/[io2, results],
   unittest2,
   ../../eth/[rlp, common]
 


### PR DESCRIPTION
Same/usual CI success/failure pattern as `master`; no regressions.