### PR TITLE
switch NAT module from ValidIpAddress to IpAddress

### DIFF
--- a/eth/net/utils.nim
+++ b/eth/net/utils.nim
@@ -63,4 +63,4 @@ proc getRouteIpv4*(): Result[IpAddress, cstring] =
                # This should not occur really.
                error "Address conversion error", exception = e.name, msg = e.msg
                return err("Invalid IP address")
-    ok(ValidIpAddress.init(ip))
+    ok(ip)

--- a/eth/net/utils.nim
+++ b/eth/net/utils.nim
@@ -14,14 +14,14 @@ import
 type
   IpLimits* = object
     limit*: uint
-    ips: Table[ValidIpAddress, uint]
+    ips: Table[IpAddress, uint]
 
 func hash*(ip: ValidIpAddress): Hash =
   case ip.family
   of IpAddressFamily.IPv6: hash(ip.address_v6)
   of IpAddressFamily.IPv4: hash(ip.address_v4)
 
-func inc*(ipLimits: var IpLimits, ip: ValidIpAddress): bool =
+func inc*(ipLimits: var IpLimits, ip: IpAddress): bool =
   let val = ipLimits.ips.getOrDefault(ip, 0)
   if val < ipLimits.limit:
     ipLimits.ips[ip] = val + 1
@@ -29,7 +29,7 @@ func inc*(ipLimits: var IpLimits, ip: ValidIpAddress): bool =
   else:
     false
 
-func dec*(ipLimits: var IpLimits, ip: ValidIpAddress) =
+func dec*(ipLimits: var IpLimits, ip: IpAddress) =
   let val = ipLimits.ips.getOrDefault(ip, 0)
   if val == 1:
     ipLimits.ips.del(ip)

--- a/eth/net/utils.nim
+++ b/eth/net/utils.nim
@@ -46,7 +46,7 @@ func isGlobalUnicast*(address: IpAddress): bool =
   let a = initTAddress(address, Port(0))
   a.isGlobalUnicast()
 
-proc getRouteIpv4*(): Result[ValidIpAddress, cstring] =
+proc getRouteIpv4*(): Result[IpAddress, cstring] =
   # Avoiding Exception with initTAddress and can't make it work with static.
   # Note: `publicAddress` is only used an "example" IP to find the best route,
   # no data is send over the network to this IP!

--- a/eth/p2p/discoveryv5/enr.nim
+++ b/eth/p2p/discoveryv5/enr.nim
@@ -165,7 +165,7 @@ template toFieldPair*(key: string, value: auto): FieldPair =
 
 func addAddress(
     fields: var seq[FieldPair],
-    ip: Option[ValidIpAddress],
+    ip: Option[IpAddress],
     tcpPort, udpPort: Option[Port]) =
   ## Add address information in new fields. Incomplete address
   ## information is allowed (example: Port but not IP) as that information
