### PR TITLE
Allow for getting ENR field value when rlp list

### DIFF
--- a/eth/p2p/discoveryv5/enr.nim
+++ b/eth/p2p/discoveryv5/enr.nim
@@ -278,8 +278,12 @@ func get*(r: Record, key: string, T: type): EnrResult[T] =
       ? requireKind(f, kNum)
       ok(T(f.num))
     elif T is seq[byte]:
-      ? requireKind(f, kBytes)
-      ok(f.bytes)
+      if requireKind(f, kBytes).isOk:
+        ok(f.bytes)
+      elif requireKind(f, kList).isOk:
+        ok(f.listRaw)
+      else:
+        err("Invalid rlp type for seq[byte]")
     elif T is string:
       ? requireKind(f, kString)
       ok(f.str)


### PR DESCRIPTION
Might want to remove this all together so it is always considered as just a byte string