### PR TITLE
eth_hash: condition converter deprecation warning on nim version

### DIFF
--- a/eth/common/eth_hash.nim
+++ b/eth/common/eth_hash.nim
@@ -30,5 +30,11 @@ template keccakHash*(v: Address): Hash32 {.deprecated.} =
 
 from nimcrypto/hash import MDigest
 
-converter toMDigest*(v: Hash32): MDigest[256] {.deprecated.} =
+# TODO https://github.com/nim-lang/Nim/issues/24241
+when (NimMajor, NimMinor) >= (2, 12) or defined(ethDigestConverterWarning):
+  {.pragma: convdeprecated, deprecated.}
+else:
+  {.pragma: convdeprecated.}
+
+converter toMDigest*(v: Hash32): MDigest[256] {.convdeprecated.} =
   MDigest[256](data: v.data)


### PR DESCRIPTION
The warning gives too many false positives - until things work properly, locally one can just remove it to find instances where it gets used..

https://github.com/nim-lang/Nim/issues/24241