### PR TITLE
add discv5_network_byte metric in discoveryv5 protocol

### DIFF
--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -171,6 +171,10 @@ type
 
   DiscResult*[T] = Result[T, cstring]
 
+  Direction {.pure.} = enum
+    In = "in"
+    Out = "out"
+
 const
   defaultDiscoveryConfig* = DiscoveryConfig(
     tableIpLimits: DefaultTableIpLimits,
@@ -277,7 +281,7 @@ proc sendTo(d: Protocol, a: Address, data: seq[byte]): Future[void] {.async.} =
     # because of ping failures due to own network connection failure.
     warn "Discovery send failed", msg = e.msg, address = $ta
 
-  discv5_network_bytes.inc(data.len.int64, labelValues = ["out"])
+  discv5_network_bytes.inc(data.len.int64, labelValues = [$Direction.Out])
 
 proc send*(d: Protocol, a: Address, data: seq[byte]) =
   asyncSpawn sendTo(d, a, data)
@@ -425,7 +429,7 @@ proc sendWhoareyou(d: Protocol, toId: NodeId, a: Address,
     debug "Node with this id already has ongoing handshake, ignoring packet"
 
 proc receive*(d: Protocol, a: Address, packet: openArray[byte]) =
-  discv5_network_bytes.inc(packet.len.int64, labelValues = ["in"])
+  discv5_network_bytes.inc(packet.len.int64, labelValues = [$Direction.In])
 
   let decoded = d.codec.decodePacket(a, packet)
   if decoded.isOk:

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -277,7 +277,7 @@ proc sendTo(d: Protocol, a: Address, data: seq[byte]): Future[void] {.async.} =
     # because of ping failures due to own network connection failure.
     warn "Discovery send failed", msg = e.msg, address = $ta
 
-  discv5_network_bytes.inc(data.len, labelValues = ["out"])
+  discv5_network_bytes.inc(data.len.int64, labelValues = ["out"])
 
 proc send*(d: Protocol, a: Address, data: seq[byte]) =
   asyncSpawn sendTo(d, a, data)
@@ -425,7 +425,7 @@ proc sendWhoareyou(d: Protocol, toId: NodeId, a: Address,
     debug "Node with this id already has ongoing handshake, ignoring packet"
 
 proc receive*(d: Protocol, a: Address, packet: openArray[byte]) =
-  discv5_network_bytes.inc(packet.len, labelValues = ["in"])
+  discv5_network_bytes.inc(packet.len.int64, labelValues = ["in"])
 
   let decoded = d.codec.decodePacket(a, packet)
   if decoded.isOk:


### PR DESCRIPTION
This PR adds a simple metric that helps measuring the in/out traffic
See, for example [this](https://www.notion.so/Measure-DiscV5-bandwidth-with-Waku-discovery-1698f96fb65c80659fa1fbfdac49b1ef?d=16f8f96fb65c8067adb2001c2a329eca#16a8f96fb65c800ca96fe41f60052693)