@@ -190,7 +190,7 @@ func addAddress(
 func init*(
     T: type Record,
     seqNum: uint64, pk: PrivateKey,
-    ip: Option[ValidIpAddress],
+    ip: Option[IpAddress],
     tcpPort, udpPort: Option[Port],
     extraFields: openArray[FieldPair] = []):
     EnrResult[T] =
@@ -321,7 +321,7 @@ func update*(
 func update*(
     r: var Record,
     pk: PrivateKey,
-    ip: Option[ValidIpAddress],
+    ip: Option[IpAddress],
     tcpPort, udpPort: Option[Port] = none[Port](),
     extraFields: openArray[FieldPair] = []):
     EnrResult[void] =

--- a/eth/p2p/discoveryv5/node.nim
+++ b/eth/p2p/discoveryv5/node.nim
@@ -19,7 +19,7 @@ type
   NodeId* = UInt256
 
   Address* = object
-    ip*: ValidIpAddress
+    ip*: IpAddress
     port*: Port
 
   Node* = ref object
@@ -58,7 +58,7 @@ func newNode*(r: Record): Result[Node, cstring] =
     ok(Node(id: pk.get().toNodeId(), pubkey: pk.get(), record: r,
        address: none(Address)))
 
-func update*(n: Node, pk: PrivateKey, ip: Option[ValidIpAddress],
+func update*(n: Node, pk: PrivateKey, ip: Option[IpAddress],
     tcpPort, udpPort: Option[Port] = none[Port](),
     extraFields: openArray[FieldPair] = []): Result[void, cstring] =
   ? n.record.update(pk, ip, tcpPort, udpPort, extraFields)

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -479,7 +479,7 @@ proc processClient(transp: DatagramTransport, raddr: TransportAddress):
            except ValueError as e:
              error "Not a valid IpAddress", exception = e.name, msg = e.msg
              return
-  let a = Address(ip: ValidIpAddress.init(ip), port: raddr.port)
+  let a = Address(ip: ip, port: raddr.port)
 
   proto.receive(a, buf)
 
@@ -832,7 +832,7 @@ proc revalidateNode*(d: Protocol, n: Node) {.async.} =
         discard d.addNode(nodes[][0])
 
     # Get IP and port from pong message and add it to the ip votes
-    let a = Address(ip: ValidIpAddress.init(res.ip), port: Port(res.port))
+    let a = Address(ip: res.ip, port: Port(res.port))
     d.ipVote.insert(n.id, a)
 
 proc revalidateLoop(d: Protocol) {.async.} =
@@ -1003,7 +1003,7 @@ proc newProtocol*(
   Protocol(
     privateKey: privKey,
     localNode: node,
-    bindAddress: Address(ip: ValidIpAddress.init(bindIp), port: bindPort),
+    bindAddress: Address(ip: bindIp, port: bindPort),
     codec: Codec(localNode: node, privKey: privKey,
       sessions: Sessions.init(256)),
     bootstrapRecords: @bootstrapRecords,

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -175,7 +175,7 @@ const
   )
 
 chronicles.formatIt(Option[Port]): $it
-chronicles.formatIt(Option[ValidIpAddress]): $it
+chronicles.formatIt(Option[IpAddress]): $it
 
 proc addNode*(d: Protocol, node: Node): bool =
   ## Add `Node` to discovery routing table.
@@ -865,7 +865,7 @@ proc refreshLoop(d: Protocol) {.async.} =
   except CancelledError:
     trace "refreshLoop canceled"
 
-proc updateExternalIp*(d: Protocol, extIp: ValidIpAddress, udpPort: Port): bool =
+proc updateExternalIp*(d: Protocol, extIp: IpAddress, udpPort: Port): bool =
   var success = false
   let
     previous = d.localNode.address
@@ -956,7 +956,7 @@ func init*(
 
 proc newProtocol*(
     privKey: PrivateKey,
-    enrIp: Option[ValidIpAddress],
+    enrIp: Option[IpAddress],
     enrTcpPort, enrUdpPort: Option[Port],
     localEnrFields: openArray[(string, seq[byte])] = [],
     bootstrapRecords: openArray[Record] = [],

--- a/tests/fuzzing/discoveryv5/fuzz_decode_packet.nim
+++ b/tests/fuzzing/discoveryv5/fuzz_decode_packet.nim
@@ -12,12 +12,12 @@ init:
     privKeyB = PrivateKey.fromHex(nodeBKey)[] # receive -> decode
 
     enrRecA = enr.Record.init(1, privKeyA,
-      some(ValidIpAddress.init("127.0.0.1")), some(Port(9000)),
+      some(parseIpAddress("127.0.0.1")), some(Port(9000)),
       some(Port(9000))).expect("Properly initialized private key")
     nodeA = newNode(enrRecA).expect("Properly initialized record")
 
     enrRecB = enr.Record.init(1, privKeyB,
-      some(ValidIpAddress.init("127.0.0.1")), some(Port(9000)),
+      some(parseIpAddress("127.0.0.1")), some(Port(9000)),
       some(Port(9000))).expect("Properly initialized private key")
     nodeB = newNode(enrRecB).expect("Properly initialized record")
 

--- a/tests/fuzzing/enr/generate.nim
+++ b/tests/fuzzing/enr/generate.nim
@@ -11,7 +11,7 @@ proc generate() =
   let
     rng = newRng()
     privKey = PrivateKey.random(rng[])
-    ip = some(ValidIpAddress.init("127.0.0.1"))
+    ip = some(parseIpAddress("127.0.0.1"))
     port = some(Port(20301))
 
   block:

--- a/tests/p2p/discv5_test_helper.nim
+++ b/tests/p2p/discv5_test_helper.nim
@@ -6,8 +6,8 @@ import
 
 export net
 
-proc localAddress*(port: int): Address =
-  Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(port))
+func localAddress*(port: int): Address =
+  Address(ip: parseIpAddress("127.0.0.1"), port: Port(port))
 
 proc initDiscoveryNode*(
     rng: ref HmacDrbgContext,
@@ -35,11 +35,11 @@ proc initDiscoveryNode*(
 
   protocol
 
-proc nodeIdInNodes*(id: NodeId, nodes: openArray[Node]): bool =
+func nodeIdInNodes*(id: NodeId, nodes: openArray[Node]): bool =
   for n in nodes:
     if id == n.id: return true
 
-proc generateNode*(privKey: PrivateKey, port: int = 20302,
+func generateNode*(privKey: PrivateKey, port: int = 20302,
     ip: IpAddress = parseIpAddress("127.0.0.1"),
     localEnrFields: openArray[FieldPair] = []): Node =
   let port = Port(port)
@@ -55,7 +55,7 @@ proc generateNRandomNodes*(rng: var HmacDrbgContext, n: int): seq[Node] =
   res
 
 proc nodeAndPrivKeyAtDistance*(n: Node, rng: var HmacDrbgContext, d: uint32,
-    ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): (Node, PrivateKey) =
+    ip: IpAddress = parseIpAddress("127.0.0.1")): (Node, PrivateKey) =
   while true:
     let pk = PrivateKey.random(rng)
     let node = generateNode(pk, ip = ip)
@@ -63,23 +63,23 @@ proc nodeAndPrivKeyAtDistance*(n: Node, rng: var HmacDrbgContext, d: uint32,
       return (node, pk)
 
 proc nodeAtDistance*(n: Node, rng: var HmacDrbgContext, d: uint32,
-    ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): Node =
+    ip: IpAddress = parseIpAddress("127.0.0.1")): Node =
   let (node, _) = n.nodeAndPrivKeyAtDistance(rng, d, ip)
   node
 
 proc nodesAtDistance*(
     n: Node, rng: var HmacDrbgContext, d: uint32, amount: int,
-    ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): seq[Node] =
+    ip: IpAddress = parseIpAddress("127.0.0.1")): seq[Node] =
   for i in 0..<amount:
     result.add(nodeAtDistance(n, rng, d, ip))
 
 proc nodesAtDistanceUniqueIp*(
     n: Node, rng: var HmacDrbgContext, d: uint32, amount: int,
-    ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1")): seq[Node] =
+    ip: IpAddress = parseIpAddress("127.0.0.1")): seq[Node] =
   var ta = initTAddress(ip, Port(0))
   for i in 0..<amount:
     ta.inc()
-    result.add(nodeAtDistance(n, rng, d, ValidIpAddress.init(ta.address())))
+    result.add(nodeAtDistance(n, rng, d, ta.address()))
 
 proc addSeenNode*(d: discv5_protocol.Protocol, n: Node): bool =
   # Add it as a seen node, warning: for testing convenience only!

--- a/tests/p2p/discv5_test_helper.nim
+++ b/tests/p2p/discv5_test_helper.nim
@@ -40,7 +40,7 @@ proc nodeIdInNodes*(id: NodeId, nodes: openArray[Node]): bool =
     if id == n.id: return true
 
 proc generateNode*(privKey: PrivateKey, port: int = 20302,
-    ip: ValidIpAddress = ValidIpAddress.init("127.0.0.1"),
+    ip: IpAddress = parseIpAddress("127.0.0.1"),
     localEnrFields: openArray[FieldPair] = []): Node =
   let port = Port(port)
   let enr = enr.Record.init(1, privKey, some(ip),

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -416,7 +416,7 @@ suite "Discovery v5 Tests":
   test "New protocol with enr":
     let
       privKey = PrivateKey.random(rng[])
-      ip = some(ValidIpAddress.init("127.0.0.1"))
+      ip = some(parseIpAddress("127.0.0.1"))
       port = Port(20301)
       node = newProtocol(privKey, ip, some(port), some(port), bindPort = port,
         rng = rng)
@@ -511,7 +511,7 @@ suite "Discovery v5 Tests":
     let
       port = Port(9000)
       srcRecord = enr.Record.init(1, PrivateKey.random(rng[]),
-        some(ValidIpAddress.init("11.12.13.14")),
+        some(parseIpAddress("11.12.13.14")),
         some(port), some(port))[]
       srcNode = newNode(srcRecord)[]
       pk = PrivateKey.random(rng[])
@@ -521,7 +521,7 @@ suite "Discovery v5 Tests":
     block: # Duplicates
       let
         record = enr.Record.init(
-          1, pk, some(ValidIpAddress.init("12.13.14.15")),
+          1, pk, some(parseIpAddress("12.13.14.15")),
           some(port), some(port))[]
 
       # Exact duplicates
@@ -531,7 +531,7 @@ suite "Discovery v5 Tests":
 
       # Node id duplicates
       let recordSameId = enr.Record.init(
-        1, pk, some(ValidIpAddress.init("212.13.14.15")),
+        1, pk, some(parseIpAddress("212.13.14.15")),
         some(port), some(port))[]
       records.add(recordSameId)
       nodes = verifyNodesRecords(records, srcNode, limit, targetDistance)
@@ -540,7 +540,7 @@ suite "Discovery v5 Tests":
     block: # No address
       let
         recordNoAddress = enr.Record.init(
-          1, pk, none(ValidIpAddress), some(port), some(port))[]
+          1, pk, none(IpAddress), some(port), some(port))[]
         records = [recordNoAddress]
         test = verifyNodesRecords(records, srcNode, limit, targetDistance)
       check test.len == 0
@@ -548,7 +548,7 @@ suite "Discovery v5 Tests":
     block: # Invalid address - any local
       let
         recordInvalidAddress = enr.Record.init(
-          1, pk, some(ValidIpAddress.init("0.0.0.0")),
+          1, pk, some(parseIpAddress("0.0.0.0")),
           some(port), some(port))[]
         records = [recordInvalidAddress]
         test = verifyNodesRecords(records, srcNode, limit, targetDistance)
@@ -557,7 +557,7 @@ suite "Discovery v5 Tests":
     block: # Invalid address - site local
       let
         recordInvalidAddress = enr.Record.init(
-          1, pk, some(ValidIpAddress.init("10.1.2.3")),
+          1, pk, some(parseIpAddress("10.1.2.3")),
           some(port), some(port))[]
         records = [recordInvalidAddress]
         test = verifyNodesRecords(records, srcNode, limit, targetDistance)
@@ -566,7 +566,7 @@ suite "Discovery v5 Tests":
     block: # Invalid address - loopback
       let
         recordInvalidAddress = enr.Record.init(
-          1, pk, some(ValidIpAddress.init("127.0.0.1")),
+          1, pk, some(parseIpAddress("127.0.0.1")),
           some(port), some(port))[]
         records = [recordInvalidAddress]
         test = verifyNodesRecords(records, srcNode, limit, targetDistance)
@@ -575,7 +575,7 @@ suite "Discovery v5 Tests":
     block: # Invalid distance
       let
         recordInvalidDistance = enr.Record.init(
-          1, pk, some(ValidIpAddress.init("12.13.14.15")),
+          1, pk, some(parseIpAddress("12.13.14.15")),
           some(port), some(port))[]
         records = [recordInvalidDistance]
         test = verifyNodesRecords(records, srcNode, limit, @[0'u16])
@@ -584,7 +584,7 @@ suite "Discovery v5 Tests":
     block: # Invalid distance but distance validation is disabled
       let
         recordInvalidDistance = enr.Record.init(
-          1, pk, some(ValidIpAddress.init("12.13.14.15")),
+          1, pk, some(parseIpAddress("12.13.14.15")),
           some(port), some(port))[]
         records = [recordInvalidDistance]
         test = verifyNodesRecords(records, srcNode, limit)
@@ -594,7 +594,7 @@ suite "Discovery v5 Tests":
     let
       port = Port(9000)
       srcRecord = enr.Record.init(1, PrivateKey.random(rng[]),
-        some(ValidIpAddress.init("127.0.0.0")),
+        some(parseIpAddress("127.0.0.0")),
         some(port), some(port))[]
       srcNode = newNode(srcRecord)[]
       pk = PrivateKey.random(rng[])
@@ -604,7 +604,7 @@ suite "Discovery v5 Tests":
     block: # valid address - lo with lo src
       let
         record = enr.Record.init(
-          1, pk, some(ValidIpAddress.init("127.0.0.1")),
+          1, pk, some(parseIpAddress("127.0.0.1")),
           some(port), some(port))[]
         test = verifyNodesRecords([record], srcNode, limit, targetDistance)
       check test.len == 1
@@ -612,7 +612,7 @@ suite "Discovery v5 Tests":
     block: # valid address - global with lo src
       let
         record = enr.Record.init(
-          1, pk, some(ValidIpAddress.init("1.2.3.4")),
+          1, pk, some(parseIpAddress("1.2.3.4")),
           some(port), some(port))[]
         test = verifyNodesRecords([record], srcNode, limit, targetDistance)
       check test.len == 1
@@ -621,7 +621,7 @@ suite "Discovery v5 Tests":
     let
       port = Port(9000)
       srcRecord = enr.Record.init(1, PrivateKey.random(rng[]),
-        some(ValidIpAddress.init("192.168.1.1")),
+        some(parseIpAddress("192.168.1.1")),
         some(port), some(port))[]
       srcNode = newNode(srcRecord)[]
       pk = PrivateKey.random(rng[])
@@ -631,7 +631,7 @@ suite "Discovery v5 Tests":
     block: # valid address - site local with site local src
       let
         record = enr.Record.init(
-          1, pk, some(ValidIpAddress.init("192.168.1.2")),
+          1, pk, some(parseIpAddress("192.168.1.2")),
           some(port), some(port))[]
         test = verifyNodesRecords([record], srcNode, limit, targetDistance)
       check test.len == 1
@@ -639,7 +639,7 @@ suite "Discovery v5 Tests":
     block: # valid address - global with site local src
       let
         record = enr.Record.init(
-          1, pk, some(ValidIpAddress.init("1.2.3.4")),
+          1, pk, some(parseIpAddress("1.2.3.4")),
           some(port), some(port))[]
         test = verifyNodesRecords([record], srcNode, limit, targetDistance)
       check test.len == 1
@@ -684,7 +684,7 @@ suite "Discovery v5 Tests":
       let
         privKey = PrivateKey.random(rng[])
         enrRec = enr.Record.init(1, privKey,
-          some(ValidIpAddress.init("127.0.0.1")), some(Port(9000)),
+          some(parseIpAddress("127.0.0.1")), some(Port(9000)),
           some(Port(9000))).expect("Properly initialized private key")
         sendNode = newNode(enrRec).expect("Properly initialized record")
       var codec = Codec(localNode: sendNode, privKey: privKey, sessions: Sessions.init(5))
@@ -713,7 +713,7 @@ suite "Discovery v5 Tests":
     let
       privKey = PrivateKey.random(rng[])
       enrRec = enr.Record.init(1, privKey,
-        some(ValidIpAddress.init("127.0.0.1")), some(Port(9000)),
+        some(parseIpAddress("127.0.0.1")), some(Port(9000)),
         some(Port(9000))).expect("Properly initialized private key")
       sendNode = newNode(enrRec).expect("Properly initialized record")
     var codec = Codec(localNode: sendNode, privKey: privKey, sessions: Sessions.init(5))
@@ -744,7 +744,7 @@ suite "Discovery v5 Tests":
       a = localAddress(20303)
       privKey = PrivateKey.random(rng[])
       enrRec = enr.Record.init(1, privKey,
-        some(ValidIpAddress.init("127.0.0.1")), some(Port(9000)),
+        some(parseIpAddress("127.0.0.1")), some(Port(9000)),
         some(Port(9000))).expect("Properly initialized private key")
       sendNode = newNode(enrRec).expect("Properly initialized record")
     var codec = Codec(localNode: sendNode, privKey: privKey, sessions: Sessions.init(5))

--- a/tests/p2p/test_discoveryv5_encoding.nim
+++ b/tests/p2p/test_discoveryv5_encoding.nim
@@ -258,12 +258,12 @@ suite "Discovery v5.1 Packet Encodings Test Vectors":
       privKeyB = PrivateKey.fromHex(nodeBKey)[] # receive -> decode
 
       enrRecA = enr.Record.init(1, privKeyA,
-        some(ValidIpAddress.init("127.0.0.1")), some(Port(9000)),
+        some(parseIpAddress("127.0.0.1")), some(Port(9000)),
         some(Port(9000))).expect("Properly initialized private key")
       nodeA = newNode(enrRecA).expect("Properly initialized record")
 
       enrRecB = enr.Record.init(1, privKeyB,
-        some(ValidIpAddress.init("127.0.0.1")), some(Port(9000)),
+        some(parseIpAddress("127.0.0.1")), some(Port(9000)),
         some(Port(9000))).expect("Properly initialized private key")
       nodeB = newNode(enrRecB).expect("Properly initialized record")
 
@@ -479,12 +479,12 @@ suite "Discovery v5.1 Additional Encode/Decode":
       privKeyB = PrivateKey.random(rng[]) # receiver -> decode
 
       enrRecA = enr.Record.init(1, privKeyA,
-        some(ValidIpAddress.init("127.0.0.1")), some(Port(9000)),
+        some(parseIpAddress("127.0.0.1")), some(Port(9000)),
         some(Port(9000))).expect("Properly initialized private key")
       nodeA = newNode(enrRecA).expect("Properly initialized record")
 
       enrRecB = enr.Record.init(1, privKeyB,
-        some(ValidIpAddress.init("127.0.0.1")), some(Port(9000)),
+        some(parseIpAddress("127.0.0.1")), some(Port(9000)),
         some(Port(9000))).expect("Properly initialized private key")
       nodeB = newNode(enrRecB).expect("Properly initialized record")
 

--- a/tests/p2p/test_enr.nim
+++ b/tests/p2p/test_enr.nim
@@ -68,7 +68,7 @@ suite "ENR":
   test "Create from ENode address":
     let
       keypair = KeyPair.random(rng[])
-      ip = ValidIpAddress.init("10.20.30.40")
+      ip = parseIpAddress("10.20.30.40")
       port = some(Port(9000))
       enr = Record.init(
         100, keypair.seckey, some(ip), port, port,@[])[]
@@ -92,7 +92,7 @@ suite "ENR":
       keypair = KeyPair.random(rng[])
       port = none(Port)
       enr = Record.init(
-        100, keypair.seckey, none(ValidIpAddress), port, port)[]
+        100, keypair.seckey, none(IpAddress), port, port)[]
       typedEnr = get enr.toTypedRecord()
 
     check:
@@ -123,7 +123,7 @@ suite "ENR":
       pk = PrivateKey.fromHex(
         "5d2908f3f09ea1ff2e327c3f623159639b00af406e9009de5fd4b910fc34049d")[]
       newField = toFieldPair("test", 123'u)
-    var r = Record.init(1, pk, none(ValidIpAddress), none(Port), none(Port))[]
+    var r = Record.init(1, pk, none(IpAddress), none(Port), none(Port))[]
 
     block: # Insert new k:v pair, update of seqNum should occur.
       let updated = r.update(pk, [newField])
@@ -190,11 +190,11 @@ suite "ENR":
     let
       pk = PrivateKey.fromHex(
         "5d2908f3f09ea1ff2e327c3f623159639b00af406e9009de5fd4b910fc34049d")[]
-    var r = Record.init(1, pk, none(ValidIpAddress),
+    var r = Record.init(1, pk, none(IpAddress),
       some(Port(9000)), some(Port(9000)))[]
 
     block:
-      let updated = r.update(pk, none(ValidIpAddress),
+      let updated = r.update(pk, none(IpAddress),
         some(Port(9000)), some(Port(9000)))
       check updated.isOk()
       check:
@@ -204,7 +204,7 @@ suite "ENR":
         r.seqNum == 1
 
     block:
-      let updated = r.update(pk, none(ValidIpAddress),
+      let updated = r.update(pk, none(IpAddress),
         some(Port(9001)), some(Port(9002)))
       check updated.isOk()
       check:
@@ -214,7 +214,7 @@ suite "ENR":
         r.seqNum == 2
 
     block:
-      let updated = r.update(pk, some(ValidIpAddress.init("10.20.30.40")),
+      let updated = r.update(pk, some(parseIpAddress("10.20.30.40")),
         some(Port(9000)), some(Port(9000)))
       check updated.isOk()
 
@@ -233,7 +233,7 @@ suite "ENR":
         r.seqNum == 3
 
     block:
-      let updated = r.update(pk, some(ValidIpAddress.init("10.20.30.40")),
+      let updated = r.update(pk, some(parseIpAddress("10.20.30.40")),
         some(Port(9001)), some(Port(9001)))
       check updated.isOk()
 

--- a/tests/p2p/test_ip_vote.nim
+++ b/tests/p2p/test_ip_vote.nim
@@ -12,9 +12,9 @@ suite "IP vote":
     var
       votes = IpVote.init(2)
     let
-      addr1 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(1))
-      addr2 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(2))
-      addr3 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(3))
+      addr1 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(1))
+      addr2 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(2))
+      addr3 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(3))
 
     votes.insert(NodeId.random(rng[]), addr1);
     votes.insert(NodeId.random(rng[]), addr1);
@@ -32,9 +32,9 @@ suite "IP vote":
     var
       votes = IpVote.init(threshold)
     let
-      addr1 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(1))
-      addr2 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(2))
-      addr3 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(3))
+      addr1 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(1))
+      addr2 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(2))
+      addr3 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(3))
 
     votes.insert(NodeId.random(rng[]), addr1);
     votes.insert(NodeId.random(rng[]), addr2);
@@ -50,9 +50,9 @@ suite "IP vote":
     var
       votes = IpVote.init(threshold)
     let
-      addr1 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(1))
-      addr2 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(2))
-      addr3 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(3))
+      addr1 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(1))
+      addr2 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(2))
+      addr3 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(3))
 
     votes.insert(NodeId.random(rng[]), addr1);
     votes.insert(NodeId.random(rng[]), addr2);
