### PR TITLE
discv5: Queue message requests when no session set up yet

### DIFF
--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -123,6 +123,8 @@ const
   defaultResponseTimeout* = 4.seconds ## timeout for the response of a request-response
   ## call
   defaultSessionsSize* = 256 ## Size of the session cache
+  maxQueuedRequestsPerPeer* = 8 ## Max outbound requests queued per peer while
+  ## a handshake is in progress
 
   ## Ban durations for banned nodes in the routing table
   NodeBanDurationInvalidResponse = 15.minutes
@@ -162,7 +164,7 @@ type
     handshakeTimeout: Duration
     responseTimeout: Duration
     rng*: ref HmacDrbgContext
-
+    requestQueues: Table[HandshakeKey, seq[seq[byte]]]
 
   PendingRequest = object
     node: Node
@@ -468,6 +470,16 @@ proc banNode*(d: Protocol, n: Node, banPeriod: chronos.Duration) =
 proc isBanned*(d: Protocol, nodeId: NodeId): bool =
   d.banNodes and d.routingTable.isBanned(nodeId)
 
+# TODO: This could be improved to do the clean-up immediately in case a non
+# whoareyou response does arrive, but we would need to store the AuthTag
+# somewhere
+proc registerRequest(d: Protocol, n: Node, message: seq[byte],
+    nonce: AESGCMNonce) =
+  let request = PendingRequest(node: n, message: message)
+  if not d.pendingRequests.hasKeyOrPut(nonce, request):
+    sleepAsync(d.responseTimeout).addCallback() do(data: pointer):
+      d.pendingRequests.del(nonce)
+
 proc receive*(d: Protocol, a: Address, packet: openArray[byte]) =
   discv5_network_bytes.inc(packet.len.int64, labelValues = [$Direction.In])
 
@@ -508,6 +520,20 @@ proc receive*(d: Protocol, a: Address, packet: openArray[byte]) =
 
         trace "Send handshake message packet", dstId = toNode.id, address
         d.send(toNode, data)
+
+        # Session is now established on our side. Drain any requests that were
+        # queued while the handshake was in progress, these will be encrypted
+        # with the new session key.
+        let key = HandshakeKey(nodeId: toNode.id, address: address)
+        var queued: seq[seq[byte]]
+        if d.requestQueues.pop(key, queued):
+          for qmsg in queued:
+            let (qdata, qnonce) = encodeMessagePacket(d.rng[], d.codec,
+              toNode.id, address, qmsg)
+            d.registerRequest(toNode, qmsg, qnonce)
+            trace "Send queued message packet", dstId = toNode.id, address
+            d.send(toNode, qdata)
+            discovery_message_requests_outgoing.inc()
       else:
         debug "Timed out or unrequested whoareyou packet", address = a
     of HandshakeMessage:
@@ -559,16 +585,6 @@ proc processClient(transp: DatagramTransport, raddr: TransportAddress):
 
   proto.receive(Address(ip: raddr.toIpAddress(), port: raddr.port), buf)
 
-# TODO: This could be improved to do the clean-up immediately in case a non
-# whoareyou response does arrive, but we would need to store the AuthTag
-# somewhere
-proc registerRequest(d: Protocol, n: Node, message: seq[byte],
-    nonce: AESGCMNonce) =
-  let request = PendingRequest(node: n, message: message)
-  if not d.pendingRequests.hasKeyOrPut(nonce, request):
-    sleepAsync(d.responseTimeout).addCallback() do(data: pointer):
-      d.pendingRequests.del(nonce)
-
 proc waitMessage(d: Protocol, fromNode: Node, reqId: RequestId):
     Future[Opt[Message]] {.async: (raw: true, raises: [CancelledError]).} =
   let retFuture = Future[Opt[Message]].Raising([CancelledError]).init("discv5.waitMessage")
@@ -617,15 +633,40 @@ proc sendMessage*[T: SomeMessage](d: Protocol, toNode: Node, m: T):
     address = toNode.address.get()
     reqId = RequestId.init(d.rng[])
     message = encodeMessage(m, reqId)
