### PR TITLE
remove the `init` block

### DIFF
--- a/tests/fuzzing/discoveryv5/fuzz_decode_packet.nim
+++ b/tests/fuzzing/discoveryv5/fuzz_decode_packet.nim
@@ -3,27 +3,26 @@ import
   testutils/fuzzing,
   ../../../eth/p2p/discoveryv5/[encoding, sessions, node]
 
-init:
-  const
-    nodeAKey = "0xeef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f"
-    nodeBKey = "0x66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb1cde628"
-  let
-    rng = newRng()
-    privKeyA = PrivateKey.fromHex(nodeAKey)[] # sender -> encode
-    privKeyB = PrivateKey.fromHex(nodeBKey)[] # receive -> decode
+const
+  nodeAKey = "0xeef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f"
+  nodeBKey = "0x66fb62bfbd66b9177a138c1e5cddbe4f7c30c343e94e68df8769459cb1cde628"
+let
+  rng = newRng()
+  privKeyA = PrivateKey.fromHex(nodeAKey)[] # sender -> encode
+  privKeyB = PrivateKey.fromHex(nodeBKey)[] # receive -> decode
 
-    enrRecA = enr.Record.init(1, privKeyA,
-      Opt.some(parseIpAddress("127.0.0.1")), Opt.some(Port(9000)),
-      Opt.some(Port(9000))).expect("Properly initialized private key")
-    nodeA = Node.fromRecord(enrRecA)
+  enrRecA = enr.Record.init(1, privKeyA,
+    Opt.some(parseIpAddress("127.0.0.1")), Opt.some(Port(9000)),
+    Opt.some(Port(9000))).expect("Properly initialized private key")
+  nodeA = Node.fromRecord(enrRecA)
 
-    enrRecB = enr.Record.init(1, privKeyB,
-      Opt.some(parseIpAddress("127.0.0.1")), Opt.some(Port(9000)),
-      Opt.some(Port(9000))).expect("Properly initialized private key")
-    nodeB = Node.fromRecord(enrRecB)
+  enrRecB = enr.Record.init(1, privKeyB,
+    Opt.some(parseIpAddress("127.0.0.1")), Opt.some(Port(9000)),
+    Opt.some(Port(9000))).expect("Properly initialized private key")
+  nodeB = Node.fromRecord(enrRecB)
 
-  var codecB = Codec(localNode: nodeB, privKey: privKeyB,
-    sessions: Sessions.init(5))
+var codecB = Codec(localNode: nodeB, privKey: privKeyB,
+  sessions: Sessions.init(5))
 
 test:
   # It is not the best idea to generate extra data and encrypt data but we do


### PR DESCRIPTION
After
https://github.com/nim-lang/Nim/commit/2501e23d8170c56b61d126a9e349ae6d8e4b6267, the Nim compiler is stricter about the scopes.
This fixes the failing test on both Nim devel and 2.2.x.