### PR TITLE
Add a predicate to filter nodes in routing table neighbours function

### DIFF
--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -516,7 +516,7 @@ proc neighbours*(
   if result.len > k:
     result.setLen(k)
 
-proc neighboursAtDistance*(r: RoutingTable, distance: uint16,
+func neighboursAtDistance*(r: RoutingTable, distance: uint16,
     k: int = BUCKET_SIZE, seenOnly = false): seq[Node] =
   ## Return up to k neighbours at given logarithmic distance.
   result = r.neighbours(r.idAtDistance(r.localNode.id, distance), k, seenOnly)

--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -490,8 +490,13 @@ func bucketsByDistanceTo(r: RoutingTable, id: NodeId): seq[KBucket] =
 func nodesByDistanceTo(r: RoutingTable, k: KBucket, id: NodeId): seq[Node] =
   sortedByIt(k.nodes, r.distance(it.id, id))
 
-func neighbours*(r: RoutingTable, id: NodeId, k: int = BUCKET_SIZE,
-    seenOnly = false): seq[Node] =
+proc neighbours*(
+    r: RoutingTable,
+    id: NodeId,
+    k: int = BUCKET_SIZE,
+    seenOnly = false,
+    filterPred: proc(nodeId: NodeId): bool {.closure.} = nil,
+): seq[Node] {.effectsOf: filterPred.} =
   ## Return up to k neighbours of the given node id.
   ## When seenOnly is set to true, only nodes that have been contacted
   ## previously successfully will be selected.
@@ -500,7 +505,7 @@ func neighbours*(r: RoutingTable, id: NodeId, k: int = BUCKET_SIZE,
     for bucket in r.bucketsByDistanceTo(id):
       for n in r.nodesByDistanceTo(bucket, id):
         # Only provide actively seen nodes when `seenOnly` set.
-        if not seenOnly or n.seen:
+        if (not seenOnly or n.seen) and (filterPred == nil or filterPred(n.id)):
           result.add(n)
           if result.len == k * 2:
             break addNodes
@@ -511,7 +516,7 @@ func neighbours*(r: RoutingTable, id: NodeId, k: int = BUCKET_SIZE,
   if result.len > k:
     result.setLen(k)
 
-func neighboursAtDistance*(r: RoutingTable, distance: uint16,
+proc neighboursAtDistance*(r: RoutingTable, distance: uint16,
     k: int = BUCKET_SIZE, seenOnly = false): seq[Node] =
   ## Return up to k neighbours at given logarithmic distance.
   result = r.neighbours(r.idAtDistance(r.localNode.id, distance), k, seenOnly)

--- a/tests/p2p/test_routing_table.nim
+++ b/tests/p2p/test_routing_table.nim
@@ -686,3 +686,25 @@ suite "Routing Table Tests":
       table.isBanned(node2.id) == true
       table.addNode(node1) == Existing
       table.addNode(node2) == Banned
+
+  test "neighbours filter predicate":
+    let numNodes = 10
+    let local = generateNode(PrivateKey.random(rng[]))
+    var table = RoutingTable.init(local, 1, ipLimits, rng = rng,
+      distanceCalculator = customDistanceCalculator)
+
+    let nodes = generateNRandomNodes(rng[], numNodes)
+
+    for n in nodes:
+      check table.addNode(n) == Added
+
+    let neighbours = table.neighbours(
+      local.id, k = numNodes, seenOnly = false, nil) # no predicate
+    check neighbours.len() == numNodes
+
+    let filteredNeignbours = table.neighbours(
+      local.id, k = numNodes, seenOnly = false,
+      proc(id: NodeId): bool = id == nodes[0].id) # Only return the first node
+    check:
+      filteredNeignbours.len() == 1
+      filteredNeignbours[0] == nodes[0]


### PR DESCRIPTION
This PR adds a new filter predicate to the `neighbours` function in the routing table. 

This is useful for applying additional filtering criteria while still getting the correct number of k nodes in the result. The new parameter is optional and if not set, all nodes are returned as before.