### PR TITLE
discv5: Only add public addresses to IP limits of routing table

### DIFF
--- a/eth/net/utils.nim
+++ b/eth/net/utils.nim
@@ -1,5 +1,5 @@
 # nim-eth
-# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Copyright (c) 2020-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -47,6 +47,11 @@ func isGlobalUnicast*(address: TransportAddress): bool =
 func isGlobalUnicast*(address: IpAddress): bool =
   let a = initTAddress(address, Port(0))
   a.isGlobalUnicast()
+
+func isPublic*(address: IpAddress): bool =
+  ## Returns true for globally routable (public) addresses
+  let a = initTAddress(address, Port(0))
+  not (a.isLoopback() or a.isSiteLocal() or a.isLinkLocal())
 
 proc getRouteIpv4*(): Result[IpAddress, cstring] =
   # Avoiding Exception with initTAddress and can't make it work with static.

--- a/eth/p2p/discoveryv5/encoding.nim
+++ b/eth/p2p/discoveryv5/encoding.nim
@@ -1,5 +1,5 @@
 # nim-eth - Node Discovery Protocol v5
-# Copyright (c) 2020-2025 Status Research & Development GmbH
+# Copyright (c) 2020-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -1,5 +1,5 @@
 # nim-eth - Node Discovery Protocol v5
-# Copyright (c) 2020-2025 Status Research & Development GmbH
+# Copyright (c) 2020-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -1,5 +1,5 @@
 # nim-eth - Node Discovery Protocol v5
-# Copyright (c) 2020-2025 Status Research & Development GmbH
+# Copyright (c) 2020-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -175,6 +175,12 @@ func ipLimitInc(r: var RoutingTable, b: KBucket, n: Node): bool =
   ## When one of the ip limits is reached return false, else increment them and
   ## return true.
   let ip = n.address.get().ip # Node from table should always have an address
+
+  # Apply IP limits only to public addresses. The limits defend against Sybil
+  # attacks from a single public IP, which is not meaningful on a private
+  # network. go-ethereum applies the same exemption.
+  if not ip.isPublic():
+    return true
   # Check ip limit for bucket
   if not b.ipLimits.inc(ip):
     return false
@@ -189,7 +195,8 @@ func ipLimitDec(r: var RoutingTable, b: KBucket, n: Node) =
   ## Decrement the ip limits of the routing table and the bucket for the
   ## specified `Node` its ip.
   let ip = n.address.get().ip # Node from table should always have an address
-
+  if not ip.isPublic():
+    return
   b.ipLimits.dec(ip)
   r.ipLimits.dec(ip)
 
@@ -263,15 +270,18 @@ func split(k: KBucket): tuple[lower, upper: KBucket] =
     bucket.nodes.add(node)
     # Ip limits got reset because of the KBucket.new, so there is the need to
     # increment again for each added node. It should however never fail as the
-    # previous bucket had the same limits.
-    doAssert(bucket.ipLimits.inc(node.address.get().ip),
-      "IpLimit increment should work as all buckets have the same limits")
+    # previous bucket had the same limits. IP limits only track public addresses
+    # so non-public addresses are not counted.
+    if node.address.get().ip.isPublic():
+      doAssert(bucket.ipLimits.inc(node.address.get().ip),
+        "IpLimit increment should work as all buckets have the same limits")
 
   for node in k.replacementCache:
     let bucket = if node.id <= splitid: result.lower else: result.upper
     bucket.replacementCache.add(node)
-    doAssert(bucket.ipLimits.inc(node.address.get().ip),
-      "IpLimit increment should work as all buckets have the same limits")
+    if node.address.get().ip.isPublic():
+      doAssert(bucket.ipLimits.inc(node.address.get().ip),
+        "IpLimit increment should work as all buckets have the same limits")
 
 func inRange(k: KBucket, n: Node): bool =
   k.istart <= n.id and n.id <= k.iend

--- a/tests/p2p/test_routing_table.nim
+++ b/tests/p2p/test_routing_table.nim
@@ -1,3 +1,10 @@
+# nim-eth
+# Copyright (c) 2020-2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 {.used.}
 
 import
@@ -276,14 +283,20 @@ suite "Routing Table Tests":
     # bitsPerHop = 1 -> Split only the branch in range of own id
     var table = RoutingTable.init(node, 1, DefaultTableIpLimits, rng = rng)
 
+    # Use public IPs: LAN/loopback/link-local addresses are not added to IP limits
+    const
+      pubIp1 = parseIpAddress("1.2.3.4")   # public IP to hit the bucket limit
+      pubBaseIp1 = parseIpAddress("2.3.4.0") # base for unique-IP fill in bucket 1
+      pubBaseIp2 = parseIpAddress("3.4.5.0") # base for unique-IP fill in bucket 2
+
     block: # First bucket
       let sameIpNodes = node.nodesAtDistance(rng[], 256,
-        int(DefaultTableIpLimits.bucketIpLimit))
+        int(DefaultTableIpLimits.bucketIpLimit), pubIp1)
       for n in sameIpNodes:
         check table.addNode(n) == Added
 
       # Try to add a node, which should fail due to ip bucket limit
