### PR TITLE
update version to 0.5.0

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -1,6 +1,6 @@
 mode = ScriptMode.Verbose
 
-version       = "1.0.0"
+version       = "0.5.0"
 author        = "Status Research & Development GmbH"
 description   = "Ethereum Common library"
 license       = "MIT"

--- a/eth.nimble
+++ b/eth.nimble
@@ -8,7 +8,7 @@ skipDirs      = @["tests"]
 
 requires "nim >= 1.6.0",
          "nimcrypto",
-         "stint",
+         "stint >= 0.8.0",
          "secp256k1",
          "chronos",
          "chronicles",

--- a/eth/common/base_rlp.nim
+++ b/eth/common/base_rlp.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import
-  std/typetraits, ./base, ../rlp, 
+  std/typetraits, ./base, ../rlp,
   ../rlp/results as rlp_results
 
 export base, rlp, rlp_results
@@ -49,7 +49,7 @@ func significantBytesBE(val: openArray[byte]): int =
 
 proc append*(w: var RlpWriter, value: StUint) =
   if value > 128:
-    let bytes = value.toByteArrayBE
+    let bytes = value.toBytesBE
     let nonZeroBytes = significantBytesBE(bytes)
     w.append bytes.toOpenArray(bytes.len - nonZeroBytes, bytes.len - 1)
   else:

--- a/eth/p2p/discovery.nim
+++ b/eth/p2p/discovery.nim
@@ -143,7 +143,7 @@ proc sendPong*(d: DiscoveryProtocol, n: Node, token: MDigest[256]) =
 
 proc sendFindNode*(d: DiscoveryProtocol, n: Node, targetNodeId: NodeId) =
   var data: array[64, byte]
-  data[32 .. ^1] = targetNodeId.toByteArrayBE()
+  data[32 .. ^1] = targetNodeId.toBytesBE()
   let payload = rlp.encode((data, expiration()))
   let msg = pack(cmdFindNode, payload, d.privKey)
   trace ">>> find_node to ", n #, ": ", msg.toHex()
@@ -249,7 +249,7 @@ proc recvFindNode(
   let rng = rlp.listElem(0).toBytes
   # Check for pubkey len
   if rng.len == 64:
-    let nodeId = readUintBE[256](rng[32 .. ^1])
+    let nodeId = UInt256.fromBytesBE(rng.toOpenArray(32, 63))
     d.kademlia.recvFindNode(node, nodeId)
   else:
     trace "Invalid target public key received"

--- a/eth/p2p/discoveryv5/node.nim
+++ b/eth/p2p/discoveryv5/node.nim
@@ -80,7 +80,7 @@ func `==`*(a, b: Node): bool =
     (not a.isNil and not b.isNil and a.pubkey == b.pubkey)
 
 func hash*(id: NodeId): Hash =
-  hash(id.toByteArrayBE)
+  hash(id.toBytesBE)
 
 proc random*(T: type NodeId, rng: var HmacDrbgContext): T =
   rng.generate(T)

--- a/eth/p2p/discoveryv5/sessions.nim
+++ b/eth/p2p/discoveryv5/sessions.nim
@@ -32,7 +32,7 @@ type
 
 func makeKey(id: NodeId, address: Address): SessionKey =
   var pos = 0
-  result[pos ..< pos+sizeof(id)] = toBytes(id)
+  result[pos ..< pos+sizeof(id)] = toBytesBE(id)
   pos.inc(sizeof(id))
   case address.ip.family
   of IpAddressFamily.IpV4:
@@ -40,7 +40,7 @@ func makeKey(id: NodeId, address: Address): SessionKey =
   of IpAddressFamily.IpV6:
     result[pos ..< pos+sizeof(address.ip.address_v6)] = address.ip.address_v6
   pos.inc(sizeof(address.ip.address_v6))
-  result[pos ..< pos+sizeof(address.port)] = toBytes(address.port.uint16)
+  result[pos ..< pos+sizeof(address.port)] = toBytesBE(address.port.uint16)
 
 func store*(s: var Sessions, id: NodeId, address: Address, r, w: AesKey) =
   var value: array[sizeof(r) + sizeof(w), byte]

--- a/eth/p2p/kademlia.nim
+++ b/eth/p2p/kademlia.nim
@@ -102,7 +102,7 @@ proc `==`*(a, b: Node): bool = (a.isNil and b.isNil) or
   (not a.isNil and not b.isNil and a.node.pubkey == b.node.pubkey)
 
 proc timeKey(id: NodeId, ip: IpAddress, cmd: CommandId): TimeKey =
-  result[0..31] = id.toByteArrayBE()[0..31]
+  result[0..31] = id.toBytesBE()[0..31]
   case ip.family
   of IpAddressFamily.IPv6:
     result[32..47] = ip.address_v6[0..15]

--- a/tests/fuzzing/discovery/generate.nim
+++ b/tests/fuzzing/discovery/generate.nim
@@ -38,7 +38,7 @@ proc generate() =
   # valid data for a FindNode packet
   block:
     var data: array[64, byte]
-    data[32 .. ^1] = peerKey.toPublicKey().toNodeId().toByteArrayBE()
+    data[32 .. ^1] = peerKey.toPublicKey().toNodeId().toBytesBE()
     let payload = rlp.encode((data, expiration()))
     let encodedData = @[3.byte] & @payload
     debug "FindNode", data=byteutils.toHex(encodedData)


### PR DESCRIPTION
1.0.0 was never an intentional release and the nim-eth repo is not yet stable in terms of API, thus we start at 0.5.0 and go from there for the first tagged release.

Most of the eth code in this repo now is aligned with various specs meaning that most API can be considered "mostly" stable, but there are still aspects being worked on as well as a potential future reorganisation of the code turning nim-eth into a more "pure" spec-driven core ethereum infrastructure repo, removing in the process application-level stuff that happens to be common between nimbus-eth1 and eth2 and ended up in here for convenience.