### PR TITLE
avoid `XDeclaredButNotUsed` in `kvstore_sqlite3` with empty tuple

### DIFF
--- a/eth/db/kvstore_sqlite3.nim
+++ b/eth/db/kvstore_sqlite3.nim
@@ -248,7 +248,7 @@ iterator exec*[Params, Res](s: SqliteStmt[Params, Res],
   # `yield` statements cause when inlining the loop body
   var res = KvResult[void].ok()
   when params is tuple:
-    var i = 1
+    var i {.used.} = 1
     for param in fields(params):
       if (let v = bindParam(s, i, param); v != SQLITE_OK):
         res = KvResult[void].err(toErrorString(s.env, v))


### PR DESCRIPTION
Suppresses an annoying hint that gets triggered when `params is tuple` but it's an empty tuple without fields.

```
Hint: 'i' is declared but not used [XDeclaredButNotUsed]
```