-      let anotherSameIpNode = node.nodeAtDistance(rng[], 256)
+      let anotherSameIpNode = node.nodeAtDistance(rng[], 256, pubIp1)
       check table.addNode(anotherSameIpNode) == IpLimitReached
 
       # Remove one and try add again
@@ -292,31 +305,29 @@ suite "Routing Table Tests":
 
       # Further fill the bucket with nodes with different ip.
       let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256,
-        int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit),
-        parseIpAddress("192.168.0.1"))
+        int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit), pubBaseIp1)
       for n in diffIpNodes:
         check table.addNode(n) == Added
 
     block: # Second bucket
       # Try to add another node with the same IP, but different distance.
       # This should split the bucket and add it.
-      let anotherSameIpNode = node.nodeAtDistance(rng[], 255)
+      let anotherSameIpNode = node.nodeAtDistance(rng[], 255, pubIp1)
       check table.addNode(anotherSameIpNode) == Added
 
       # Add more nodes with different ip and distance 255 to get in the new bucket
       let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 255,
-        int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit - 1),
-        parseIpAddress("192.168.1.1"))
+        int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit - 1), pubBaseIp2)
       for n in diffIpNodes:
         check table.addNode(n) == Added
 
       let sameIpNodes = node.nodesAtDistance(rng[], 255,
-        int(DefaultTableIpLimits.bucketIpLimit - 1))
+        int(DefaultTableIpLimits.bucketIpLimit - 1), pubIp1)
       for n in sameIpNodes:
         check table.addNode(n) == Added
 
       # Adding in another one should fail again
-      let anotherSameIpNode2 = node.nodeAtDistance(rng[], 255)
+      let anotherSameIpNode2 = node.nodeAtDistance(rng[], 255, pubIp1)
       check table.addNode(anotherSameIpNode2) == IpLimitReached
 
   test "Ip limits on routing table":
@@ -324,58 +335,65 @@ suite "Routing Table Tests":
     # bitsPerHop = 1 -> Split only the branch in range of own id
     var table = RoutingTable.init(node, 1, DefaultTableIpLimits, rng = rng)
 
+    # Use public IPs: LAN/loopback/link-local addresses are not added to IP limits
+    const
+      pubIp1 = parseIpAddress("1.2.3.4")   # public IP to exhaust the table limit
+      pubBaseIp1 = parseIpAddress("2.3.4.0") # base for unique-IP fill
+      pubIp2 = parseIpAddress("3.4.5.1")   # a second distinct public IP
+
     let amount = uint32(DefaultTableIpLimits.tableIpLimit div
       DefaultTableIpLimits.bucketIpLimit)
     # Fill `amount` of buckets, each with 14 nodes with different ips and 2
     # with equal ones.
     for j in 0..<amount:
       let nodes = node.nodesAtDistanceUniqueIp(rng[], 256 - j,
-        int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit),
-        parseIpAddress("192.168.0.1"))
+        int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit), pubBaseIp1)
       for n in nodes:
         check table.addNode(n) == Added
 
       let sameIpNodes = node.nodesAtDistance(rng[], 256 - j,
-        int(DefaultTableIpLimits.bucketIpLimit))
+        int(DefaultTableIpLimits.bucketIpLimit), pubIp1)
       for n in sameIpNodes:
         check table.addNode(n) == Added
 
     # Add a node with a different IP, should work and split a bucket once more.
-    let anotherDiffIpNode = node.nodeAtDistance(rng[], 256 - amount,
-      parseIpAddress("192.168.1.1"))
+    let anotherDiffIpNode = node.nodeAtDistance(rng[], 256 - amount, pubIp2)
     check table.addNode(anotherDiffIpNode) == Added
 
     let amountLeft = int(DefaultTableIpLimits.tableIpLimit mod
       DefaultTableIpLimits.bucketIpLimit)
 
-    let sameIpNodes = node.nodesAtDistance(rng[], 256 - amount, amountLeft)
+    let sameIpNodes = node.nodesAtDistance(rng[], 256 - amount, amountLeft, pubIp1)
     for n in sameIpNodes:
       check table.addNode(n) == Added
 
     # Add a node with same ip to this fresh bucket, should fail because of total
     # ip limit of routing table is reached.
-    let anotherSameIpNode = node.nodeAtDistance(rng[], 256 - amount)
+    let anotherSameIpNode = node.nodeAtDistance(rng[], 256 - amount, pubIp1)
     check table.addNode(anotherSameIpNode) == IpLimitReached
 
   test "Ip limits on replacement cache":
     let node = generateNode(PrivateKey.random(rng[]))
     var table = RoutingTable.init(node, 1, DefaultTableIpLimits, rng = rng)
 
+    const
+      pubIp1 = parseIpAddress("1.2.3.4")
+      pubBaseIp1 = parseIpAddress("2.3.4.0")
+
     let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256,