+    key = HandshakeKey(nodeId: toNode.id, address: address)
+
+  if key in d.requestQueues:
+    # A handshake is already in progress with this peer. Queue the request and
+    # send it once the session is established.
+    if d.requestQueues.getOrDefault(key).len < maxQueuedRequestsPerPeer:
+      d.requestQueues.mgetOrPut(key, @[]).add(message)
+      trace "Queued request during handshake", dstId = toNode.id,
+        address, kind = messageKind(T)
+    else:
+      # Note: if request queue gets full this gets silently dropped. For the
+      # API caller this will look like a timeout.
+      trace "Request queue full, dropping request", dstId = toNode.id,
+        address, kind = messageKind(T)
+    return reqId
 
   let (data, nonce) = encodeMessagePacket(d.rng[], d.codec, toNode.id,
     address, message)
-
   d.registerRequest(toNode, message, nonce)
+
+  if d.codec.sessions.load(toNode.id, address).isNone():
+    # Sending message packet without a session, mark this peer as having a
+    # handshake in progress so subsequent requests are queued rather than
+    # sent randomly encrypted and either dropped at receipient or causing
+    # too many concurrent handshakes/whoareyous.
+    d.requestQueues[key] = @[]
+    sleepAsync(d.responseTimeout).addCallback() do(data: pointer):
+      d.requestQueues.del(key)
+
   trace "Send message packet", dstId = toNode.id, address, kind = messageKind(T)
   d.send(toNode, data)
   discovery_message_requests_outgoing.inc()
-  return reqId
+
+  reqId
 
 proc ping*(d: Protocol, toNode: Node):
     Future[DiscResult[PongMessage]] {.async: (raises: [CancelledError]).} =

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -1044,3 +1044,30 @@ suite "Discovery v5.1 Tests":
 
     await node2.closeWait()
     await node1.closeWait()
+
+  asyncTest "Concurrent requests to a peer without a session are queued":
+    let
+      # Short response timeout so dropped pings fail fast in the test.
+      config = DiscoveryConfig.init(
+        DefaultTableIpLimit, DefaultBucketIpLimit, DefaultBitsPerHop,
+        defaultHandshakeTimeout, 500.milliseconds, defaultSessionsSize, false)
+      node1 = initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(20308),
+        config = config)
+      node2 = initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(20309),
+        config = config)
+
+    # All pings are fired before yielding to the event loop.
+    let handshakeFuture = node1.ping(node2.localNode)
+    var queuedFutures: seq[Future[DiscResult[PongMessage]]]
+    for _ in 0..<maxQueuedRequestsPerPeer:
+      queuedFutures.add(node1.ping(node2.localNode))
+    let overflowFuture = node1.ping(node2.localNode)
+
+    check (await handshakeFuture).isOk()
+    for f in queuedFutures:
+      check (await f).isOk()
+
+    check (await overflowFuture).isErr()
+
+    await node1.closeWait()
+    await node2.closeWait()

--- a/tests/p2p/test_discoveryv5_encoding.nim
+++ b/tests/p2p/test_discoveryv5_encoding.nim
@@ -8,7 +8,7 @@
 {.used.}
 
 import
-  std/[options, sequtils, tables, net],
+  std/[sequtils, tables, net],
   unittest2,
   stint, stew/byteutils,
   ../../eth/enr/enr,


### PR DESCRIPTION
Currently concurrent message requests will be all send even when no session is being setup yet. This means that all of these are randomly encrypted and will either each cause a whoareyou and thus handshake setup or some of those might be dropped depending on recipient implementation.

We adjust this here so we only send the first one, and queue the others. Once the session setup finishes, the requests in the queue are send. If handshake feels, this will timeout and they are all dropped.

This is inspired by https://github.com/logos-storage/logos-storage-nim-dht/pull/83/changes and the discv5 specs: https://github.com/ethereum/devp2p/blob/e0091d1140bddce2a9805047b94110d3ad439e6e/discv5/discv5-theory.md#handshake-implementation-considerations

However, the specs mention to still send it yet add in a queue, but that is rather wastefull so we only send the first and buffer the rest.

The main differences in the implementation of logos-storage-nim-dht are:
- Don't add the `haskey` return value in `encodeMessagePacket` and don't run `encodeMessagePacket` for each queued up message. As this is wasteful and unneeded. You have to rerun `encodeMessagePacket` anyhow once the session is set up.
- `sendPending` is async while it shouldn't be and discarded. Not needed.
-  Using HandshakeKey to include address (as the session uses also)