@@ -68,8 +68,8 @@ suite "IP vote":
     var
       votes = IpVote.init(threshold)
     let
-      addr1 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(1))
-      addr2 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(2))
+      addr1 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(1))
+      addr2 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(2))
 
     let nodeIdA = NodeId.random(rng[])
     votes.insert(nodeIdA, addr1);
@@ -86,9 +86,9 @@ suite "IP vote":
     var
       votes = IpVote.init(threshold)
     let
-      addr1 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(1))
-      addr2 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(2))
-      addr3 = Address(ip: ValidIpAddress.init("127.0.0.1"), port: Port(3))
+      addr1 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(1))
+      addr2 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(2))
+      addr3 = Address(ip: parseIpAddress("127.0.0.1"), port: Port(3))
 
     let nodeIdA = NodeId.random(rng[])
     votes.insert(nodeIdA, addr1);

--- a/tests/p2p/test_routing_table.nim
+++ b/tests/p2p/test_routing_table.nim
@@ -460,7 +460,7 @@ suite "Routing Table Tests":
     let updatedNode1 = generateNode(pk)
     # Need to do an update to get seqNum increased
     let updated = updatedNode1.update(pk,
-      some(ValidIpAddress.init("192.168.0.1")),
+      some(parseIpAddress("192.168.0.1")),
       some(Port(9000)), some(Port(9000)))
     check updated.isOk()
     check table.addNode(updatedNode1) == Existing
