### PR TITLE
Add missing rlp imports to properple decode/encode blocks/bodies

### DIFF
--- a/eth/common/blocks_rlp.nim
+++ b/eth/common/blocks_rlp.nim
@@ -7,8 +7,9 @@
 
 {.push raises: [].}
 
-import ./[addresses_rlp, blocks, base_rlp, hashes_rlp], ../rlp
+import
+  ./[addresses_rlp, blocks, base_rlp, hashes_rlp, headers_rlp, transactions_rlp], ../rlp
 
 from stew/objects import checkedEnumAssign
 
-export addresses_rlp, blocks, base_rlp, hashes_rlp, rlp
+export addresses_rlp, blocks, base_rlp, hashes_rlp, headers_rlp, transactions_rlp, rlp

--- a/eth/rlp.nim
+++ b/eth/rlp.nim
@@ -1,9 +1,16 @@
+# nim-eth
+# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 ## This module implements RLP encoding and decoding as
 ## defined in Appendix B of the Ethereum Yellow Paper:
 ## https://ethereum.github.io/yellowpaper/paper.pdf
 
 import
-  std/[strutils, options],
+  std/strutils,
   stew/[byteutils, shims/macros],
   results,
   ./rlp/[writer, object_serialization],

--- a/eth/rlp/bin/rlp_inspect.nim
+++ b/eth/rlp/bin/rlp_inspect.nim
@@ -1,3 +1,10 @@
+# eth
+# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   std/os,
   ../../rlp

--- a/eth/rlp/bitseqs.nim
+++ b/eth/rlp/bitseqs.nim
@@ -1,3 +1,10 @@
+# eth
+# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   stew/bitseqs,
   ../rlp

--- a/eth/rlp/object_serialization.nim
+++ b/eth/rlp/object_serialization.nim
@@ -1,3 +1,10 @@
+# eth
+# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   stew/shims/macros
 

--- a/eth/rlp/priv/defs.nim
+++ b/eth/rlp/priv/defs.nim
@@ -1,3 +1,10 @@
+# eth
+# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 const
   BLOB_START_MARKER* = byte(0x80)
   LIST_START_MARKER* = byte(0xc0)

--- a/eth/rlp/results.nim
+++ b/eth/rlp/results.nim
@@ -1,8 +1,15 @@
+# eth
+# Copyright (c) 2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import ../rlp
 import writer
 import pkg/results
 
-export 
+export
   rlp, results
 
 proc append*[T](w: var RlpWriter, val: Opt[T]) =

--- a/eth/rlp/writer.nim
+++ b/eth/rlp/writer.nim
@@ -1,3 +1,10 @@
+# eth
+# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   std/options,
   pkg/results,


### PR DESCRIPTION
Without these added transanction/header import/exports decoding blocks or block bodies would fail if one only had imported blocks_rlp.

Also removes unused import + add copyright comments in rlp code.