### PR TITLE
Overhaul of ENR implementation - part I

### DIFF
--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -253,7 +253,7 @@ func updateRecord*(
     d: Protocol, enrFields: openArray[(string, seq[byte])]): DiscResult[void] =
   ## Update the ENR of the local node with provided `enrFields` k:v pairs.
   let fields = mapIt(enrFields, toFieldPair(it[0], it[1]))
-  d.localNode.record.update(d.privateKey, fields)
+  d.localNode.record.update(d.privateKey, extraFields = fields)
   # TODO: Would it make sense to actively ping ("broadcast") to all the peers
   # we stored a handshake with in order to get that ENR updated?
 
@@ -992,6 +992,8 @@ proc newProtocol*(
   var record: Record
   if previousRecord.isSome():
     record = previousRecord.get()
+    # TODO: this is faulty in case the intent is to remove a field with
+    # opt.none
     record.update(privKey, enrIp, enrTcpPort, enrUdpPort,
       customEnrFields).expect("Record within size limits and correct key")
   else:
@@ -1045,6 +1047,8 @@ proc newProtocol*(
     record =
       if previousRecord.isSome():
         var res = previousRecord.get()
+        # TODO: this is faulty in case the intent is to remove a field with
+        # opt.none
         res.update(privKey, enrIp, enrTcpPort, enrUdpPort,
           customEnrFields).expect("Record within size limits and correct key")
         res

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -437,9 +437,9 @@ suite "Discovery v5 Tests":
         previousRecord = Opt.some(updatesNode.getRecord()))
     check:
       node.getRecord().seqNum == 1
-      noUpdatesNode.getRecord().seqNum == 1
-      updatesNode.getRecord().seqNum == 2
-      moreUpdatesNode.getRecord().seqNum == 3
+      noUpdatesNode.getRecord().seqNum == 2
+      updatesNode.getRecord().seqNum == 3
+      moreUpdatesNode.getRecord().seqNum == 4
 
     # Defect (for now?) on incorrect key use
     expect ResultDefect:


### PR DESCRIPTION
- Rework adding and updating of fields by having an insert call that gets used everywhere. Avoiding also duplicate keys. One side-effect of this is that ENR sequence number will always get updated on an update call, even if nothing changes.
- Deprecate initRecord as it is only used in tests and is flawed
- Assert when predefined keys go into the extra custom pairs. Any of the predefined keys are only to be passed now via specific parameters to make sure that the correct types are stored in ENR.
- Clearify the Opt.none behaviour for Record.update
- When setting ipv6, allow for tcp/udp port fields to be used default
- General clean-up
- Rework/clean-up completely the ENR tests.