### PR TITLE
remove unusued rlpx features, tighten hello exchange and some error h…

### DIFF
--- a/eth/p2p.nim
+++ b/eth/p2p.nim
@@ -27,7 +27,7 @@ proc addCapability*(node: EthereumNode,
 
   let pos = lowerBound(node.protocols, p, rlpx.cmp)
   node.protocols.insert(p, pos)
-  node.capabilities.insert(p.asCapability, pos)
+  node.capabilities.insert(p.capability, pos)
 
   if p.networkStateInitializer != nil and networkState.isNil:
     node.protocolStates[p.index] = p.networkStateInitializer(node)

--- a/eth/p2p/p2p_backends_helpers.nim
+++ b/eth/p2p/p2p_backends_helpers.nim
@@ -16,7 +16,7 @@ let protocolManager = ProtocolManager()
 proc registerProtocol*(proto: ProtocolInfo) {.gcsafe.} =
   {.gcsafe.}:
     proto.index = protocolManager.protocols.len
-    if proto.name == "p2p":
+    if proto.capability.name == "p2p":
       doAssert(proto.index == 0)
     protocolManager.protocols.add proto
 

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -1231,7 +1231,7 @@ proc rlpxAccept*(node: EthereumNode, stream: StreamTransport): Future[Peer] {.as
     peer = Peer(network: node)
     remoteAddress = peer.transport.remoteAddress()
     deadline = sleepAsync(connectionTimeout)
-  trace "Incoming connection", remoteAddress
+  trace "Incoming connection", remoteAddress = $remoteAddress
 
   var ok = false
   try:

--- a/eth/p2p/rlpx.nim
+++ b/eth/p2p/rlpx.nim
@@ -1229,7 +1229,7 @@ proc rlpxAccept*(node: EthereumNode, stream: StreamTransport): Future[Peer] {.as
 
   let
     peer = Peer(network: node)
-    remoteAddress = peer.transport.remoteAddress()
+    remoteAddress = stream.remoteAddress()
     deadline = sleepAsync(connectionTimeout)
   trace "Incoming connection", remoteAddress = $remoteAddress
 

--- a/eth/p2p/rlpxtransport.nim
+++ b/eth/p2p/rlpxtransport.nim
@@ -12,6 +12,8 @@
 
 import results, chronos, eth/common/keys, ./[auth, rlpxcrypt]
 
+export results, keys, auth, rlpxcrypt
+
 type
   RlpxTransport* = ref object
     stream: StreamTransport

--- a/eth/p2p/rlpxtransport.nim
+++ b/eth/p2p/rlpxtransport.nim
@@ -10,9 +10,9 @@
 
 {.push raises: [], gcsafe.}
 
-import results, chronos, eth/common/keys, ./[auth, rlpxcrypt]
+import results, chronos, ../common/keys, ./[auth, rlpxcrypt]
 
-export results, keys, auth, rlpxcrypt
+export results, keys
 
 type
   RlpxTransport* = ref object

--- a/eth/p2p/rlpxtransport.nim
+++ b/eth/p2p/rlpxtransport.nim
@@ -1,0 +1,241 @@
+# nim-eth
+# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at
+#     https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at
+#     https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+{.push raises: [], gcsafe.}
+
+import results, chronos, eth/common/keys, ./[auth, rlpxcrypt]
+
+type
+  RlpxTransport* = ref object
+    stream: StreamTransport
+    state: SecretState
+    pubkey*: PublicKey
+
+  RlpxTransportError* = object of CatchableError
+
+template `^`(arr): auto =
+  # passes a stack array with a matching `arrLen` variable as an open array
+  arr.toOpenArray(0, `arr Len` - 1)
+
+proc initiatorHandshake(
+    rng: ref HmacDrbgContext,
+    keys: KeyPair,
+    stream: StreamTransport,
+    remotePubkey: PublicKey,
+): Future[ConnectionSecret] {.
+    async: (raises: [CancelledError, TransportError, RlpxTransportError])
+.} =
+  # https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/rlpx.md#initial-handshake
+  var
+    handshake = Handshake.init(rng[], keys, {Initiator})
+    authMsg: array[AuthMessageMaxEIP8, byte]
+
+  let
+    authMsgLen = handshake.authMessage(rng[], remotePubkey, authMsg).expect(
+        "No errors with correctly sized buffer"
+      )
+
+    writeRes = await stream.write(addr authMsg[0], authMsgLen)
+  if writeRes != authMsgLen:
+    raise (ref RlpxTransportError)(msg: "Could not write RLPx handshake header")
+
+  var ackMsg = newSeqOfCap[byte](1024)
+  ackMsg.setLen(MsgLenLenEIP8)
+  await stream.readExactly(addr ackMsg[0], len(ackMsg))
+
+  let ackMsgLen = handshake.decodeAckMsgLen(ackMsg).valueOr:
+    raise
+      (ref RlpxTransportError)(msg: "Could not decode handshake ack length: " & $error)
+
+  ackMsg.setLen(ackMsgLen)
+  await stream.readExactly(addr ackMsg[MsgLenLenEIP8], ackMsgLen - MsgLenLenEIP8)
+
+  handshake.decodeAckMessage(ackMsg).isOkOr:
+    raise (ref RlpxTransportError)(msg: "Could not decode handshake ack: " & $error)
+
+  handshake.getSecrets(^authMsg, ackMsg)
+
+proc responderHandshake(
+    rng: ref HmacDrbgContext, keys: KeyPair, stream: StreamTransport
+): Future[(ConnectionSecret, PublicKey)] {.
+    async: (raises: [CancelledError, TransportError, RlpxTransportError])
+.} =
+  # https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/rlpx.md#initial-handshake
+  var
+    handshake = Handshake.init(rng[], keys, {auth.Responder})
+    authMsg = newSeqOfCap[byte](1024)
+
+  authMsg.setLen(MsgLenLenEIP8)
+  await stream.readExactly(addr authMsg[0], len(authMsg))
+
+  let authMsgLen = handshake.decodeAuthMsgLen(authMsg).valueOr:
+    raise
+      (ref RlpxTransportError)(msg: "Could not decode handshake auth length: " & $error)
+
+  authMsg.setLen(authMsgLen)
+  await stream.readExactly(addr authMsg[MsgLenLenEIP8], authMsgLen - MsgLenLenEIP8)
+
+  handshake.decodeAuthMessage(authMsg).isOkOr:
+    raise (ref RlpxTransportError)(
+      msg: "Could not decode handshake auth message: " & $error
+    )
+
+  var ackMsg: array[AckMessageMaxEIP8, byte]
+  let ackMsgLen =
+    handshake.ackMessage(rng[], ackMsg).expect("no errors with correcly sized buffer")
+
+  var res = await stream.write(addr ackMsg[0], ackMsgLen)
+  if res != ackMsgLen:
+    raise (ref RlpxTransportError)(msg: "Could not write RLPx ack message")
+
+  (handshake.getSecrets(authMsg, ^ackMsg), handshake.remoteHPubkey)
+
+proc connect*(
+    _: type RlpxTransport,
+    rng: ref HmacDrbgContext,
+    keys: KeyPair,
+    address: TransportAddress,
+    remotePubkey: PublicKey,
+): Future[RlpxTransport] {.
+    async: (raises: [CancelledError, TransportError, RlpxTransportError])
+.} =
+  var stream = await connect(address)
+
+  try:
+    let secrets = await initiatorHandshake(rng, keys, stream, remotePubkey)
+    var res = RlpxTransport(stream: move(stream), pubkey: remotePubkey)
+    initSecretState(secrets, res.state)
+    res
+  finally:
+    if stream != nil:
+      stream.close()
+
+proc accept*(
+    _: type RlpxTransport,
+    rng: ref HmacDrbgContext,
+    keys: KeyPair,
+    stream: StreamTransport,
+): Future[RlpxTransport] {.
+    async: (raises: [CancelledError, TransportError, RlpxTransportError])
+.} =
+  var stream = stream
+  try:
+    let (secrets, remotePubkey) = await responderHandshake(rng, keys, stream)
+    var res = RlpxTransport(stream: move(stream), pubkey: remotePubkey)
+    initSecretState(secrets, res.state)
+    res
+  finally:
+    if stream != nil:
+      stream.close()
+
+proc recvMsg*(
+    transport: RlpxTransport
+): Future[seq[byte]] {.
+    async: (raises: [CancelledError, TransportError, RlpxTransportError])
+.} =
+  ## Read an RLPx frame from the given peer
+  var msgHeaderEnc: RlpxEncryptedHeader
+  await transport.stream.readExactly(addr msgHeaderEnc[0], msgHeaderEnc.len)
+
+  let msgHeader = decryptHeader(transport.state, msgHeaderEnc).valueOr:
+    raise (ref RlpxTransportError)(msg: "Cannot decrypt RLPx frame header")
+
+  # The capability-id and context id are always zero
+  # https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/rlpx.md#framing
+  if (msgHeader[4] != 0x80) or (msgHeader[5] != 0x80):
+    raise
+      (ref RlpxTransportError)(msg: "Invalid capability-id/context-id in RLPx header")
+
+  let msgSize = msgHeader.getBodySize()
+  let remainingBytes = encryptedLength(msgSize) - 32
+
+  var encryptedBytes = newSeq[byte](remainingBytes)
+  await transport.stream.readExactly(addr encryptedBytes[0], len(encryptedBytes))
+
+  let decryptedMaxLength = decryptedLength(msgSize) # Padded length
+  var msgBody = newSeq[byte](decryptedMaxLength)
+
+  if decryptBody(transport.state, encryptedBytes, msgSize, msgBody).isErr():
+    raise (ref RlpxTransportError)(msg: "Cannot decrypt message body")
+
+  reset(encryptedBytes) # Release memory (TODO: in-place decryption)
+
+  msgBody.setLen(msgSize) # Remove padding
+
+  msgBody
+
+proc sendMsg*(
+    transport: RlpxTransport, data: seq[byte]
+) {.async: (raises: [CancelledError, TransportError, RlpxTransportError]).} =
+  let cipherText = encryptMsg(data, transport.state)
+  var res = await transport.stream.write(cipherText)
+  if res != len(cipherText):
+    raise (ref RlpxTransportError)(msg: "Could not complete writing message")
+
+proc remoteAddress*(
+    transport: RlpxTransport
+): TransportAddress {.raises: [TransportOsError].} =
+  transport.stream.remoteAddress()
+
+proc closed*(transport: RlpxTransport): bool =
+  transport.stream != nil and transport.stream.closed
+
+proc close*(transport: RlpxTransport) =
+  if transport.stream != nil:
+    transport.stream.close()
+
+proc closeWait*(
+    transport: RlpxTransport
+): Future[void] {.async: (raises: [], raw: true).} =
+  transport.stream.closeWait()
+
+when isMainModule:
+  # Simple CLI application for negotiating an RLPx connection with a peer
+
+  import stew/byteutils, std/cmdline, std/strutils, eth/rlp
+  if paramCount() < 3:
+    echo "rlpxtransport ip port pubkey"
+    quit 1
+
+  let
+    rng = newRng()
+    kp = KeyPair.random(rng[])
+
+  echo "Local key: ", toHex(kp.pubkey.toRaw())
+
+  let client = waitFor RlpxTransport.connect(
+    rng,
+    kp,
+    initTAddress(paramStr(1), parseInt(paramStr(2))),
+    PublicKey.fromHex(paramStr(3))[],
+  )
+
+  proc encodeMsg(msgId: uint64, msg: auto): seq[byte] =
+    var rlpWriter = initRlpWriter()
+    rlpWriter.append msgId
+    rlpWriter.appendRecordType(msg, typeof(msg).rlpFieldsCount > 1)
+    rlpWriter.finish
+
+  waitFor client.sendMsg(
+    encodeMsg(
+      uint64 0, (uint64 4, "nimbus", @[("eth", uint64 68)], uint64 0, kp.pubkey.toRaw())
+    )
+  )
+
+  while true:
+    echo "Reading message"
+    var data = waitFor client.recvMsg()
+    var rlp = rlpFromBytes(data)
+    let msgId = rlp.read(uint64)
+    if msgId == 0:
+      echo "Hello: ",
+        rlp.read((uint64, string, seq[(string, uint64)], uint64, seq[byte]))
+    else:
+      echo "Unknown message ", msgId, " ", toHex(data)

--- a/tests/p2p/all_tests.nim
+++ b/tests/p2p/all_tests.nim
@@ -6,4 +6,5 @@ import
   ./test_ecies,
   ./test_enode,
   ./test_rlpx_thunk,
+  ./test_rlpxtransport,
   ./test_protocol_handlers

--- a/tests/p2p/test_crypt.nim
+++ b/tests/p2p/test_crypt.nim
@@ -159,11 +159,9 @@ suite "Ethereum RLPx encryption/decryption test suite":
     var csecResponder = responder.getSecrets(m0, m1)
     var stateInitiator: SecretState
     var stateResponder: SecretState
-    var iheader, rheader: array[16, byte]
+    var iheader: array[16, byte]
     initSecretState(csecInitiator, stateInitiator)
     initSecretState(csecResponder, stateResponder)
-    burnMem(iheader)
-    burnMem(rheader)
     for i in 1..1000:
       # initiator -> responder
       block:
@@ -176,8 +174,9 @@ suite "Ethereum RLPx encryption/decryption test suite":
           randomBytes(ibody) == len(ibody)
           stateInitiator.encrypt(iheader, ibody,
                                  encrypted).isOk()
-          stateResponder.decryptHeader(toOpenArray(encrypted, 0, 31),
-                                       rheader).isOk()
+        let rheader = stateResponder.decryptHeader(
+          toOpenArray(encrypted, 0, 31)).expect("valid data")
+
         var length = getBodySize(rheader)
         check length == len(ibody)
         var rbody = newSeq[byte](decryptedLength(length))
@@ -190,7 +189,6 @@ suite "Ethereum RLPx encryption/decryption test suite":
           iheader == rheader
           ibody == rbody
         burnMem(iheader)
-        burnMem(rheader)
       # responder -> initiator
       block:
         var ibody = newSeq[byte](i * 3)
@@ -202,8 +200,8 @@ suite "Ethereum RLPx encryption/decryption test suite":
           randomBytes(ibody) == len(ibody)
           stateResponder.encrypt(iheader, ibody,
                                  encrypted).isOk()
-          stateInitiator.decryptHeader(toOpenArray(encrypted, 0, 31),
-                                       rheader).isOk()
+        let rheader = stateInitiator.decryptHeader(
+          toOpenArray(encrypted, 0, 31)).expect("valid data")
         var length = getBodySize(rheader)
         check length == len(ibody)
         var rbody = newSeq[byte](decryptedLength(length))
@@ -216,4 +214,3 @@ suite "Ethereum RLPx encryption/decryption test suite":
           iheader == rheader
           ibody == rbody
         burnMem(iheader)
-        burnMem(rheader)

--- a/tests/p2p/test_rlpxtransport.nim
+++ b/tests/p2p/test_rlpxtransport.nim
@@ -41,7 +41,7 @@ suite "RLPx transport":
 
     await serverFut
 
-  asyncTest "Connect/accept":
+  asyncTest "Detect invalid pubkey":
     proc serveClient(server: StreamServer) {.async.} =
       let transp = await server.accept()
       discard await RlpxTransport.accept(rng, keys1, transp)

--- a/tests/p2p/test_rlpxtransport.nim
+++ b/tests/p2p/test_rlpxtransport.nim
@@ -1,0 +1,60 @@
+{.used.}
+
+import
+  unittest2,
+  chronos/unittest2/asynctests,
+  ../../eth/common/keys,
+  ../../eth/p2p/rlpxtransport
+
+suite "RLPx transport":
+  setup:
+    let
+      rng = newRng()
+      keys1 = KeyPair.random(rng[])
+      keys2 = KeyPair.random(rng[])
+      server = createStreamServer(initTAddress("127.0.0.1:0"), {ReuseAddr})
+
+  teardown:
+    waitFor server.closeWait()
+
+  asyncTest "Connect/accept":
+    const msg = @[byte 0, 1, 2, 3]
+    proc serveClient(server: StreamServer) {.async.} =
+      let transp = await server.accept()
+      let a = await RlpxTransport.accept(rng, keys1, transp)
+      await a.sendMsg(msg)
+      await a.closeWait()
+
+    let serverFut = server.serveClient()
+    defer:
+      await serverFut.wait(1.seconds)
+
+    let client =
+      await RlpxTransport.connect(rng, keys2, server.localAddress(), keys1.pubkey)
+
+    defer:
+      await client.closeWait()
+    let rmsg = await client.recvMsg().wait(1.seconds)
+
+    check:
+      msg == rmsg
+
+    await serverFut
+
+  asyncTest "Connect/accept":
+    proc serveClient(server: StreamServer) {.async.} =
+      let transp = await server.accept()
+      discard await RlpxTransport.accept(rng, keys1, transp)
+      raiseAssert "should fail to accept due to pubkey error"
+
+    let serverFut = server.serveClient()
+    defer:
+      expect(RlpxTransportError):
+        await serverFut.wait(1.seconds)
+
+    let keys3 = KeyPair.random(rng[])
+
+    # accept side should close connections
+    expect(TransportError):
+      discard
+        await RlpxTransport.connect(rng, keys2, server.localAddress(), keys3.pubkey)

--- a/tests/rlp/test_api_usage.nim
+++ b/tests/rlp/test_api_usage.nim
@@ -21,8 +21,7 @@ proc test_blockBodyTranscode() =
       transactions: @[
         Transaction(nonce: 1)]),
     BlockBody(
-      uncles: @[
-        BlockHeader(nonce: BlockNonce([0x20u8,0,0,0,0,0,0,0]))]),
+      uncles: @[Header(nonce: Bytes8([0x20u8,0,0,0,0,0,0,0]))]),
     BlockBody(),
     BlockBody(
       transactions: @[


### PR DESCRIPTION
…andling

* disconnect peers that send non-hello messages during initial hello step
* fix devp2p protocol version - 4 because we don't implement snappy (yet) - this is cosmetic since this particular version field is not actually being used
* fix ack message length checking
* move RLPx transport code to separate module, annotate with asyncraises
* increase max RLPx message size to 16mb, per EIP-706
* make sure both accept/connect timeout after 10s
* aim to log every connection attempt once at debug level
* make capability-id/context-id check more accurate
* disallow random messages before hello