### PR TITLE
Convert EthTime from Time to distinct uint64

### DIFF
--- a/eth/common/eth_times.nim
+++ b/eth/common/eth_times.nim
@@ -1,0 +1,51 @@
+# Nimbus
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at
+#     https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at
+#     https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import
+  std/times
+
+type
+  EthTime* = distinct uint64
+
+func now*(_: type EthTime): EthTime =
+  getTime().utc.toTime.toUnix.EthTime
+
+func `+`*(a: EthTime, b: EthTime): EthTime =
+  EthTime(a.uint64 + b.uint64)
+
+func `+`*(a: EthTime, b: uint64): EthTime =
+  EthTime(a.uint64 + b)
+
+func `-`*(a: EthTime, b: EthTime): EthTime =
+  EthTime(a.uint64 - b.uint64)
+
+func `-`*(a: EthTime, b: uint64): EthTime =
+  EthTime(a.uint64 - b)
+
+func `==`*(a: EthTime, b: EthTime): bool =
+  a.uint64 == b.uint64
+
+func `==`*(a: EthTime, b: uint64): bool =
+  a.uint64 == b
+
+func `<`*(a: EthTime, b: EthTime): bool =
+  a.uint64 < b.uint64
+
+func `<`*(a: EthTime, b: uint64): bool =
+  a.uint64 < b
+
+func `<`*(a: uint64, b: EthTime): bool =
+  a < b.uint64
+
+func `<=`*(a: EthTime, b: EthTime): bool =
+  a.uint64 <= b.uint64
+
+func `$`*(x: EthTime): string =
+  $(x.uint64)

--- a/eth/common/eth_types.nim
+++ b/eth/common/eth_types.nim
@@ -10,17 +10,15 @@
 ## from many places
 
 import
-  std/[options, strutils, times],
+  std/[options, strutils],
   stew/[byteutils, endians2], stint,
-  ./eth_hash
+  ./eth_hash, ./eth_times
 
 export
-  options, stint, eth_hash,
-  times.Time, times.fromUnix, times.toUnix
+  options, stint, eth_hash, eth_times
 
 type
   Hash256* = MDigest[256]
-  EthTime* = Time
   VMWord* = UInt256
   BlockNonce* = array[8, byte]
   AccountNonce* = uint64
@@ -330,3 +328,4 @@ func `==`*(a, b: NetworkId): bool =
 
 func `$`*(x: NetworkId): string =
   `$`(uint(x))
+

--- a/eth/common/eth_types_rlp.nim
+++ b/eth/common/eth_types_rlp.nim
@@ -377,8 +377,8 @@ proc read*(rlp: var Rlp, T: type Receipt): T =
   rlp.read(result.bloom)
   rlp.read(result.logs)
 
-proc read*(rlp: var Rlp, T: type Time): T {.inline.} =
-  result = fromUnix(rlp.read(int64))
+proc read*(rlp: var Rlp, T: type EthTime): T {.inline.} =
+  result = EthTime rlp.read(uint64)
 
 proc append*(rlpWriter: var RlpWriter, value: HashOrNum) =
   case value.isHash
@@ -393,8 +393,8 @@ proc read*(rlp: var Rlp, T: type HashOrNum): T =
   else:
     result = HashOrNum(isHash: false, number: rlp.read(BlockNumber))
 
-proc append*(rlpWriter: var RlpWriter, t: Time) {.inline.} =
-  rlpWriter.append(t.toUnix())
+proc append*(rlpWriter: var RlpWriter, t: EthTime) {.inline.} =
+  rlpWriter.append(t.uint64)
 
 proc rlpHash*[T](v: T): Hash256 =
   keccakHash(rlp.encode(v))


### PR DESCRIPTION
This changes will break nimbus-eth2. If nimbus-eth2 fixed, it will break nimbus-eth1 because nimbus-eth2 using nim 1.6.14 while nimbus-eth1 still using nim 1.6.12.
Wait until nim 1.6.16 released.