### PR TITLE
ecies: cleanup

### DIFF
--- a/tests/p2p/test_ecies.nim
+++ b/tests/p2p/test_ecies.nim
@@ -23,21 +23,9 @@ proc compare[A, B](x: openArray[A], y: openArray[B], s: int = 0): bool =
       result = false
       break
 
-template offsetOf(a: EciesHeader, b: untyped): int =
-  cast[int](cast[uint](unsafeAddr b) - cast[uint](unsafeAddr a))
-
 let rng = newRng()
 
 suite "ECIES test suite":
-  test "ECIES structures alignment":
-    var header: EciesHeader
-    check:
-      offsetOf(header, header.version) == 0
-      offsetOf(header, header.pubkey) == 1
-      offsetOf(header, header.iv) == 1 + 64
-      offsetOf(header, header.data) == 1 + 64 + aes128.sizeBlock
-      sizeof(header) == 1 + 64 + aes128.sizeBlock + 1
-
   test "KDF test vectors":
     # KDF test
     # Copied from https://github.com/ethereum/pydevp2p/blob/develop/devp2p/tests/test_ecies.py#L53


### PR DESCRIPTION
* avoid memory allocation in kdf
* fix some (mostly harmless) off-by-one openArrays
* avoid packed object
* fix some missing burnMem