### PR TITLE
avoid `burnMem` for `keccakHash`

### DIFF
--- a/eth/common/eth_hash.nim
+++ b/eth/common/eth_hash.nim
@@ -30,10 +30,16 @@ template withKeccakHash*(body: untyped): KeccakHash =
     body
     finish(h)
 
-func keccakHash*(input: openArray[byte]): KeccakHash =
-  keccak256.digest(input)
-func keccakHash*(input: openArray[char]): KeccakHash =
-  keccak256.digest(input)
+func keccakHash*(input: openArray[byte]): KeccakHash {.noinit.} =
+    # We use the init-update-finish interface to avoid
+    # the expensive burning/clearing memory (20~30% perf)
+    var ctx: keccak256
+    ctx.init()
+    ctx.update(input)
+    ctx.finish()
+
+func keccakHash*(input: openArray[char]): KeccakHash {.noinit.} =
+  keccakHash(input.toOpenArrayByte(0, input.high()))
 
 func keccakHash*(a, b: openArray[byte]): KeccakHash =
   withKeccakHash:


### PR DESCRIPTION
We don't need to clear keccak context after hashing ethereum data since it is already public - similar to
https://github.com/status-im/nimbus-eth2/pull/222.

Because we overwrite the result fully, we also don't need to zero first.