### PR TITLE
Add RlpArrayBufWriter - uses ArrayBuf to avoid heap allocations

### DIFF
--- a/eth/rlp/arraybuf_writer.nim
+++ b/eth/rlp/arraybuf_writer.nim
@@ -1,0 +1,131 @@
+# eth
+# Copyright (c) 2019-2025 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import stew/[arraybuf, assign2], ./priv/defs, utils
+
+const MAX_PENDING_LISTS = 10
+
+type RlpArrayBufWriter*[N: static int] = object
+  pendingLists: ArrayBuf[MAX_PENDING_LISTS, tuple[remainingItems, startPos: int]]
+  output: ArrayBuf[N, byte]
+
+func writeCount(writer: var RlpArrayBufWriter, count: int, baseMarker: byte) =
+  if count < THRESHOLD_LEN:
+    writer.output.add(baseMarker + byte(count))
+  else:
+    let lenPrefixBytes = uint64(count).bytesNeeded
+
+    writer.output.add baseMarker + (THRESHOLD_LEN - 1) + byte(lenPrefixBytes)
+
+    writer.output.setLen(writer.output.len + lenPrefixBytes)
+    writer.output.writeBigEndian(uint64(count), writer.output.len - 1, lenPrefixBytes)
+
+proc maybeClosePendingLists(self: var RlpArrayBufWriter) =
+  while self.pendingLists.len > 0:
+    let lastListIdx = self.pendingLists.len - 1
+    doAssert self.pendingLists[lastListIdx].remainingItems > 0
+
+    self.pendingLists[lastListIdx].remainingItems -= 1
+    # if one last item is remaining in the list
+    if self.pendingLists[lastListIdx].remainingItems == 0:
+      # A list have been just finished. It was started in `startList`.
+      let listStartPos = self.pendingLists[lastListIdx].startPos
+      self.pendingLists.setLen lastListIdx
+
+      let
+        listLen = self.output.len - listStartPos
+        totalPrefixBytes =
+          if listLen < int(THRESHOLD_LEN):
+            1
+          else:
+            int(uint64(listLen).bytesNeeded) + 1
+
+      #Shift the written data to make room for the prefix length
+      self.output.setLen(self.output.len + totalPrefixBytes)
+
+      moveMem(
+        addr self.output[listStartPos + totalPrefixBytes],
+        unsafeAddr self.output[listStartPos],
+        listLen,
+      )
+
+      # Write out the prefix length
+      if listLen < THRESHOLD_LEN:
+        self.output[listStartPos] = LIST_START_MARKER + byte(listLen)
+      else:
+        let listLenBytes = totalPrefixBytes - 1
+        self.output[listStartPos] = LEN_PREFIXED_LIST_MARKER + byte(listLenBytes)
+
+        self.output.writeBigEndian(
+          uint64(listLen), listStartPos + listLenBytes, listLenBytes
+        )
+    else:
+      # The currently open list is not finished yet. Nothing to do.
+      return
+
+func writeInt*(writer: var RlpArrayBufWriter, i: SomeUnsignedInt) =
+  if i == typeof(i)(0):
+    writer.output.add BLOB_START_MARKER
+  elif i < typeof(i)(BLOB_START_MARKER):
+    writer.output.add byte(i)
+  else:
+    let bytesNeeded = i.bytesNeeded
+    writer.writeCount(bytesNeeded, BLOB_START_MARKER)
+
+    writer.output.setLen(writer.output.len + bytesNeeded)
+    writer.output.writeBigEndian(i, writer.output.len - 1, bytesNeeded)
+  writer.maybeClosePendingLists()
+
+func appendRawBytes*(self: var RlpArrayBufWriter, bytes: openArray[byte]) =
+  self.output.setLen(self.output.len + bytes.len)
+  assign(
+    self.output.toOpenArray(self.output.len - bytes.len, self.output.len - 1), bytes
+  )
+  self.maybeClosePendingLists()
+
+proc writeBlob*(self: var RlpArrayBufWriter, bytes: openArray[byte]) =
+  if bytes.len == 1 and byte(bytes[0]) < BLOB_START_MARKER:
+    self.output.add byte(bytes[0])
+    self.maybeClosePendingLists()
+  else:
+    self.writeCount(bytes.len, BLOB_START_MARKER)
+    self.appendRawBytes(bytes)
+
+proc appendDetached*(writer: var RlpArrayBufWriter, bytes: openArray[byte]) =
+  writer.output.setLen(writer.output.len + bytes.len)
+  assign(
+    writer.output.toOpenArray(writer.output.len - bytes.len, writer.output.len - 1),
+    bytes,
+  )
+
+  # INFO: normally we would update the list and wrap counters but this proc avoids that
+  # for special cases like transaction types
+  # writer.maybeClosePendingLists()
+
+proc appendDetached*(writer: var RlpArrayBufWriter, data: byte) =
+  writer.output.add(data)
+
+  # INFO: normally we would update the list and wrap counters but this proc avoids that
+  # for special cases like transaction types
+  # writer.maybeClosePendingLists()
+
+proc startList*(self: var RlpArrayBufWriter, listSize: int) =
+  if listSize == 0:
+    self.writeCount(0, LIST_START_MARKER)
+    self.maybeClosePendingLists()
+  else:
+    self.pendingLists.add((listSize, self.output.len))
+
+template finish*[N](self: RlpArrayBufWriter[N]): ArrayBuf[N, byte] =
+  doAssert self.pendingLists.len == 0,
+    "Insufficient number of elements written to a started list"
+  self.output
+
+func clear*(w: var RlpArrayBufWriter) =
+  # Prepare writer for reuse
+  w.pendingLists.setLen(0)
+  w.output.setLen(0)

