### PR TITLE
Discv5 Routing Table: Add support for banning nodes

### DIFF
--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -324,7 +324,8 @@ func init*(T: type RoutingTable, localNode: Node, bitsPerHop = DefaultBitsPerHop
     bitsPerHop: bitsPerHop,
     ipLimits: IpLimits(limit: ipLimits.tableIpLimit),
     distanceCalculator: distanceCalculator,
-    rng: rng)
+    rng: rng,
+    bannedNodes: initTable[NodeId, chronos.Moment]())
 
 func splitBucket(r: var RoutingTable, index: int) =
   let bucket = r.buckets[index]

--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -14,7 +14,7 @@ import
   ../../net/utils,
   "."/[node, random2, enr]
 
-export results
+export results, chronos.timer
 
 declareGauge routing_table_nodes,
   "Discovery routing table nodes", labels = ["state"]
@@ -99,7 +99,7 @@ type
     ReplacementAdded
     ReplacementExisting
     NoAddress
-    BannedNode
+    Banned
 
 # xor distance functions
 func distance*(a, b: NodeId): UInt256 =
@@ -194,8 +194,8 @@ func ipLimitDec(r: var RoutingTable, b: KBucket, n: Node) =
   b.ipLimits.dec(ip)
   r.ipLimits.dec(ip)
 
-proc replaceNode*(r: var RoutingTable, n: Node)
 func getNode*(r: RoutingTable, id: NodeId): Opt[Node]
+proc replaceNode*(r: var RoutingTable, n: Node)
 
 proc banNode*(r: var RoutingTable, nodeId: NodeId, period: chronos.Duration) =
   ## Ban a node from the routing table for the given period. The node is removed
@@ -384,7 +384,7 @@ proc addNode*(r: var RoutingTable, n: Node): NodeStatus =
     return LocalNode
 
   if r.isBanned(n.id):
-    return BannedNode
+    return Banned
 
   let bucket = r.bucketForNode(n.id)
 

--- a/tests/p2p/test_routing_table.nim
+++ b/tests/p2p/test_routing_table.nim
@@ -1,6 +1,7 @@
 {.used.}
 
 import
+  std/os,
   unittest2,
   ../../eth/common/keys, ../../eth/p2p/discoveryv5/[routing_table, node, enr],
   ./discv5_test_helper
@@ -611,8 +612,10 @@ suite "Routing Table Tests":
     var table = RoutingTable.init(localNode, 1, DefaultTableIpLimits, rng = rng)
 
     check table.addNode(node1) == Added
-    table.banNode(node1.id, 1.microseconds)
-    table.banNode(node2.id, 1.microseconds)
+    table.banNode(node1.id, 1.nanoseconds)
+    table.banNode(node2.id, 1.nanoseconds)
+
+    sleep(100)
 
     # Can add nodes for which the ban has expired
     check:

--- a/tests/p2p/test_routing_table.nim
+++ b/tests/p2p/test_routing_table.nim
@@ -615,7 +615,7 @@ suite "Routing Table Tests":
     table.banNode(node1.id, 1.nanoseconds)
     table.banNode(node2.id, 1.nanoseconds)
 
-    sleep(100)
+    sleep(1)
 
     # Can add nodes for which the ban has expired
     check:


### PR DESCRIPTION
This PR add support for banning nodes from the Discv5 routing table. This feature will be used by both Discv5 and the portal subnetworks in Fluffy. See the related task here: https://github.com/status-im/nimbus-eth1/issues/2809

- Nodes are banned by id so they can be banned even if not yet present in the routing table. 
- Once banned, nodes cannot be added to the routing table. 
- When banned, nodes are removed from the routing table and replaced using the replacement cache.

The updates to the Discv5 protocol to implement banning of peers will be included in a separate PR.