@@ -509,7 +509,7 @@ suite "Routing Table Tests":
     for i in 0..<DefaultTableIpLimits.bucketIpLimit + 1:
       # Need to do an update to get seqNum increased
       let updated = updatedNode1.update(pk,
-        some(ValidIpAddress.init("192.168.0.1")),
+        some(parseIpAddress("192.168.0.1")),
         some(Port(9000+i)), some(Port(9000+i)))
       check updated.isOk()
       check table.addNode(updatedNode1) == Existing

--- a/tests/p2p/test_routing_table.nim
+++ b/tests/p2p/test_routing_table.nim
@@ -291,7 +291,7 @@ suite "Routing Table Tests":
       # Further fill the bucket with nodes with different ip.
       let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256,
         int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit),
-        ValidIpAddress.init("192.168.0.1"))
+        parseIpAddress("192.168.0.1"))
       for n in diffIpNodes:
         check table.addNode(n) == Added
 
@@ -304,7 +304,7 @@ suite "Routing Table Tests":
       # Add more nodes with different ip and distance 255 to get in the new bucket
       let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 255,
         int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit - 1),
-        ValidIpAddress.init("192.168.1.1"))
+        parseIpAddress("192.168.1.1"))
       for n in diffIpNodes:
         check table.addNode(n) == Added
 
