### PR TITLE
Remove redundant enr test and actually enable tests

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -66,6 +66,8 @@ task test_common, "Run common tests":
 
 task test, "Run all tests":
   run "tests/test_bloom", ""
+  run "tests/test_enr", ""
+  run "tests/test_enode", ""
 
   test_keyfile_task()
   test_rlp_task()
@@ -76,6 +78,7 @@ task test, "Run all tests":
   test_common_task()
 
 task test_discv5_full, "Run discovery v5 and its dependencies tests":
+  run "tests/test_enr", ""
   test_rlp_task()
   test_discv5_task()
 

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -11,12 +11,13 @@
 {. warning[UnusedImport]:off .}
 
 import
-  ./utp/all_utp_tests,
+  ./common/all_tests,
+  ./db/all_tests,
   ./keyfile/all_tests,
   ./p2p/all_tests,
   ./rlp/all_tests,
   ./trie/all_tests,
-  ./db/all_tests,
-  ./common/all_tests,
+  ./utp/all_utp_tests,
   ./test_bloom,
+  ./test_enr,
   ./test_enode

--- a/tests/p2p/all_tests.nim
+++ b/tests/p2p/all_tests.nim
@@ -1,7 +1,6 @@
 {.used.}
 
 import
-  ./test_enr,
   ./test_hkdf,
   ./test_ip_vote,
   ./test_routing_table,

--- a/tests/test_enr.nim
+++ b/tests/test_enr.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
@@ -7,16 +7,14 @@
 {.used.}
 
 import
-  std/[sequtils, net, math],
+  std/[sequtils, net],
   stew/byteutils,
   unittest2,
-  ../../eth/enr/enr,
-  ../../eth/p2p/discoveryv5/messages,
-  ../../eth/p2p/discoveryv5/messages_encoding
+  ../eth/enr/enr
 
 let rng = newRng()
 
-proc testRlpEncodingLoop*(r: enr.Record): bool =
+func testRlpEncodingLoop(r: enr.Record): bool =
   let encoded = rlp.encode(r)
   let decoded = rlp.decode(encoded, enr.Record)
   decoded == r
@@ -33,28 +31,7 @@ suite "ENR test vector tests":
     secp256k1 = "03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138"
     udp = 0x765f
 
-  test "Test vector full encode loop":
-    let res = Record.fromURI(uri)
-    check res.isOk()
-    let r = res.value()
-
-    const
-      maxNodesPerMessage = 3
-      nodesLen = 11
-
-    let reqId = RequestId.init(rng[])
-
-    var message: NodesMessage
-    message.total = ceil(nodesLen / maxNodesPerMessage).uint32
-
-    for i in 0 ..< nodesLen:
-      message.enrs.add(r)
-
-    if message.enrs.len != 0:
-      let z = encodeMessage(message, reqId)
-      discard z
-
-  test "Test vector full encode loop":
+  test "Test vector full decode - encode loop":
     let res = Record.fromURI(uri)
     check res.isOk()
     let r = res.value()
@@ -71,7 +48,7 @@ suite "ENR test vector tests":
 
       r.toURI() == uri
 
-  test "Test vector Record.init":
+  test "Test vector Record.init - encode":
     let privKey = PrivateKey.fromHex(
       pk).expect("valid private key")
 

--- a/tests/utp/test_utp_socket.nim
+++ b/tests/utp/test_utp_socket.nim
@@ -59,7 +59,7 @@ procSuite "uTP socket":
       defaultRcvOutgoingId,
       rng[]
     )
-    let fut1 =  socket.startOutgoingSocket()
+    let fut1 = socket.startOutgoingSocket()
     let initialPacket = await q.get()
 
     check:
@@ -515,7 +515,7 @@ procSuite "uTP socket":
       rng[]
     )
 
-    let fut1 = outgoingSocket.startOutgoingSocket()
+    let _ = outgoingSocket.startOutgoingSocket()
 
     let initialPacket = await q.get()
 
@@ -1417,7 +1417,7 @@ procSuite "uTP socket":
 
     let socket = newOutgoingSocket[TransportAddress](testAddress, initTestSnd(q), cfg, defaultRcvOutgoingId, rng[])
 
-    asyncSpawn socket.startOutgoingSocket()
+    let _ = socket.startOutgoingSocket()
 
     let initialPacket = await q.get()
 


### PR DESCRIPTION
ENR and Enode tests were not actually being run as part of the tests

Also move the enr tests outside of p2p tests.

Better would be to just run all_tests.nim but that one currently fails for orc. TBI