-      int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit + 1),
-      parseIpAddress("192.168.0.1"))
+      int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit + 1), pubBaseIp1)
     for n in diffIpNodes:
       check table.addNode(n) == Added
 
     let sameIpNodes = node.nodesAtDistance(rng[], 256,
-      int(DefaultTableIpLimits.bucketIpLimit - 1))
+      int(DefaultTableIpLimits.bucketIpLimit - 1), pubIp1)
     for n in sameIpNodes:
       check table.addNode(n) == Added
 
-    let anotherSameIpNode1 = node.nodeAtDistance(rng[], 256)
+    let anotherSameIpNode1 = node.nodeAtDistance(rng[], 256, pubIp1)
     check table.addNode(anotherSameIpNode1) == ReplacementAdded
 
-    let anotherSameIpNode2 = node.nodeAtDistance(rng[], 256)
+    let anotherSameIpNode2 = node.nodeAtDistance(rng[], 256, pubIp1)
     check table.addNode(anotherSameIpNode2) == IpLimitReached
 
     block: # Replace node to see if the first one becomes available
@@ -397,35 +415,38 @@ suite "Routing Table Tests":
     let node = generateNode(PrivateKey.random(rng[]))
     var table = RoutingTable.init(node, 1, DefaultTableIpLimits, rng = rng)
 
+    const
+      pubIp1 = parseIpAddress("1.2.3.4")
+      pubBaseIp1 = parseIpAddress("2.3.4.0")
+      pubBaseIp2 = parseIpAddress("3.4.5.0")
+      pubIp2 = parseIpAddress("4.5.6.7")
+
     block: # Fill bucket
       let sameIpNodes = node.nodesAtDistance(rng[], 256,
-        int(DefaultTableIpLimits.bucketIpLimit - 1))
+        int(DefaultTableIpLimits.bucketIpLimit - 1), pubIp1)
       for n in sameIpNodes:
         check table.addNode(n) == Added
 
       let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256,
-        int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit + 1),
-        parseIpAddress("192.168.0.1"))
+        int(BUCKET_SIZE - DefaultTableIpLimits.bucketIpLimit + 1), pubBaseIp1)
       for n in diffIpNodes:
         check table.addNode(n) == Added
 
     block: # Fill bucket replacement cache
-      let sameIpNode = node.nodeAtDistance(rng[], 256)
+      let sameIpNode = node.nodeAtDistance(rng[], 256, pubIp1)
       check table.addNode(sameIpNode) == ReplacementAdded
 
       let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256,
-        int(REPLACEMENT_CACHE_SIZE - 1),
-        parseIpAddress("192.168.1.1"))
+        int(REPLACEMENT_CACHE_SIZE - 1), pubBaseIp2)
       for n in diffIpNodes:
         check table.addNode(n) == ReplacementAdded
 
     # Try to add node to replacement, but limit is reached
-    let sameIpNode = node.nodeAtDistance(rng[], 256)
+    let sameIpNode = node.nodeAtDistance(rng[], 256, pubIp1)
     check table.addNode(sameIpNode) == IpLimitReached
 
     # Add one with different ip, to remove the first
-    let diffIpNode = node.nodeAtDistance(rng[], 256,
-      parseIpAddress("192.168.2.1"))
+    let diffIpNode = node.nodeAtDistance(rng[], 256, pubIp2)
     check table.addNode(diffIpNode) == ReplacementAdded
 
     # Now the add should work
@@ -435,20 +456,24 @@ suite "Routing Table Tests":
     let node = generateNode(PrivateKey.random(rng[]))
     var table = RoutingTable.init(node, 1, DefaultTableIpLimits, rng = rng)
 
+    const
+      pubIp1 = parseIpAddress("1.2.3.4")
+      pubBaseIp1 = parseIpAddress("2.3.4.0")
+
     # Fill bucket
     let diffIpNodes = node.nodesAtDistanceUniqueIp(rng[], 256, BUCKET_SIZE,
-      parseIpAddress("192.168.0.1"))
+      pubBaseIp1)
     for n in diffIpNodes:
       check table.addNode(n) == Added
 
     # Test if double add does not account for the ip limits.
     for i in 0..<DefaultTableIpLimits.bucketIpLimit:
-      let sameIpNode = node.nodeAtDistance(rng[], 256)
+      let sameIpNode = node.nodeAtDistance(rng[], 256, pubIp1)
       check table.addNode(sameIpNode) == ReplacementAdded
       # Add it again
       check table.addNode(sameIpNode) == ReplacementExisting
 
-    let sameIpNode = node.nodeAtDistance(rng[], 256)
+    let sameIpNode = node.nodeAtDistance(rng[], 256, pubIp1)
     check table.addNode(sameIpNode) == IpLimitReached
 
   test "Ip limits on bucket: double add with new ip":


### PR DESCRIPTION
This doesn't make that much sense for private / loopback addresses as these are mostly used for test setups.

Hive actually has a failure which is likely due to this in the `FindNodeResults` discv5 test.

go-ethereum has similar code in place with an isLAN check.