@@ -329,7 +329,7 @@ suite "Routing Table Tests":
     for j in 0..<amount:
       let nodes = node.nodesAtDistanceUniqueIp(rng[], 256 - j,
         int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit),
-        ValidIpAddress.init("192.168.0.1"))
+        parseIpAddress("192.168.0.1"))
       for n in nodes:
         check table.addNode(n) == Added
 
@@ -340,7 +340,7 @@ suite "Routing Table Tests":
 
     # Add a node with a different IP, should work and split a bucket once more.
     let anotherDiffIpNode = node.nodeAtDistance(rng[], 256 - amount,
-      ValidIpAddress.init("192.168.1.1"))
+      parseIpAddress("192.168.1.1"))
     check table.addNode(anotherDiffIpNode) == Added
 
     let amountLeft = int(DefaultTableIpLimits.tableIpLimit mod
@@ -361,7 +361,7 @@ suite "Routing Table Tests":
 
     let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256,
       int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit + 1),
-      ValidIpAddress.init("192.168.0.1"))
+      parseIpAddress("192.168.0.1"))
     for n in diffIpNodes:
       check table.addNode(n) == Added
 
@@ -403,7 +403,7 @@ suite "Routing Table Tests":
 
       let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256,
         int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit + 1),
-        ValidIpAddress.init("192.168.0.1"))
+        parseIpAddress("192.168.0.1"))
       for n in diffIpNodes:
         check table.addNode(n) == Added
 
