### PR TITLE
rm two deprecated fromURI variations

### DIFF
--- a/eth/common/blocks_rlp.nim
+++ b/eth/common/blocks_rlp.nim
@@ -1,15 +1,13 @@
 # eth
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   ./[addresses_rlp, blocks, base_rlp, hashes_rlp, headers_rlp, transactions_rlp], ../rlp
-
-from stew/objects import checkedEnumAssign
 
 export addresses_rlp, blocks, base_rlp, hashes_rlp, headers_rlp, transactions_rlp, rlp

--- a/eth/p2p/discoveryv5/enr.nim
+++ b/eth/p2p/discoveryv5/enr.nim
@@ -1,5 +1,5 @@
 # nim-eth - Node Discovery Protocol v5
-# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Copyright (c) 2020-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -8,7 +8,7 @@
 ## ENR implementation according to specification in EIP-778:
 ## https://github.com/ethereum/EIPs/blob/master/EIPS/eip-778.md
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   std/[strutils, sequtils, macros, algorithm, net],
@@ -537,17 +537,6 @@ func fromURI*(T: type Record, s: string): EnrResult[T] =
     Record.fromBase64(s[prefix.len .. ^1])
   else:
     err("Invalid URI prefix")
-
-
-func fromURI*(r: var Record, s: string): bool {.deprecated: "Use the Result[Record] version instead".} =
-  ## Loads ENR from its URI encoding: base64-encoded rlp-encoded bytes,
-  ## prefixed with "enr:". Verifies the signature.
-  r = Record.fromURI(s).valueOr:
-    return false
-  true
-
-template fromURI*(r: var Record, url: EnrUri): bool {.deprecated: "Use the Result[Record] version instead".} =
-  fromURI(r, string(url))
 
 func toBase64*(r: Record): string =
   Base64Url.encode(r.raw)


### PR DESCRIPTION
These trigger deprecation warnings in `nimbus-eth1` via https://github.com/status-im/nimbus-eth1/blob/1ec00066d7f8d7025d362590c463f2d21e6e9eef/execution_chain/networking/eth1_enr.nim#L17-L18
```nim
export
  enr.Record, enr.fromURI, enode
```
don't seem to be used anywhere else, and are trivial to migrate even if so.