### PR TITLE
Run all_tests instead of seperate parts tests

### DIFF
--- a/eth.nimble
+++ b/eth.nimble
@@ -65,17 +65,7 @@ task test_common, "Run common tests":
   run "tests/common/all_tests", "common"
 
 task test, "Run all tests":
-  run "tests/test_bloom", ""
-  run "tests/test_enr", ""
-  run "tests/test_enode", ""
-
-  test_keyfile_task()
-  test_rlp_task()
-  test_discv5_task()
-  test_trie_task()
-  test_db_task()
-  test_utp_task()
-  test_common_task()
+  run "tests/all_tests", ""
 
 task test_discv5_full, "Run discovery v5 and its dependencies tests":
   run "tests/test_enr", ""


### PR DESCRIPTION
Triggers locally a runtime error on the orc build

```
MPT trie proof verification Error: execution of an external program failed: '/home/deme/repos/nimbus-eth1/vendor/nim-eth/build/all_tests'
stack trace: (most recent call last)
./nimbus-eth1/vendor/nimbus-build-system/vendor/Nim/lib/system/nimscript.nim(427, 18)
./nimbus-eth1/vendor/nim-eth/eth.nimble(68, 3) testTask
,/nimbus-eth1/vendor/nim-eth/eth.nimble(44, 3) run
./nimbus-eth1/vendor/nim-eth/eth.nimble(39, 3) build
./nimbus-eth1/vendor/nimbus-build-system/vendor/Nim/lib/system/nimscript.nim(264, 7) exec
./nimbus-eth1/vendor/nimbus-build-system/vendor/Nim/lib/system/nimscript.nim(264, 7) Error: unhandled exception: FAILED: nim c  --styleCheck:usages --styleCheck:error --verbosity:0 --skipUserCfg --nimcache:build/nimcache -f -d:chronicles_log_level=TRACE --threads:on -d:release  --mm:orc -r --outdir:build/ tests/all_tests [OSError]
```