### PR TITLE
clean up redundant code in eth/rlp/writer.nim

### DIFF
--- a/eth/common/base_rlp.nim
+++ b/eth/common/base_rlp.nim
@@ -7,29 +7,16 @@
 
 {.push raises: [].}
 
-import std/typetraits, ./base, ../rlp
+import
+  std/typetraits, ./base, ../rlp, 
+  ../rlp/options as rlp_options
 
-export base, rlp
+export base, rlp, rlp_options
 
-# TODO why is rlp serialization of `Opt` here and not in rlp?
-proc append*[T](w: var RlpWriter, val: Opt[T]) =
-  mixin append
-
-  if val.isSome:
-    w.append(val.get())
-  else:
-    w.append("")
 
 template read*[T](rlp: var Rlp, val: var T) =
   mixin read
   val = rlp.read(type val)
-
-proc read*[T](rlp: var Rlp, val: var Opt[T]) {.raises: [RlpError].} =
-  mixin read
-  if rlp.blobLen != 0:
-    val = Opt.some(rlp.read(T))
-  else:
-    rlp.skipElem
 
 proc read*(rlp: var Rlp, T: type StUint): T {.raises: [RlpError].} =
   if rlp.isBlob:

--- a/eth/common/base_rlp.nim
+++ b/eth/common/base_rlp.nim
@@ -9,9 +9,9 @@
 
 import
   std/typetraits, ./base, ../rlp, 
-  ../rlp/options as rlp_options
+  ../rlp/results as rlp_results
 
-export base, rlp, rlp_options
+export base, rlp, rlp_results
 
 
 template read*[T](rlp: var Rlp, val: var T) =