--- a/eth/rlp/arraybuf_writer.nim
+++ b/eth/rlp/arraybuf_writer.nim
@@ -7,10 +7,8 @@
 
 import stew/[arraybuf, assign2], ./priv/defs, utils
 
-const MAX_PENDING_LISTS = 10
-
-type RlpArrayBufWriter*[N: static int] = object
-  pendingLists: ArrayBuf[MAX_PENDING_LISTS, tuple[remainingItems, startPos: int]]
+type RlpArrayBufWriter*[N: static int, MAX_DEPTH: static int = 10] = object
+  pendingLists: ArrayBuf[MAX_DEPTH, tuple[remainingItems, startPos: int]]
   output: ArrayBuf[N, byte]
 
 func writeCount(writer: var RlpArrayBufWriter, count: int, baseMarker: byte) =
@@ -120,10 +118,13 @@ proc startList*(self: var RlpArrayBufWriter, listSize: int) =
   else:
     self.pendingLists.add((listSize, self.output.len))
 
-template finish*[N](self: RlpArrayBufWriter[N]): ArrayBuf[N, byte] =
+template finish*(self: RlpArrayBufWriter, asOpenArray: static bool = false): auto =
   doAssert self.pendingLists.len == 0,
     "Insufficient number of elements written to a started list"
-  self.output
+  when asOpenArray:
+    self.output.buf.toOpenArray(0, self.output.n - 1)
+  else:
+    @(self.output.buf.toOpenArray(0, self.output.n - 1))
 
 func clear*(w: var RlpArrayBufWriter) =
   # Prepare writer for reuse

--- a/eth/rlp/arraybuf_writer.nim
+++ b/eth/rlp/arraybuf_writer.nim
@@ -83,7 +83,7 @@ func writeInt*(writer: var RlpArrayBufWriter, i: SomeUnsignedInt) =
 func appendRawBytes*(self: var RlpArrayBufWriter, bytes: openArray[byte]) =
   self.output.setLen(self.output.len + bytes.len)
   assign(
-    self.output.toOpenArray(self.output.len - bytes.len, self.output.len - 1), bytes
+    self.output.buf.toOpenArray(self.output.len - bytes.len, self.output.len - 1), bytes
   )
   self.maybeClosePendingLists()
 
