### PR TITLE
Adjust test names and comments for `blobGasUsed` field

### DIFF
--- a/eth/rlp/writer.nim
+++ b/eth/rlp/writer.nim
@@ -228,11 +228,15 @@ macro genOptionalFieldsValidation(obj: untyped, T: type, num: static[int]): unty
 
   # generate something like
   when false:
-    if obj.excessBlobGas.isSome:
-      doAssert(obj.withdrawalsRoot.isSome, "withdrawalsRoot expected")
-      doAssert(obj.fee.isSome, "fee expected")
-    if obj.withdrawalsRoot.isSome:
-      doAssert(obj.fee.isSome, "fee expected")
+    if obj.fee.isNone:
+      doAssert(obj.withdrawalsRoot.isNone, "withdrawalsRoot needs fee")
+      doAssert(obj.blobGasUsed.isNone, "blobGasUsed needs fee")
+      doAssert(obj.excessBlobGas.isNone, "excessBlobGas needs fee")
+    if obj.withdrawalsRoot.isNone:
+      doAssert(obj.blobGasUsed.isNone, "blobGasUsed needs withdrawalsRoot")
+      doAssert(obj.excessBlobGas.isNone, "excessBlobGas needs withdrawalsRoot")
+    doAssert obj.blobGasUsed.isSome == obj.excessBlobGas.isSome,
+      "blobGasUsed and excessBlobGas must both be present or absent"
 
 macro countFieldsRuntimeImpl(obj: untyped, T: type, num: static[int]): untyped =
   let

--- a/tests/rlp/test_rlp_codec.nim
+++ b/tests/rlp/test_rlp_codec.nim
@@ -61,7 +61,8 @@ suite "BlockHeader roundtrip test":
     expect AssertionDefect:
       roundTrip(h)
 
-  test "Header + none(baseFee) + some(withdrawalsRoot) + some(excessBlobGas)":
+  test "Header + none(baseFee) + some(withdrawalsRoot) + " &
+      "some(blobGasUsed) + some(excessBlobGas)":
     let h = BlockHeader(
       withdrawalsRoot: some(Hash256()),
       blobGasUsed: some(1'u64),
@@ -70,7 +71,8 @@ suite "BlockHeader roundtrip test":
     expect AssertionDefect:
       roundTrip(h)
 
-  test "Header + none(baseFee) + none(withdrawalsRoot) + some(excessBlobGas)":
+  test "Header + none(baseFee) + none(withdrawalsRoot) + " &
+      "some(blobGasUsed) + some(excessBlobGas)":
     let h = BlockHeader(
       blobGasUsed: some(1'u64),
       excessBlobGas: some(1'u64)
@@ -78,7 +80,8 @@ suite "BlockHeader roundtrip test":
     expect AssertionDefect:
       roundTrip(h)
 
-  test "Header + some(baseFee) + none(withdrawalsRoot) + some(excessBlobGas)":
+  test "Header + some(baseFee) + none(withdrawalsRoot) + " &
+      "some(blobGasUsed) + some(excessBlobGas)":
     let h = BlockHeader(
       fee: some(2.u256),
       blobGasUsed: some(1'u64),
@@ -94,7 +97,8 @@ suite "BlockHeader roundtrip test":
     )
     roundTrip(h)
 
-  test "Header + some(baseFee) + some(withdrawalsRoot) + some(excessBlobGas)":
+  test "Header + some(baseFee) + some(withdrawalsRoot) + " &
+      "some(blobGasUsed) + some(excessBlobGas)":
     let h = BlockHeader(
       fee: some(2.u256),
       withdrawalsRoot: some(Hash256()),


### PR DESCRIPTION
`blobGasUsed` was not mentioned in `test_rlp_codec` test names, despite being used. Further, update the idea of `genOptionalFieldsValidation` to also check for `blobGasUsed`, and fix the check to catch unsupported combinations of optional fields.