### PR TITLE
discv5: cap findNode response at findNodeResultLimit per spec

### DIFF
--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -108,7 +108,7 @@ const
   alpha = 3 ## Kademlia concurrency factor
   lookupRequestLimit = 3 ## Amount of distances requested in a single Findnode
   ## message for a lookup or query
-  findNodeResultLimit = 16 ## Maximum amount of ENRs in the total Nodes messages
+  findNodeResultLimit* = 16 ## Maximum amount of ENRs in the total Nodes messages
   ## that will be processed
   maxNodesPerMessage = 3 ## Maximum amount of ENRs per individual Nodes message
   refreshInterval = 5.minutes ## Interval of launching a random query to
@@ -360,7 +360,7 @@ proc handleFindNode(d: Protocol, fromId: NodeId, fromAddr: Address,
     # TODO: Still deduplicate also?
     if fn.distances.all(proc (x: uint16): bool = return x <= 256):
       d.sendNodes(fromId, fromAddr, reqId,
-        d.routingTable.neighboursAtDistances(fn.distances, seenOnly = true))
+        d.routingTable.neighboursAtDistances(fn.distances, seenOnly = true, k = findNodeResultLimit))
     else:
       # At least one invalid distance, but the polite node we are, still respond
       # with empty nodes.

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -245,7 +245,31 @@ suite "Discovery v5.1 Tests":
     discovered =
       await findNode(testNode, mainNode.localNode, @[dist])
     check discovered.isOk
-    check discovered[].len == 16
+    check discovered[].len == findNodeResultLimit
+
+    await mainNode.closeWait()
+    await testNode.closeWait()
+
+  asyncTest "FindNode limit across multiple distances":
+    const
+      dist1 = 253'u16
+      dist2 = 254'u16
+    let
+      mainNode = initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(20301))
+      testNode = initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(20302))
+
+    # 10 nodes at each distance = 20 total, which exceeds findNodeResultLimit.
+    for n in nodesAtDistance(mainNode.localNode, rng[], dist1, 10) &
+             nodesAtDistance(mainNode.localNode, rng[], dist2, 10):
+      discard mainNode.addSeenNode(n)
+
+    check (await testNode.ping(mainNode.localNode)).isOk()
+    check (await mainNode.ping(testNode.localNode)).isOk()
+
+    let discovered = await findNode(testNode, mainNode.localNode, @[dist1, dist2])
+    check:
+      discovered.isOk()
+      discovered[].len == findNodeResultLimit
 
     await mainNode.closeWait()
     await testNode.closeWait()


### PR DESCRIPTION
The discv5 spec suggests 16 ENRs max in findNode Nodes responses. The neighboursAtDistances call was relying on the default k = BUCKET_SIZE, which currently equals the findNodeResultLimit. This change properly separates those limits.