### PR TITLE
Fix missing CancelledError on discv5 waitMessage + results imports

### DIFF
--- a/eth/keys.nim
+++ b/eth/keys.nim
@@ -1,5 +1,5 @@
 # Nim Ethereum Keys
-# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Copyright (c) 2020-2024 Status Research & Development GmbH
 # Licensed under either of
 # - Apache License, version 2.0, (LICENSE-APACHEv2)
 # - MIT license (LICENSE-MIT)
@@ -17,7 +17,8 @@
 import
   std/strformat,
   secp256k1, bearssl/hash as bhash, bearssl/rand,
-  stew/[byteutils, objects, results, ptrops],
+  stew/[byteutils, objects, ptrops],
+  results,
   ./common/eth_hash
 
 from nimcrypto/utils import burnMem

--- a/eth/p2p/discoveryv5/encoding.nim
+++ b/eth/p2p/discoveryv5/encoding.nim
@@ -16,7 +16,8 @@
 import
   std/[tables, options, hashes, net],
   nimcrypto/[bcmode, rijndael, sha2], stint, chronicles,
-  stew/[results, byteutils, endians2], metrics,
+  stew/[byteutils, endians2], metrics,
+  results,
   ".."/../[rlp, keys],
   "."/[messages_encoding, node, enr, hkdf, sessions]
 

--- a/eth/p2p/discoveryv5/enr.nim
+++ b/eth/p2p/discoveryv5/enr.nim
@@ -13,7 +13,8 @@
 import
   std/[strutils, macros, algorithm, options, net],
   nimcrypto/[keccak, utils],
-  stew/[base64, results],
+  stew/base64,
+  results,
   chronicles,
   ".."/../[rlp, keys],
   ../../net/utils

--- a/eth/p2p/discoveryv5/messages_encoding.nim
+++ b/eth/p2p/discoveryv5/messages_encoding.nim
@@ -11,7 +11,8 @@
 
 import
   std/net,
-  stew/[arrayops, results],
+  stew/arrayops,
+  results,
   ../../rlp,
   "."/[messages, enr]
 

--- a/eth/rlp.nim
+++ b/eth/rlp.nim
@@ -4,7 +4,8 @@
 
 import
   std/[strutils, options],
-  stew/[byteutils, shims/macros, results],
+  stew/[byteutils, shims/macros],
+  results,
   ./rlp/[writer, object_serialization],
   ./rlp/priv/defs
 

--- a/eth/utp/packets.nim
+++ b/eth/utp/packets.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Copyright (c) 2020-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -12,7 +12,8 @@
 import
   faststreams,
   chronos,
-  stew/[endians2, results, objects],
+  stew/[endians2, objects],
+  results,
   ../p2p/discoveryv5/random2
 
 export results, random2

--- a/eth/utp/utp_socket.nim
+++ b/eth/utp/utp_socket.nim
@@ -9,7 +9,8 @@
 import
   std/[sugar, deques],
   chronos, chronicles, metrics,
-  stew/[results, bitops2],
+  stew/bitops2,
+  results,
   ./growable_buffer,
   ./packets,
   ./ledbat_congestion_control,
@@ -18,7 +19,7 @@ import
   ./clock_drift_calculator
 
 export
-  chronicles
+  chronicles, results
 
 logScope:
   topics = "eth utp utp_socket"


### PR DESCRIPTION
Fixes a missing CancelledError async raising on discv5 waitMessage which would cause "Error set on a non-raising future".

Also moves some more results import away from stew.