### PR TITLE
Rename routing_table_nodes metric for discv4 routing table

### DIFF
--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -16,7 +16,7 @@ import
 
 export results
 
-declarePublicGauge routing_table_nodes,
+declareGauge routing_table_nodes,
   "Discovery routing table nodes", labels = ["state"]
 
 type

--- a/eth/p2p/kademlia.nim
+++ b/eth/p2p/kademlia.nim
@@ -15,8 +15,8 @@ import
 
 export sets # TODO: This should not be needed, but compilation fails otherwise
 
-declarePublicGauge routing_table_nodes,
-  "Discovery routing table nodes"
+declareGauge discv4_routing_table_nodes,
+  "Discovery v4 routing table nodes"
 
 logScope:
   topics = "eth p2p kademlia"
@@ -221,7 +221,7 @@ proc add(k: KBucket, n: Node): Node =
       k.nodes.add(n)
   elif k.len < BUCKET_SIZE:
       k.nodes.add(n)
-      routing_table_nodes.inc()
+      discv4_routing_table_nodes.inc()
   else:
       k.replacementCache.add(n)
       return k.head
@@ -230,7 +230,7 @@ proc add(k: KBucket, n: Node): Node =
 proc removeNode(k: KBucket, n: Node) =
   let i = k.nodes.find(n)
   if i != -1:
-    routing_table_nodes.dec()
+    discv4_routing_table_nodes.dec()
     k.nodes.delete(i)
 
 proc split(k: KBucket): tuple[lower, upper: KBucket] =


### PR DESCRIPTION
In Fluffy (and potentially other projects) there seems to be some import/export pollution that I can't immediately track down.

This causes duplicate metric names for the discv5 and portal routing tables vs the (not used) discv4 routing table.

As quickfix we give the discv4 one a specific `discv4` prefix.
The import/export pollution should still be resolved ideally to avoid having these unused metrics.