@@ -98,7 +98,7 @@ proc writeBlob*(self: var RlpArrayBufWriter, bytes: openArray[byte]) =
 proc appendDetached*(writer: var RlpArrayBufWriter, bytes: openArray[byte]) =
   writer.output.setLen(writer.output.len + bytes.len)
   assign(
-    writer.output.toOpenArray(writer.output.len - bytes.len, writer.output.len - 1),
+    writer.output.buf.toOpenArray(writer.output.len - bytes.len, writer.output.len - 1),
     bytes,
   )
 

--- a/eth/rlp/writer.nim
+++ b/eth/rlp/writer.nim
@@ -233,13 +233,6 @@ proc encode*[T](v: T): seq[byte] =
     writer.append(v)
     move(writer.finish)
 
-proc encodeToArrayBuf*[N: static int, T](v: T): ArrayBuf[N, byte] =
-  mixin append
-
-  var writer = RlpArrayBufWriter[N]()
-  writer.append(v)
-  move(writer.finish)
-
 proc computeRlpHash*[T](v: T): Hash32 =
   mixin append
 

--- a/eth/rlp/writer.nim
+++ b/eth/rlp/writer.nim
@@ -19,7 +19,7 @@ import
   stint,
   ../common/hashes
 
-export arraybuf, default_writer, length_writer, two_pass_writer, hash_writer
+export arraybuf, default_writer, length_writer, two_pass_writer, hash_writer, arraybuf_writer
 
 type
   RlpWriter* = RlpDefaultWriter | RlpTwoPassWriter | RlpLengthTracker | RlpHashWriter | RlpArrayBufWriter

--- a/eth/rlp/writer.nim
+++ b/eth/rlp/writer.nim
@@ -14,6 +14,7 @@ import
   length_writer,
   two_pass_writer,
   default_writer,
+  arraybuf_writer,
   utils,
   stint,
   ../common/hashes
@@ -21,7 +22,7 @@ import
 export arraybuf, default_writer, length_writer, two_pass_writer, hash_writer
 
 type
-  RlpWriter* = RlpDefaultWriter | RlpTwoPassWriter | RlpLengthTracker | RlpHashWriter
+  RlpWriter* = RlpDefaultWriter | RlpTwoPassWriter | RlpLengthTracker | RlpHashWriter | RlpArrayBufWriter
 
   RlpIntBuf* = ArrayBuf[9, byte] ## Small buffer for holding a single RLP-encoded integer
 
@@ -231,6 +232,13 @@ proc encode*[T](v: T): seq[byte] =
     var writer = initTwoPassWriter(tracker)
     writer.append(v)
     move(writer.finish)
+
+proc encodeToArrayBuf*[N: static int, T](v: T): ArrayBuf[N, byte] =
+  mixin append
+
+  var writer = RlpArrayBufWriter[N]()
+  writer.append(v)
+  move(writer.finish)
 
 proc computeRlpHash*[T](v: T): Hash32 =
   mixin append

--- a/tests/fuzzing/discoveryv5/fuzz_decode_packet.nim
+++ b/tests/fuzzing/discoveryv5/fuzz_decode_packet.nim
@@ -3,12 +3,13 @@ import
   testutils/fuzzing,
   ../../../eth/p2p/discoveryv5/[encoding, sessions, node]
 
+var rng = newRng()
+
 init:
   const
     nodeAKey = "0xeef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f"
     nodeBKey = "0x66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb1cde628"
   let
-    rng = newRng()
     privKeyA = PrivateKey.fromHex(nodeAKey)[] # sender -> encode
     privKeyB = PrivateKey.fromHex(nodeBKey)[] # receive -> decode
 