@@ -413,7 +413,7 @@ suite "Routing Table Tests":
 
       let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256,
         int(REPLACEMENT_CACHE_SIZE - 1),
-        ValidIpAddress.init("192.168.1.1"))
+        parseIpAddress("192.168.1.1"))
       for n in diffIpNodes:
         check table.addNode(n) == ReplacementAdded
 
@@ -423,7 +423,7 @@ suite "Routing Table Tests":
 
     # Add one with different ip, to remove the first
     let diffIpNode = node.nodeAtDistance(rng[], 256,
-      ValidIpAddress.init("192.168.2.1"))
+      parseIpAddress("192.168.2.1"))
     check table.addNode(diffIpNode) == ReplacementAdded
 
     # Now the add should work
@@ -435,7 +435,7 @@ suite "Routing Table Tests":
 
     # Fill bucket
     let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256, BUCKET_SIZE,
-      ValidIpAddress.init("192.168.0.1"))
+      parseIpAddress("192.168.0.1"))
     for n in diffIpNodes:
       check table.addNode(n) == Added
 
@@ -478,7 +478,7 @@ suite "Routing Table Tests":
 
     # Fill bucket
     let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256, BUCKET_SIZE,
-      ValidIpAddress.init("192.168.0.1"))
+      parseIpAddress("192.168.0.1"))
     for n in diffIpNodes:
       check table.addNode(n) == Added
 
