### PR TITLE
Make uTP debug logging less spammy

### DIFF
--- a/eth/utp/utp_discv5_protocol.nim
+++ b/eth/utp/utp_discv5_protocol.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -86,7 +86,7 @@ proc messageHandler(
   let
     p = UtpDiscv5Protocol(protocol)
     nodeAddress = NodeAddress.init(srcId, srcUdpAddress)
-  debug "Received utp payload from known node. Start processing",
+  trace "Received utp payload from known node. Start processing",
     nodeId = nodeAddress.nodeId, address = nodeAddress.address
   asyncSpawn p.router.processIncomingBytes(request, nodeAddress)
 


### PR DESCRIPTION
Adjust debug logging so that you can use it to follow just the creation of a socket, packets received and destroy (at least for the happy or usual paths). Other details are set to trace or are removed when redudant information.