### PR TITLE
discv4: prefer ipv6

### DIFF
--- a/eth/p2p.nim
+++ b/eth/p2p.nim
@@ -84,7 +84,7 @@ proc newEthereumNode*(
     bootstrapNodes: seq[ENode] = @[],
     bindUdpPort: Port,
     bindTcpPort: Port,
-    bindIp = IPv4_any(),
+    bindIp = IPv6_any(),
     rng = newRng()): EthereumNode =
 
   if rng == nil: # newRng could fail

--- a/eth/p2p/kademlia.nim
+++ b/eth/p2p/kademlia.nim
@@ -49,7 +49,6 @@ type
     istart, iend: UInt256
     nodes: seq[Node]
     replacementCache: seq[Node]
-    lastUpdated: float # epochTime
 
   CommandId* = enum
     cmdPing = 1
@@ -216,7 +215,6 @@ proc add(k: KBucket, n: Node): Node =
   ## If the bucket is full, we add the node to the bucket's replacement cache and return the
   ## node at the head of the list (i.e. the least recently seen), which should be evicted if it
   ## fails to respond to a ping.
-  k.lastUpdated = epochTime()
   let nodeIdx = k.nodes.find(n)
   if nodeIdx != -1:
       k.nodes.delete(nodeIdx)


### PR DESCRIPTION
This allows bonding with ipv4-mapped nodes above all, which fixes a bunch of warnings