@@ -487,7 +487,7 @@ suite "Routing Table Tests":
 
     # For replacements we don't need to get seqNum increased as the node will
     # still get pushed in front of the queue.
-    let updatedNode1 = generateNode(pk, ip = ValidIpAddress.init("192.168.1.1"))
+    let updatedNode1 = generateNode(pk, ip = parseIpAddress("192.168.1.1"))
     check table.addNode(updatedNode1) == ReplacementExisting
 
     let sameIpNodes = node.nodesAtDistance(rng[], 256,

--- a/tools/dcli.nim
+++ b/tools/dcli.nim
@@ -191,9 +191,14 @@ proc run(config: DiscoveryConf) {.raises: [CatchableError].} =
     # TODO: allow for no TCP port mapping!
     (extIp, _, extUdpPort) = setupAddress(config.nat,
       config.listenAddress, udpPort, udpPort, "dcli")
+    extValidIp =
+      if extIp.isSome:
+        some ValidIpAddress.init(extIp.get)
+      else:
+        none ValidIpAddress
 
   let d = newProtocol(config.nodeKey,
-          extIp, none(Port), extUdpPort,
+          extValidIp, none(Port), extUdpPort,
           bootstrapRecords = config.bootnodes,
           bindIp = bindIp, bindPort = udpPort,
           enrAutoUpdate = config.enrAutoUpdate)

--- a/tools/dcli.nim
+++ b/tools/dcli.nim
@@ -191,14 +191,9 @@ proc run(config: DiscoveryConf) {.raises: [CatchableError].} =
     # TODO: allow for no TCP port mapping!
     (extIp, _, extUdpPort) = setupAddress(config.nat,
       config.listenAddress, udpPort, udpPort, "dcli")
-    extValidIp =
-      if extIp.isSome:
-        some ValidIpAddress.init(extIp.get)
-      else:
-        none ValidIpAddress
 
   let d = newProtocol(config.nodeKey,
-          extValidIp, none(Port), extUdpPort,
+          extIp, none(Port), extUdpPort,
           bootstrapRecords = config.bootnodes,
           bindIp = bindIp, bindPort = udpPort,
           enrAutoUpdate = config.enrAutoUpdate)

--- a/tools/dcli.nim
+++ b/tools/dcli.nim
@@ -37,7 +37,7 @@ type
     listenAddress* {.
       defaultValue: defaultListenAddress(config)
       desc: "Listening address for the Discovery v5 traffic"
-      name: "listen-address" }: ValidIpAddress
+      name: "listen-address" }: IpAddress
 
     persistingFile* {.
       defaultValue: "peerstore.csv",
@@ -108,8 +108,8 @@ type
         desc: "ENR URI of the node to send a talkReq message"
         name: "node" .}: Node
 
-func defaultListenAddress*(conf: DiscoveryConf): ValidIpAddress =
-  (static ValidIpAddress.init("0.0.0.0"))
+func defaultListenAddress*(conf: DiscoveryConf): IpAddress =
+  (static parseIpAddress("0.0.0.0"))
 
 func defaultAdminListenAddress*(conf: DiscoveryConf): ValidIpAddress =
   (static ValidIpAddress.init("127.0.0.1"))


### PR DESCRIPTION
`ValidIpAddress` is deprecated. `nim-eth` uses it elsewhere as well, but this PR addresses specifically the main place the deprecation warnings shows up in the `nimbus-eth2` build process.