### PR TITLE
move signal ignore out of `eth/common`

### DIFF
--- a/eth/common/utils.nim
+++ b/eth/common/utils.nim
@@ -8,13 +8,8 @@
 
 import
   std/[hashes],
-  nimcrypto/hash, stew/byteutils, metrics,
+  nimcrypto/hash, stew/byteutils,
   ./eth_types
-
-when defined(posix):
-  import std/[posix, os]
-
-export metrics
 
 proc hash*(d: MDigest): Hash {.inline.} = hash(d.data)
 
@@ -23,31 +18,3 @@ proc parseAddress*(hexString: string): EthAddress =
 
 proc `$`*(a: EthAddress): string =
   a.toHex()
-
-# Block all/most signals in the current thread, so we don't interfere with regular signal
-# handling elsewhere.
-proc ignoreSignalsInThread*() =
-  when defined(posix):
-    var signalMask, oldSignalMask: Sigset
-
-    # sigprocmask() doesn't work on macOS, for multithreaded programs
-    if sigfillset(signalMask) != 0:
-      echo osErrorMsg(osLastError())
-      quit(QuitFailure)
-    when defined(boehmgc):
-      # Turns out Boehm GC needs some signals to deal with threads:
-      # https://www.hboehm.info/gc/debugging.html
-      const
-        SIGPWR = 30
-        SIGXCPU = 24
-        SIGSEGV = 11
-        SIGBUS = 7
-      if sigdelset(signalMask, SIGPWR) != 0 or
-        sigdelset(signalMask, SIGXCPU) != 0 or
-        sigdelset(signalMask, SIGSEGV) != 0 or
-        sigdelset(signalMask, SIGBUS) != 0:
-        echo osErrorMsg(osLastError())
-        quit(QuitFailure)
-    if pthread_sigmask(SIG_BLOCK, signalMask, oldSignalMask) != 0:
-      echo osErrorMsg(osLastError())
-      quit(QuitFailure)

--- a/eth/net/nat.nim
+++ b/eth/net/nat.nim
@@ -52,7 +52,7 @@ when defined(posix):
 
 # Block all/most signals in the current thread, so we don't interfere with regular signal
 # handling elsewhere.
-proc ignoreSignalsInThread*() =
+proc ignoreSignalsInThread() =
   when defined(posix):
     var signalMask, oldSignalMask: Sigset
 
@@ -60,20 +60,6 @@ proc ignoreSignalsInThread*() =
     if sigfillset(signalMask) != 0:
       echo osErrorMsg(osLastError())
       quit(QuitFailure)
-    when defined(boehmgc):
-      # Turns out Boehm GC needs some signals to deal with threads:
-      # https://www.hboehm.info/gc/debugging.html
-      const
-        SIGPWR = 30
-        SIGXCPU = 24
-        SIGSEGV = 11
-        SIGBUS = 7
-      if sigdelset(signalMask, SIGPWR) != 0 or
-        sigdelset(signalMask, SIGXCPU) != 0 or
-        sigdelset(signalMask, SIGSEGV) != 0 or
-        sigdelset(signalMask, SIGBUS) != 0:
-        echo osErrorMsg(osLastError())
-        quit(QuitFailure)
     if pthread_sigmask(SIG_BLOCK, signalMask, oldSignalMask) != 0:
       echo osErrorMsg(osLastError())
       quit(QuitFailure)

--- a/eth/net/nat.nim
+++ b/eth/net/nat.nim
@@ -47,6 +47,37 @@ var
 logScope:
   topics = "eth net nat"
 
+when defined(posix):
+  import std/posix
+
+# Block all/most signals in the current thread, so we don't interfere with regular signal
+# handling elsewhere.
+proc ignoreSignalsInThread*() =
+  when defined(posix):
+    var signalMask, oldSignalMask: Sigset
+
+    # sigprocmask() doesn't work on macOS, for multithreaded programs
+    if sigfillset(signalMask) != 0:
+      echo osErrorMsg(osLastError())
+      quit(QuitFailure)
+    when defined(boehmgc):
+      # Turns out Boehm GC needs some signals to deal with threads:
+      # https://www.hboehm.info/gc/debugging.html
+      const
+        SIGPWR = 30
+        SIGXCPU = 24
+        SIGSEGV = 11
+        SIGBUS = 7
+      if sigdelset(signalMask, SIGPWR) != 0 or
+        sigdelset(signalMask, SIGXCPU) != 0 or
+        sigdelset(signalMask, SIGSEGV) != 0 or
+        sigdelset(signalMask, SIGBUS) != 0:
+        echo osErrorMsg(osLastError())
+        quit(QuitFailure)
+    if pthread_sigmask(SIG_BLOCK, signalMask, oldSignalMask) != 0:
+      echo osErrorMsg(osLastError())
+      quit(QuitFailure)
+
 ## Also does threadvar initialisation.
 ## Must be called before redirectPorts() in each thread.
 proc getExternalIP*(natStrategy: NatStrategy, quiet = false): Opt[IpAddress] =

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -41,7 +41,7 @@ when useSnappy:
 # "undeclared identifier: 'activeChroniclesStream'", when the code using p2p
 # does not import chronicles. Need to resolve this properly.
 export
-  options, p2pProtocol, rlp, chronicles
+  options, p2pProtocol, rlp, chronicles, metrics
 
 declarePublicGauge rlpx_connected_peers,
   "Number of connected peers in the pool"


### PR DESCRIPTION
`net/nat` is the only place where it is used and it certainly doesn't belong in `common`