### PR TITLE
fix `{.raises.}` annotation to `writeValue`

### DIFF
--- a/eth/common/eth_types_json_serialization.nim
+++ b/eth/common/eth_types_json_serialization.nim
@@ -4,6 +4,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import
   std/[times, net],
   json_serialization, nimcrypto/[hash, utils],
@@ -12,38 +14,44 @@ import
 export
   json_serialization
 
-{.push raises: [SerializationError, IOError].}
-
-proc writeValue*(w: var JsonWriter, a: MDigest) =
+proc writeValue*(w: var JsonWriter, a: MDigest) {.raises: [IOError].} =
   w.writeValue a.data.toHex(true)
 
-proc readValue*(r: var JsonReader, a: var MDigest) {.inline.} =
+proc readValue*(
+    r: var JsonReader, a: var MDigest
+) {.inline, raises: [IOError, SerializationError].} =
   try:
     a = fromHex(type(a), r.readValue(string))
   except ValueError:
     raiseUnexpectedValue(r, "Hex string expected")
 
-proc writeValue*(w: var JsonWriter, value: StUint) {.inline.} =
+proc writeValue*(
+    w: var JsonWriter, value: StUint) {.inline, raises: [IOError].} =
   w.writeValue $value
 
-proc readValue*(r: var JsonReader, value: var StUint) {.inline.} =
+proc readValue*(
+    r: var JsonReader, value: var StUint
+) {.inline, raises: [IOError, SerializationError].} =
   value = parse(r.readValue(string), type(value))
 
-proc writeValue*(w: var JsonWriter, value: StInt) =
+proc writeValue*(w: var JsonWriter, value: StInt) {.raises: [IOError].} =
   # The Ethereum Yellow Paper defines the RLP serialization only
   # for unsigned integers:
   {.error: "RLP serialization of signed integers is not allowed".}
   discard
 
-proc writeValue*(w: var JsonWriter, t: Time) {.inline.} =
+proc writeValue*(w: var JsonWriter, t: Time) {.inline, raises: [IOError].} =
   w.writeValue t.toUnix()
 
-proc readValue*(r: var JsonReader, t: var Time) {.inline.} =
+proc readValue*(
+    r: var JsonReader, t: var Time
+) {.inline, raises: [IOError, SerializationError].} =
   t = fromUnix r.readValue(int)
 
 # TODO: remove this once case object are fully supported
 # by the serialization library
-proc writeValue*(w: var JsonWriter, value: HashOrNum) =
+proc writeValue*(
+    w: var JsonWriter, value: HashOrNum) {.raises: [IOError].} =
   w.beginRecord(HashOrNum)
   w.writeField("isHash", value.isHash)
   if value.isHash:
@@ -52,12 +60,14 @@ proc writeValue*(w: var JsonWriter, value: HashOrNum) =
     w.writeField("number", value.number)
   w.endRecord()
 
-proc writeValue*(w: var JsonWriter, value: BlockHashOrNumber) =
+proc writeValue*(
+    w: var JsonWriter, value: BlockHashOrNumber) {.raises: [IOError].} =
   w.writeValue $value
 
-proc readValue*(r: var JsonReader, value: var BlockHashOrNumber) =
+proc readValue*(
+    r: var JsonReader, value: var BlockHashOrNumber
+) {.raises: [IOError, SerializationError].} =
   try:
     value = init(BlockHashOrNumber, r.readValue(string))
   except ValueError:
     r.raiseUnexpectedValue("A hex-encoded block hash or a decimal block number expected")
-


### PR DESCRIPTION
`writeValue` doesn't raise `SerializationError`, so the `{.push.}` is not optimal. Move `{.raises.}` to each `proc`, same as other modules.