### PR TITLE
Using unsigned types for message type and requst IDs

### DIFF
--- a/tests/fuzzing/rlpx/thunk.nim
+++ b/tests/fuzzing/rlpx/thunk.nim
@@ -29,6 +29,6 @@ test:
            # because of undeterministic behaviour due to usage of network/async.
     try:
       var (msgId, msgData) = recvMsgMock(payload)
-      waitFor peer.invokeThunk(msgId.int, msgData)
+      waitFor peer.invokeThunk(msgId, msgData)
     except CatchableError as e:
       debug "Test caused CatchableError", exception=e.name, trace=e.repr, msg=e.msg

--- a/tests/p2p/p2p_test_helper.nim
+++ b/tests/p2p/p2p_test_helper.nim
@@ -1,3 +1,13 @@
+# nim-eth
+# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at
+#     https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at
+#     https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
 import
   std/strutils,
   chronos,
@@ -28,8 +38,8 @@ proc setupTestNode*(
 
 template sourceDir*: string = currentSourcePath.rsplit(DirSep, 1)[0]
 
-proc recvMsgMock*(msg: openArray[byte]): tuple[msgId: int, msgData: Rlp] =
+proc recvMsgMock*(msg: openArray[byte]): tuple[msgId: uint, msgData: Rlp] =
   var rlp = rlpFromBytes(msg)
 
-  let msgId = rlp.read(int32)
-  return (msgId.int, rlp)
+  let msgId = rlp.read(uint32)
+  return (msgId.uint, rlp)

--- a/tests/p2p/test_rlpx_thunk.json
+++ b/tests/p2p/test_rlpx_thunk.json
@@ -9,14 +9,14 @@
     "error": "UnsupportedMessageError",
     "description": "This is a message id not used by devp2p or eth"
   },
-  "Message id that is bigger than int32": {
+  "Message id that is bigger than uint32": {
     "payload": "888888888888888888",
     "error": "UnsupportedRlpError",
     "description": "This payload will result in too large int for a message id"
   },
-  "Message id that is negative": {
-    "payload": "8488888888",
-    "error": "UnsupportedRlpError",
+  "Unsupported big message id": {
+    "payload": "848888888888",
+    "error": "UnsupportedMessageError",
     "description": "This payload will result in a negative number as message id"
   },
   "No Hash nor Status, but empty list": {

--- a/tests/p2p/test_rlpx_thunk.nim
+++ b/tests/p2p/test_rlpx_thunk.nim
@@ -1,3 +1,13 @@
+# nim-eth
+# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at
+#     https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at
+#     https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
 {.used.}
 
 import
@@ -23,7 +33,7 @@ let peer = res.get()
 
 proc testThunk(payload: openArray[byte]) =
   var (msgId, msgData) = recvMsgMock(payload)
-  waitFor peer.invokeThunk(msgId.int, msgData)
+  waitFor peer.invokeThunk(msgId, msgData)
 
 proc testPayloads(filename: string) =
   let js = json.parseFile(filename)


### PR DESCRIPTION
 Negative values are neither defined for RLP nor in the protocol specs which refer to the RLPs (see yellow paper app B clause (199).