### PR TITLE
arc/orc lacks `shallowCopy` --> use `move`

### DIFF
--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -485,10 +485,16 @@ func len*(r: RoutingTable): int =
 func moveRight[T](arr: var openArray[T], a, b: int) =
   ## In `arr` move elements in range [a, b] right by 1.
   var t: T
-  shallowCopy(t, arr[b + 1])
-  for i in countdown(b, a):
-    shallowCopy(arr[i + 1], arr[i])
-  shallowCopy(arr[a], t)
+  when declared(shallowCopy):
+    shallowCopy(t, arr[b + 1])
+    for i in countdown(b, a):
+      shallowCopy(arr[i + 1], arr[i])
+    shallowCopy(arr[a], t)
+  else:
+    t = move arr[b + 1]
+    for i in countdown(b, a):
+      arr[i + 1] = move arr[i]
+    arr[a] = move t
 
 proc setJustSeen*(r: RoutingTable, n: Node) =
   ## Move `n` to the head (most recently seen) of its bucket.


### PR DESCRIPTION
`shallowCopy` is not available in `--mm:arc/orc`, but our usage can be replaced with `move`.