### PR TITLE
Update definition of block access list slot key and values to UInt256

### DIFF
--- a/eth/common/block_access_lists.nim
+++ b/eth/common/block_access_lists.nim
@@ -21,8 +21,8 @@ const EMPTY_BLOCK_ACCESS_LIST_HASH* =
 
 type
   # Type aliases for clarity (matching EIP-7928 specification)
-  StorageKey* = Bytes32
-  StorageValue* = Bytes32
+  StorageKey* = UInt256
+  StorageValue* = UInt256
   Bytecode* = Bytes
   BlockAccessIndex* = uint16
   Balance* = UInt256


### PR DESCRIPTION
EIP-7928 has been updated again here: https://github.com/ethereum/EIPs/pull/10817

This change reduces the rlp encoded size of storage slots.