### PR TITLE
Allow passing along the handshake ENR through talkresp handler

### DIFF
--- a/eth/p2p/discoveryv5/encoding.nim
+++ b/eth/p2p/discoveryv5/encoding.nim
@@ -94,7 +94,7 @@ type
     of HandshakeMessage:
       message*: Message # In a handshake we expect to always be able to decrypt
       # TODO record or node immediately?
-      node*: Option[Node]
+      node*: Opt[Node]
       srcIdHs*: NodeId
 
   HandshakeKey* = object
@@ -484,7 +484,7 @@ proc decodeHandshakePacket(c: var Codec, fromAddr: Address, nonce: AESGCMNonce,
       return err("Invalid encoded ENR")
 
   var pubkey: PublicKey
-  var newNode: Option[Node]
+  var newNode: Opt[Node]
   # TODO: Shall we return Node or Record? Record makes more sense, but we do
   # need the pubkey and the nodeid
   if record.isSome():
@@ -496,7 +496,7 @@ proc decodeHandshakePacket(c: var Codec, fromAddr: Address, nonce: AESGCMNonce,
     # Note: Not checking if the record seqNum is higher than the one we might
     # have stored as it comes from this node directly.
     pubkey = node.pubkey
-    newNode = some(node)
+    newNode = Opt.some(node)
   else:
     # TODO: Hmm, should we still verify node id of the ENR of this node?
     if challenge.pubkey.isSome():

--- a/eth/utp/utp_discv5_protocol.nim
+++ b/eth/utp/utp_discv5_protocol.nim
@@ -82,8 +82,9 @@ proc initSendCallback(
       return fut
   )
 
-proc messageHandler(protocol: TalkProtocol, request: seq[byte],
-    srcId: NodeId, srcUdpAddress: Address): seq[byte] =
+proc messageHandler(
+    protocol: TalkProtocol, request: seq[byte],
+    srcId: NodeId, srcUdpAddress: Address, node: Opt[Node]): seq[byte] =
   let
     p = UtpDiscv5Protocol(protocol)
     nodeAddress = NodeAddress.init(srcId, srcUdpAddress)

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -792,7 +792,8 @@ suite "Discovery v5 Tests":
 
     proc handler(
         protocol: TalkProtocol, request: seq[byte],
-        fromId: NodeId, fromUdpAddress: Address):
+        fromId: NodeId, fromUdpAddress: Address,
+        node: Opt[Node]):
         seq[byte] {.gcsafe, raises: [].} =
       request
 
@@ -819,7 +820,8 @@ suite "Discovery v5 Tests":
 
     proc handler(
         protocol: TalkProtocol, request: seq[byte],
-        fromId: NodeId, fromUdpAddress: Address):
+        fromId: NodeId, fromUdpAddress: Address,
+        node: Opt[Node]):
         seq[byte] {.gcsafe, raises: [].} =
       request
 
@@ -843,7 +845,8 @@ suite "Discovery v5 Tests":
 
     proc handler(
         protocol: TalkProtocol, request: seq[byte],
-        fromId: NodeId, fromUdpAddress: Address):
+        fromId: NodeId, fromUdpAddress: Address,
+        node: Opt[Node]):
         seq[byte] {.gcsafe, raises: [].} =
       request
 
@@ -882,7 +885,8 @@ suite "Discovery v5 Tests":
 
     proc handler(
         protocol: TalkProtocol, request: seq[byte],
-        fromId: NodeId, fromUdpAddress: Address):
+        fromId: NodeId, fromUdpAddress: Address,
+        node: Opt[Node]):
         seq[byte] {.gcsafe, raises: [].} =
       # Return the request + same protocol id + 2 bytes, to make it 1 byte
       # bigger than the request


### PR DESCRIPTION
This allows for protocols build on top of discv5 to use the ENR provided in the handshake directly, instead of having to rely on requesting it from the discv5 routing table.