### PR TITLE
fix ambiguous overloaded toHex symbol in tests

### DIFF
--- a/tests/common/test_keys.nim
+++ b/tests/common/test_keys.nim
@@ -1,22 +1,24 @@
 #
 #                 Ethereum P2P
-#              (c) Copyright 2018
+#              (c) Copyright 2018-2025
 #       Status Research & Development GmbH
 #
 #    See the file "LICENSE", included in this
 #    distribution, for details about the copyright.
 #
 
+{.push raises: [].}
 {.used.}
 
 import
   unittest2,
-  nimcrypto/utils, stew/byteutils,
   ../../eth/common/[addresses, keys, hashes]
 
-from strutils import toLowerAscii
+from std/strutils import toLowerAscii
+from nimcrypto/utils import fromHex, stripSpaces
+from stew/byteutils import toBytes, toHex
 
-let message = "message".toBytes()
+const message = "message".toBytes()
 let rng = newRng()
 
 const

--- a/tests/common/test_transactions.nim
+++ b/tests/common/test_transactions.nim
@@ -7,6 +7,8 @@
 #    http://opensource.org/licenses/MIT)
 # at your option. This file may not be copied, modified, or distributed except
 # according to those terms.
+
+{.push raises: [], gcsafe.}
 {.used.}
 
 import
@@ -16,7 +18,6 @@ import
 
 const
   recipient = address"095e7baea6a6c7c4c2dfeb977efac326af552d87"
-  zeroG1    = bytes48"0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
   source    = address"0x0000000000000000000000000000000000000001"
   storageKey= default(Bytes32)
   accesses  = @[AccessPair(address: source, storageKeys: @[storageKey])]
@@ -30,7 +31,7 @@ const
     s: 5.u256
   )]
 
-proc tx0(i: int): Transaction =
+func tx0(i: int): Transaction =
   Transaction(
     txType:   TxLegacy,
     nonce:    i.AccountNonce,
@@ -39,7 +40,7 @@ proc tx0(i: int): Transaction =
     gasPrice: 2.GasInt,
     payload:  abcdef)
 
-proc tx1(i: int): Transaction =
+func tx1(i: int): Transaction =
   Transaction(
     # Legacy tx contract creation.
     txType:   TxLegacy,
@@ -48,7 +49,7 @@ proc tx1(i: int): Transaction =
     gasPrice: 2.GasInt,
     payload:  abcdef)
 
-proc tx2(i: int): Transaction =
+func tx2(i: int): Transaction =
   Transaction(
     # Tx with non-zero access list.
     txType:     TxEip2930,
@@ -60,7 +61,7 @@ proc tx2(i: int): Transaction =
     accessList: accesses,
     payload:    abcdef)
 
-proc tx3(i: int): Transaction =
+func tx3(i: int): Transaction =
   Transaction(
     # Tx with empty access list.
     txType:   TxEip2930,
@@ -71,7 +72,7 @@ proc tx3(i: int): Transaction =
     gasPrice: 10.GasInt,
     payload:  abcdef)
 
-proc tx4(i: int): Transaction =
+func tx4(i: int): Transaction =
   Transaction(
     # Contract creation with access list.
     txType:     TxEip2930,
@@ -81,7 +82,7 @@ proc tx4(i: int): Transaction =
     gasPrice:   10.GasInt,
     accessList: accesses)
 
-proc tx5(i: int): Transaction =
+func tx5(i: int): Transaction =
   Transaction(
     txType:     TxEip1559,
     chainId:    chainId(1),
@@ -91,7 +92,7 @@ proc tx5(i: int): Transaction =
     maxFeePerGas: 10.GasInt,
     accessList: accesses)
 
-proc tx6(i: int): Transaction =
+func tx6(i: int): Transaction =
   const
     digest = hash32"010657f37554c781402a22917dee2f75def7ab966d7b770905398eba3c444014"
 
@@ -105,7 +106,7 @@ proc tx6(i: int): Transaction =
     accessList:          accesses,
     versionedHashes:     @[digest])
 
-proc tx7(i: int): Transaction =
+func tx7(i: int): Transaction =
   const
     digest = hash32"01624652859a6e98ffc1608e2af0147ca4e86e1ce27672d8d3f3c9d4ffd6ef7e"
 
@@ -120,7 +121,7 @@ proc tx7(i: int): Transaction =
     versionedHashes:     @[digest],
     maxFeePerBlobGas:    10000000.u256)
 
-proc tx8(i: int): Transaction =
+func tx8(i: int): Transaction =
   const
     digest = hash32"01624652859a6e98ffc1608e2af0147ca4e86e1ce27672d8d3f3c9d4ffd6ef7e"
 
@@ -136,7 +137,7 @@ proc tx8(i: int): Transaction =
     versionedHashes:     @[digest],
     maxFeePerBlobGas:    10000000.u256)
 
-proc txEip7702(i: int): Transaction =
+func txEip7702(i: int): Transaction =
   Transaction(
     txType:   TxEip7702,
     chainId:  chainId(1),


### PR DESCRIPTION
e.g.,
```
  FAIL: [11/49] eth c                                                        (112.47 sec)
  Test "eth" in category "nimble-packages"
  Failure: reBuildFailed
  nim c -o:common -r tests/common/all_tests
  Hint: used config file '/home/runner/work/Nim/Nim/config/nim.cfg' [Conf]
  Hint: used config file '/home/runner/work/Nim/Nim/config/config.nims' [Conf]
  Hint: used config file '/home/runner/work/Nim/Nim/pkgstemp/eth/nim.cfg' [Conf]
  Hint: used config file '/home/runner/work/Nim/Nim/pkgstemp/eth/config.nims' [Conf]
  Hint: used config file '/home/runner/work/Nim/Nim/pkgstemp/eth/tests/nim.cfg' [Conf]
...
  /home/runner/work/Nim/Nim/pkgstemp/eth/tests/common/test_keys.nim(242, 5) template/generic instantiation of `check` from here
  /home/runner/work/Nim/Nim/pkgstemp/eth/tests/common/test_keys.nim(243, 14) Error: ambiguous call; both utils.toHex(a: openArray[byte], lowercase: bool) [func declared in /home/runner/.nimble/pkgs2/nimcrypto-0.7.2-8ed2a20f2efaa08782bb871284cbcc3100ca1dea/nimcrypto/utils.nim(189, 6)] and byteutils.toHex(ba: openArray[byte]) [func declared in /home/runner/.nimble/pkgs2/stew-0.4.2-928e82cb8d2f554e8f10feb2349ee9c32fee3a8c/stew/byteutils.nim(215, 6)] match for: (array[0..63, byte])
```