--- a/tests/fuzzing/discoveryv5/fuzz_decode_packet.nim
+++ b/tests/fuzzing/discoveryv5/fuzz_decode_packet.nim
@@ -3,13 +3,12 @@ import
   testutils/fuzzing,
   ../../../eth/p2p/discoveryv5/[encoding, sessions, node]
 
-var rng = newRng()
-
 init:
   const
     nodeAKey = "0xeef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f"
     nodeBKey = "0x66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb1cde628"
   let
+    rng = newRng()
     privKeyA = PrivateKey.fromHex(nodeAKey)[] # sender -> encode
     privKeyB = PrivateKey.fromHex(nodeBKey)[] # receive -> decode
 

--- a/tests/rlp/test_api_usage.nim
+++ b/tests/rlp/test_api_usage.nim
@@ -265,3 +265,8 @@ suite "test api usage":
     for i in [uint64 0, 1, 10, 100, 1000, uint64.high]:
       check:
         encode(i) == encodeInt(i).data()
+
+  test "encodeToArrayBuf":
+    for i in [uint64 0, 1, 10, 100, 1000, uint64.high]:
+      check:
+        encodeToArrayBuf[10, uint64](i).data() == encodeInt(i).data()

--- a/tests/rlp/test_api_usage.nim
+++ b/tests/rlp/test_api_usage.nim
@@ -268,13 +268,18 @@ suite "test api usage":
 
   test "encodeToArrayBuf - uint64":
     for i in [uint64 0, 1, 10, 100, 1000, uint64.high]:
-      check:
-        encodeToArrayBuf[10, uint64](i).data() == encodeInt(i).data()
+      var writer = RlpArrayBufWriter[9]()
+      writer.append(i)
+
+      check writer.finish() == encodeInt(i).data()
 
   test "encodeToArrayBuf - UInt256":
     for i in [uint64 0, 1, 10, 100, 1000, uint64.high]:
+      var writer = RlpArrayBufWriter[33]()
+      writer.append(i)
+
       check:
-        encodeToArrayBuf[100, UInt256](i.u256).data() == encode(i.u256)
+        writer.finish() == encode(i.u256)
 
   test "encodeToArrayBuf - Account":
     for i in [uint64 0, 1, 10, 100, 1000, uint64.high]:
@@ -284,5 +289,9 @@ suite "test api usage":
         storageRoot: default(Hash32),
         codeHash: default(Hash32)
       )
+
+      var writer = RlpArrayBufWriter[111]()
+      writer.append(acc)
+
       check:
-        encodeToArrayBuf[111, Account](acc).data() == encode(acc)
+        writer.finish() == encode(acc)

--- a/tests/rlp/test_api_usage.nim
+++ b/tests/rlp/test_api_usage.nim
@@ -266,7 +266,23 @@ suite "test api usage":
       check:
         encode(i) == encodeInt(i).data()
 
-  test "encodeToArrayBuf":
+  test "encodeToArrayBuf - uint64":
     for i in [uint64 0, 1, 10, 100, 1000, uint64.high]:
       check:
         encodeToArrayBuf[10, uint64](i).data() == encodeInt(i).data()
+
+  test "encodeToArrayBuf - UInt256":
+    for i in [uint64 0, 1, 10, 100, 1000, uint64.high]:
+      check:
+        encodeToArrayBuf[100, UInt256](i.u256).data() == encode(i.u256)
+
+  test "encodeToArrayBuf - Account":
+    for i in [uint64 0, 1, 10, 100, 1000, uint64.high]:
+      let acc = Account(
+        nonce: i.uint64,
+        balance: i.u256,
+        storageRoot: default(Hash32),
+        codeHash: default(Hash32)
+      )
+      check:
+        encodeToArrayBuf[111, Account](acc).data() == encode(acc)


### PR DESCRIPTION
This new rlp writer significantly improves the performance of the stateroot computation in the Nimbus EL. 

It's much faster to pre-allocated the buffer on the stack using the ArrayBuf type.