### PR TITLE
discv5: remove unused listenAddress template

### DIFF
--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -1206,13 +1206,6 @@ proc `$`*(a: OptAddress): string =
 
 chronicles.formatIt(OptAddress): $it
 
-template listeningAddress*(p: Protocol): Address =
-  if p.bindAddress.ip.isNone():
-    let ta = getAutoAddress(p.bindAddress.port)
-    Address(ta.toIpAddress(), ta.port)
-  else:
-    Address(p.bindAddress.ip.get(), p.bindAddress.port)
-
 proc open*(d: Protocol) {.raises: [TransportOsError].} =
   info "Starting discovery node", node = d.localNode,
     bindAddress = d.bindAddress


### PR DESCRIPTION
This is not used in any of our projects and more importantly I believe this auto-selection does not need to be part of discv5.

Either is gets done beforehand and passed along discv5 init or it gets handled by chronos, which is exactly how it is used currently in the projects.