### PR TITLE
feat(nat): support multiple ports

### DIFF
--- a/eth/net/nat.nim
+++ b/eth/net/nat.nim
@@ -460,3 +460,12 @@ func `==`*(a, b: NatConfig): bool =
   case a.hasExtIp:
   of true: a.extIp == b.extIp
   of false: a.nat == b.nat
+
+proc toPort*(p: PortSpec): Port =
+  p.port
+
+proc toPort*(p: Opt[PortSpec]): Opt[Port] =
+  if p.isSome:
+    Opt.some(p.get().port)
+  else:
+    Opt.none(Port)


### PR DESCRIPTION
This change is required so it's possible to apply nat to more than one udp port (since quic uses its own udp port)