### PR TITLE
add mixin env to sqlite3 generic procs

### DIFF
--- a/eth/db/kvstore_sqlite3.nim
+++ b/eth/db/kvstore_sqlite3.nim
@@ -96,6 +96,7 @@ proc prepareStmt*(db: SqStoreRef,
                   Params: type,
                   Res: type,
                   managed = true): KvResult[SqliteStmt[Params, Res]] =
+  mixin env
   var s: RawStmtPtr
   checkErr db.env, sqlite3_prepare_v2(db.env, stmt, stmt.len.cint, addr s, nil)
   if managed: db.managedStmts.add s
@@ -128,6 +129,7 @@ proc bindParam(s: RawStmtPtr, n: int, val: auto): cint =
     {.fatal: "Please add support for the '" & $typeof(val) & "' type".}
 
 template bindParams(s: RawStmtPtr, params: auto) =
+  mixin env
   when params is tuple:
     when params.type.arity > 0:
       var i = 1
@@ -138,6 +140,7 @@ template bindParams(s: RawStmtPtr, params: auto) =
     checkErr s.env, bindParam(s, 1, params)
 
 proc exec*[P](s: SqliteStmt[P, void], params: P): KvResult[void] =
+  mixin env
   let s = RawStmtPtr s
   bindParams(s, params)
 


### PR DESCRIPTION
There are two solution to this error:
1. add export marker to  the `env` template
2. add `mixin env` to generic proc using `env` tamplate

I choose number 2 because the original author seems want to keep `env` private.

```text
/home/runner/work/nimbus-eth1/nimbus-eth1/vendor/nimbus-eth2/beacon_chain/beacon_chain_db_light_client.nim(292, 39) template/generic instantiation of `exec` from here
/home/runner/work/nimbus-eth1/nimbus-eth1/vendor/nim-eth/eth/db/kvstore_sqlite3.nim(142, 13) template/generic instantiation of `bindParams` from here
/home/runner/work/nimbus-eth1/nimbus-eth1/vendor/nim-eth/eth/db/kvstore_sqlite3.nim(135, 19) Error: undeclared field: 'env' for type kvstore_sqlite3.RawStmtPtr [type declared in /home/runner/work/nimbus-eth1/nimbus-eth1/vendor/nim-eth/eth/db/kvstore_sqlite3.nim(14, 3)]
stack trace: (most recent call last)
```