### PR TITLE
Fix chronos related deprecated warnings in uTP code part II

### DIFF
--- a/eth/utp/utp_discv5_protocol.nim
+++ b/eth/utp/utp_discv5_protocol.nim
@@ -70,16 +70,13 @@ proc initSendCallback(
     t: protocol.Protocol, subProtocolName: seq[byte]):
     SendCallback[NodeAddress] =
   return (
-    proc (to: NodeAddress, data: seq[byte]): Future[void] =
-      let fut = newFuture[void]()
+    proc (to: NodeAddress, data: seq[byte]){.raises: [], gcsafe.} =
       # hidden assumption here is that nodes already have established discv5
       # session between each other. In our use case this should be true as
       # opening stream is only done after successful OFFER/ACCEPT or
       # FINDCONTENT/CONTENT exchange which forces nodes to establish session
       # between each other.
       discard t.talkReqDirect(to, subProtocolName, data)
-      fut.complete()
-      return fut
   )
 
 proc messageHandler(

--- a/tests/utp/test_utils.nim
+++ b/tests/utp/test_utils.nim
@@ -106,8 +106,13 @@ proc generateDataPackets*(
   packets
 
 proc initTestSnd*(q: AsyncQueue[Packet]): SendCallback[TransportAddress]=
-  return  (
-    proc (to: TransportAddress, bytes: seq[byte]): Future[void] =
+  return (
+    proc (
+        to: TransportAddress, bytes: seq[byte]
+    ) {.raises: [], gcsafe.} =
       let p = decodePacket(bytes).get()
-      q.addLast(p)
+      try:
+        q.addLastNoWait(p)
+      except AsyncQueueFullError:
+        raiseAssert "Should not occur as unlimited queue"
   )


### PR DESCRIPTION
This also makes the uTP SendCallBack not returning a Future any more as it is not used in sendData anyhow. And in case of uTP over discv5, discv5 send call is already not async.

This gives quite a noticable throughput benchmark improvement over with uTP over UDP, and a slightly noticable with uTP over discv5