### PR TITLE
discv5: retransmit existing whoareyou on multiple undecryptable packets

### DIFF
--- a/eth/p2p/discoveryv5/encoding.nim
+++ b/eth/p2p/discoveryv5/encoding.nim
@@ -81,6 +81,8 @@ type
   Challenge* = object
     whoareyouData*: WhoareyouData
     pubkey*: Opt[PublicKey]
+    packet*: seq[byte] ## Exact encoded bytes of the WHOAREYOU packet ready for
+    ## retransmission.
 
   StaticHeader* = object
     flag: Flag
@@ -296,7 +298,8 @@ proc encodeWhoareyouPacket*(rng: var HmacDrbgContext, c: var Codec,
       idNonce: idNonce,
       recordSeq: recordSeq,
       challengeData: @iv & header)
-    challenge = Challenge(whoareyouData: whoareyouData, pubkey: pubkey)
+    challenge = Challenge(whoareyouData: whoareyouData, pubkey: pubkey,
+      packet: packet)
     key = HandshakeKey(nodeId: toId, address: toAddr)
 
   c.handshakes[key] = challenge

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -423,26 +423,33 @@ func registerTalkProtocol*(d: Protocol, protocolId: seq[byte],
 proc sendWhoareyou(d: Protocol, toId: NodeId, a: Address,
     requestNonce: AESGCMNonce, node: Opt[Node]) =
   let key = HandshakeKey(nodeId: toId, address: a)
-  if not d.codec.hasHandshake(key):
-    let
-      recordSeq =
-        if node.isSome():
-          node.get().record.seqNum
-        else:
-          0
-      pubkey = node.map(proc(node: Node): PublicKey = node.pubkey)
+  if d.codec.hasHandshake(key):
+    # A challenge is already outstanding for this peer. We only allow
+    # for one handshake per peer at a time. Could drop this but instead
+    # retransmit the original whoareyou so that the initiator can finish
+    # the handshake in case the first got lost.
+    # This is similar to behaviour of go-ethereum discv5 implementation.
+    trace "Resending whoareyou", dstId = toId, address = a
+    d.send(a, d.codec.handshakes.getOrDefault(key).packet)
+    return
 
-    let data = encodeWhoareyouPacket(d.rng[], d.codec, toId, a, requestNonce,
-      recordSeq, pubkey)
-    sleepAsync(d.handshakeTimeout).addCallback() do(data: pointer):
+  let
+    recordSeq =
+      if node.isSome():
+        node.get().record.seqNum
+      else:
+        0
+    pubkey = node.map(proc(node: Node): PublicKey = node.pubkey)
+
+  let data = encodeWhoareyouPacket(d.rng[], d.codec, toId, a, requestNonce,
+    recordSeq, pubkey)
+  sleepAsync(d.handshakeTimeout).addCallback() do(data: pointer):
     # TODO: should we still provide cancellation in case handshake completes
     # correctly?
-      d.codec.handshakes.del(key)
+    d.codec.handshakes.del(key)
 
-    trace "Send whoareyou", dstId = toId, address = a
-    d.send(a, data)
-  else:
-    debug "Node with this id already has ongoing handshake, ignoring packet"
+  trace "Send whoareyou", dstId = toId, address = a
+  d.send(a, data)
 
 proc replaceNode(d: Protocol, n: Node) =
   if n.record notin d.bootstrapRecords:

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -746,13 +746,14 @@ suite "Discovery v5.1 Tests":
     await receiveNode.closeWait()
 
   asyncTest "Handshake duplicates":
-    # Node to test the handshakes on.
-    let receiveNode = initDiscoveryNode(
-      rng, PrivateKey.random(rng[]), localAddress(20302))
-
-    # Create random packets with same node ids and same ips
-    # and "receive" them on receiveNode
+    # When multiple undecryptable packets arrive from the same peer while a
+    # challenge is already outstanding, the receiver:
+    # 1. Keeps exactly one handshake entry, keyed to the first packet's nonce.
+    # 2. Stores the original WHOAREYOU bytes for retransmission.
     let
+      receiveNode = initDiscoveryNode(
+        rng, PrivateKey.random(rng[]), localAddress(20302))
+
       a = localAddress(20303)
       privKey = PrivateKey.random(rng[])
       enrRec = enr.Record.init(1, privKey,
@@ -775,6 +776,14 @@ suite "Discovery v5.1 Tests":
     let key = HandshakeKey(nodeId: sendNode.id, address: a)
     check receiveNode.codec.handshakes[key].whoareyouData.requestNonce ==
       firstRequestNonce
+
+    let storedPacket = receiveNode.codec.handshakes[key].packet
+    check storedPacket.len > 0
+    let decoded = codec.decodePacket(a, storedPacket)
+    check:
+      decoded.isOk()
+      decoded[].flag == Whoareyou
+      decoded[].whoareyou.requestNonce == firstRequestNonce
 
     await receiveNode.closeWait()
 


### PR DESCRIPTION
When a second undecryptable packet arrives from a peer that already has an outstanding challenge, resend the exact original WHOAREYOU bytes rather than dropping the packet. This matches go-ethereum's behaviour and will help incase of a whoareyou packet loss.

This is a similar change to what go-ethereum did here https://github.com/ethereum/go-ethereum/pull/31356