### PR TITLE
fix build for `dcli` and instructions for new path

### DIFF
--- a/doc/discv5.md
+++ b/doc/discv5.md
@@ -88,13 +88,13 @@ node, by providing its ENR.
 # Make sure you have the latest modules, do NOT trust nimble on this.
 nimble install
 # Build dcli
-nim c -d:chronicles_log_level:trace -d:release --threads:on eth/p2p/discoveryv5/dcli
+nim c -d:chronicles_log_level:trace -d:release --threads:on ./tools/dcli
 # See all options
-./eth/p2p/discoveryv5/dcli --help
+./tools/dcli --help
 # Ping another node
-./eth/p2p/discoveryv5/dcli ping enr:<base64 encoding of ENR>
+./tools/dcli ping enr:<base64 encoding of ENR>
 # Run discovery node
-./eth/p2p/discoveryv5/dcli --log-level:debug --bootnode:enr:<base64 encoding of ENR>
+./tools/dcli --log-level:debug --bootnode:enr:<base64 encoding of ENR>
 ```
 
 ### Metrics
@@ -102,7 +102,7 @@ To run dcli with metrics enabled provide the `metrics` flag:
 
 ```sh
 # Run dcli with metrics
-./eth/p2p/discoveryv5/dcli --metrics --bootnode:enr:<base64 encoding of ENR>
+./tools/dcli --metrics --bootnode:enr:<base64 encoding of ENR>
 ```
 
 You can now see the metrics at http://localhost:8008/metrics. Or use e.g.

--- a/tools/dcli.nim
+++ b/tools/dcli.nim
@@ -12,9 +12,9 @@ import
   std/[options, strutils, tables, sets],
   confutils, confutils/std/net, chronicles, chronicles/topics_registry,
   chronos, metrics, metrics/chronos_httpserver, stew/byteutils, stew/bitops2,
-  ./eth/keys, ./eth/net/nat,
-  ./eth/p2p/discoveryv5/[enr, node],
-  ./eth/p2p/discoveryv5/protocol as discv5_protocol
+  ../eth/keys, ../eth/net/nat,
+  ../eth/p2p/discoveryv5/[enr, node],
+  ../eth/p2p/discoveryv5/protocol as discv5_protocol
 
 type
   DiscoveryCmd* = enum


### PR DESCRIPTION
`dcli` got moved and the guide is no longer accurate. Update the paths. Also, relative imports were incorret inside `dcli.nim`, and error when using Nim 2.0 compiler.