--- a/eth/rlp.nim
+++ b/eth/rlp.nim
@@ -448,9 +448,6 @@ func readImpl(
     else:
       rlp.bytes.len()
 
-  template getUnderlyingType[T](_: Option[T]): untyped =
-    T
-
   template getUnderlyingType[T](_: Opt[T]): untyped =
     T
 
@@ -458,16 +455,6 @@ func readImpl(
     type FieldType {.used.} = type field
     when hasCustomPragmaFixed(RecordType, fieldName, rlpCustomSerialization):
       field = rlp.read(result, FieldType)
-    elif field is Option:
-      # this works for optional fields at the end of an object/tuple
-      # if the optional field is followed by a mandatory field,
-      # custom serialization for a field or for the parent object
-      # will be better
-      type UT = getUnderlyingType(field)
-      if rlp.position < payloadEnd:
-        field = some(rlp.read(UT))
-      else:
-        field = none(UT)
     elif field is Opt:
       # this works for optional fields at the end of an object/tuple
       # if the optional field is followed by a mandatory field,

--- a/eth/rlp/options.nim
+++ b/eth/rlp/options.nim
@@ -1,17 +1,20 @@
-import
-  std/options,
-  ../rlp
+import ../rlp
+import results
 
-proc read*[T](rlp: var Rlp, O: type Option[T]): O {.inline.} =
-  mixin read
-  if not rlp.isEmpty:
-    result = some read(rlp, T)
+proc append*[T](w: var RlpWriter, val: Opt[T]) =
+  mixin append
 
-proc append*(writer: var RlpWriter, value: Option) =
-  if value.isSome:
-    writer.append value.get
+  if val.isSome:
+    w.append(val.get())
   else:
-    writer.append ""
+    w.append("")
 
-export
-  options, rlp
+proc read*[T](rlp: var Rlp, val: var Opt[T]) {.raises: [RlpError].} =
+  mixin read
+  if rlp.blobLen != 0:
+    val = Opt.some(rlp.read(T))
+  else:
+    rlp.skipElem
+
+export 
+  rlp, results

--- a/eth/rlp/results.nim
+++ b/eth/rlp/results.nim
@@ -1,5 +1,9 @@
 import ../rlp
-import results
+import writer
+import pkg/results
+
+export 
+  rlp, results
 
 proc append*[T](w: var RlpWriter, val: Opt[T]) =
   mixin append
@@ -16,5 +20,3 @@ proc read*[T](rlp: var Rlp, val: var Opt[T]) {.raises: [RlpError].} =
   else:
     rlp.skipElem
 
-export 
-  rlp, results

--- a/eth/rlp/writer.nim
+++ b/eth/rlp/writer.nim
@@ -269,7 +269,7 @@ proc initRlpList*(listSize: int): RlpWriter =
 
 # TODO: This should return a lent value
 template finish*(self: RlpWriter): seq[byte] =
-  doAssert self.pendingLists.len == 0, "Insufficient number of elements written to a started list" & $(self.pendingLists.len)
+  doAssert self.pendingLists.len == 0, "Insufficient number of elements written to a started list"
   self.output
 
 func clear*(w: var RlpWriter) =

--- a/tests/rlp/all_tests.nim
+++ b/tests/rlp/all_tests.nim
@@ -2,4 +2,5 @@ import
   ./test_api_usage,
   ./test_json_suite,
   ./test_empty_string,
-  ./test_object_serialization
+  ./test_object_serialization,
+  ./test_optional_fields

--- a/tests/rlp/test_optional_fields.nim
+++ b/tests/rlp/test_optional_fields.nim
@@ -1,0 +1,65 @@
+{.used.}
+
+import
+  ../../eth/[rlp, common],
+  unittest2
+
+# Optionals in between mandatory fields for the convenience of
+# implementation. According to the spec all optionals appear
+# after mandatory fields. Moreover, an empty optional field
+# cannot and will not appear before a non-empty optional field
+
+type ObjectWithOptionals = object
+  a* : uint64
+  b* : uint64
+  c* : Opt[uint64] # should not count this as optional
+  d* : Opt[uint64] # should not count this as optional
+  e* : uint64
+  f* : uint64
+  g* : uint64
+  h* : Opt[uint64] # should not count this as optional
+  i* : Opt[uint64] # should not count this as optional
+  j* : Opt[uint64] # should not count this as optional
+  k* : uint64
+  l* : Opt[uint64] # should count this as an optional
+  m* : Opt[uint64] # should count this as an optional
+  n* : Opt[uint64] # should count this as an optional
+
+var 
+  objWithEmptyOptional: ObjectWithOptionals
+  objWithNonEmptyOptional: ObjectWithOptionals
+  objWithNonEmptyTrailingOptionals: ObjectWithOptionals
+  objWithEmptyTrailingOptionals: ObjectWithOptionals
+
+objWithNonEmptyOptional.c = Opt.some(0'u64)
+objWithNonEmptyOptional.d = Opt.some(0'u64)
+objWithNonEmptyOptional.h = Opt.some(0'u64)
+objWithNonEmptyOptional.i = Opt.some(0'u64)
+objWithNonEmptyOptional.j = Opt.some(0'u64)
+objWithNonEmptyOptional.l = Opt.some(0'u64)
+objWithNonEmptyOptional.m = Opt.some(0'u64)
+objWithNonEmptyOptional.n = Opt.some(0'u64)
+
+objWithNonEmptyTrailingOptionals.l = Opt.some(0'u64)
+objWithNonEmptyTrailingOptionals.m = Opt.some(0'u64)
+objWithNonEmptyTrailingOptionals.n = Opt.some(0'u64)
+
+objWithEmptyTrailingOptionals.c = Opt.some(0'u64)
+objWithEmptyTrailingOptionals.d = Opt.some(0'u64)
+objWithEmptyTrailingOptionals.h = Opt.some(0'u64)
+objWithEmptyTrailingOptionals.i = Opt.some(0'u64)
+objWithEmptyTrailingOptionals.j = Opt.some(0'u64)
+
+suite "test optional fields":
+  test "all optionals are empty":
+    let bytes = rlp.encode(objWithEmptyOptional)
+
+  test "all optionals are non empty":
+    let bytes = rlp.encode(objWithNonEmptyOptional)
+
+  test "Only trailing optionals are non empty":
+    let bytes = rlp.encode(objWithNonEmptyTrailingOptionals)
+
+  test "Only trailing optionals are empty":
+    let bytes = rlp.encode(objWithEmptyTrailingOptionals)
+

--- a/tests/rlp/test_optional_fields.nim
+++ b/tests/rlp/test_optional_fields.nim
@@ -53,13 +53,16 @@ objWithEmptyTrailingOptionals.j = Opt.some(0'u64)
 suite "test optional fields":
   test "all optionals are empty":
     let bytes = rlp.encode(objWithEmptyOptional)
+    check: bytes.len == 7 # 6 mandatory fields + prefix byte
 
   test "all optionals are non empty":
     let bytes = rlp.encode(objWithNonEmptyOptional)
+    check: bytes.len == 15 # 6 mandatory + 8 optional + prefix
 
   test "Only trailing optionals are non empty":
     let bytes = rlp.encode(objWithNonEmptyTrailingOptionals)
-
+    check: bytes.len == 10 # 6 mandatory + 3 trailing optional + prefix
+  
   test "Only trailing optionals are empty":
     let bytes = rlp.encode(objWithEmptyTrailingOptionals)
-
+    check: bytes.len == 12 # 6 mandatory + 5 non trailing + prefix


### PR DESCRIPTION
### Changelog

* renamed `checkedOptionalFields` to `countOptionalFields` and removed unnecessary abstractions(`optionalFieldsNum`) for counting optional fields 
* removes redundant `hasOptional` in favor of `countOptionalFields`. 
* removed `macro countFieldsRuntimeImpl` in favor of the nimbus style guide.

### Rationale
* Logical comparison on booleans (`x == True`) is equivalent to that of integers (`x > 0`) therefore `hasOptional` was redundant
* All the counting of optional fields anyways happened in runtime(`op` of `enumerateRlpFields`) all that was required was an additional check for emptiness of optional values. Hence the `macro countFieldsRuntimeImpl` was not required.