### PR TITLE
discv5: fix potential infinite loop in randomNodes

### DIFF
--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -545,7 +545,8 @@ proc randomNodes*(r: RoutingTable, maxAmount: int,
   # while it will take less total time compared to e.g. an (async)
   # randomLookup, the time might be wasted as all nodes are possibly seen
   # already.
-  while len(seen) < maxAmount:
+  # We check against the number of nodes to avoid an infinite loop in case of a filter.
+  while len(result) < maxAmount and len(seen) < sz:
     let bucket = r.rng[].sample(r.buckets)
     if bucket.nodes.len != 0:
       let node = r.rng[].sample(bucket.nodes)

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -417,6 +417,9 @@ suite "Discovery v5 Tests":
     let discoveredFiltered = lookupNode.randomNodes(10,
       ("test", @[byte 1,2,3,4]))
     check discoveredFiltered.len == 1 and discoveredFiltered.contains(targetNode)
+    let discoveredEmpty = lookupNode.randomNodes(10,
+      proc(n: Node) : bool = false)
+    check discoveredEmpty.len == 0
 
     await lookupNode.closeWait()
 


### PR DESCRIPTION
randomNodes could do an infinite loop if used with a filter expression

- added fix
- added test (goes in infinite loop without the fix)