### PR TITLE
discv5: ping back newly added nodes after inbound handshake

### DIFF
--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -115,6 +115,8 @@ const
   ## refresh the routing table.
   revalidateMax = 10000 ## Revalidation of a peer is done between 0 and this
   ## value in milliseconds
+  pingBackMax* = 5000 ## When a node completes an inbound handshake and is newly
+  ## added to the routing table, it is pinged back within this many milliseconds
   ipMajorityInterval = 5.minutes ## Interval for checking the latest IP:Port
   ## majority and updating this when ENR auto update is set.
   initialLookups = 1 ## Amount of lookups done when populating the routing table
@@ -141,6 +143,7 @@ type
     responseTimeout: Duration
     sessionsSize*: int
     banNodes*: bool
+    pingBackMax*: int
 
   Protocol* = ref object
     transp: DatagramTransport
@@ -163,6 +166,7 @@ type
     # overkill here, use sequence
     handshakeTimeout: Duration
     responseTimeout: Duration
+    pingBackMax: int
     rng*: ref HmacDrbgContext
     requestQueues: Table[HandshakeKey, seq[seq[byte]]]
 
@@ -192,7 +196,8 @@ const
     handshakeTimeout: defaultHandshakeTimeout,
     responseTimeout: defaultResponseTimeout,
     sessionsSize: defaultSessionsSize,
-    banNodes: false
+    banNodes: false,
+    pingBackMax: pingBackMax,
   )
 
 chronicles.formatIt(Opt[Port]): $it
@@ -487,6 +492,8 @@ proc registerRequest(d: Protocol, n: Node, message: seq[byte],
     sleepAsync(d.responseTimeout).addCallback() do(data: pointer):
       d.pendingRequests.del(nonce)
 
+proc pingBack(d: Protocol, node: Node) {.async: (raises: [CancelledError]).}
+
 proc receive*(d: Protocol, a: Address, packet: openArray[byte]) =
   discv5_network_bytes.inc(packet.len.int64, labelValues = [$Direction.In])
 
@@ -562,6 +569,7 @@ proc receive*(d: Protocol, a: Address, packet: openArray[byte]) =
         if node.address.isSome() and a == node.address.get():
           if d.addNode(node):
             trace "Added new node to routing table after handshake", node
+            asyncSpawn d.pingBack(node)
 
         # Received an ENR in the handshake, add it to the session that was just
         # created in the session cache.
@@ -700,6 +708,13 @@ proc ping*(d: Protocol, toNode: Node):
     d.replaceNode(toNode)
     discovery_message_requests_outgoing.inc(labelValues = ["no_response"])
     return err("Pong message not received in time")
+
+proc pingBack(d: Protocol, node: Node) {.async: (raises: [CancelledError]).} =
+  ## Ping back a node after an inbound session setup, with a random delay.
+  await sleepAsync(milliseconds(d.rng[].rand(d.pingBackMax)))
+  let res = await d.ping(node)
+  if res.isErr():
+    trace "Ping back failed", node, err = res.error
 
 proc findNode*(d: Protocol, toNode: Node, distances: seq[uint16]):
     Future[DiscResult[seq[Node]]] {.async: (raises: [CancelledError]).} =
@@ -1078,6 +1093,7 @@ func init*(
     responseTimeout: Duration,
     sessionsSize: int,
     banNodes: bool,
+    pingBackMax = pingBackMax,
 ): T =
   DiscoveryConfig(
     tableIpLimits:
@@ -1087,6 +1103,7 @@ func init*(
     responseTimeout: responseTimeout,
     sessionsSize: sessionsSize,
     banNodes: banNodes,
+    pingBackMax: pingBackMax,
   )
 
 func init*(
@@ -1096,10 +1113,11 @@ func init*(
     bitsPerHop: int,
     sessionsSize = defaultSessionsSize,
     banNodes = false,
+    pingBackMax = pingBackMax,
 ): T =
   DiscoveryConfig.init(
     tableIpLimit, bucketIpLimit, bitsPerHop, defaultHandshakeTimeout,
-    defaultResponseTimeout, sessionsSize, banNodes,
+    defaultResponseTimeout, sessionsSize, banNodes, pingBackMax,
   )
 
 proc newProtocol*(
@@ -1172,6 +1190,7 @@ proc newProtocol*(
     banNodes: config.banNodes,
     handshakeTimeout: config.handshakeTimeout,
     responseTimeout: config.responseTimeout,
+    pingBackMax: config.pingBackMax,
     rng: rng,
   )
 

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -1104,3 +1104,31 @@ suite "Discovery v5.1 Tests":
 
     await node1.closeWait()
     await node2.closeWait()
+
+  asyncTest "Ping back on inbound handshake":
+    let
+      # pingBackMax = 0 so the ping-back fires immediately, keeping the test fast
+      config = DiscoveryConfig.init(
+        DefaultTableIpLimit, DefaultBucketIpLimit, DefaultBitsPerHop,
+        pingBackMax = 0)
+      node1 = initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(20301),
+        config = config)
+      node2 = initDiscoveryNode(rng, PrivateKey.random(rng[]), localAddress(20302),
+        config = config)
+
+    # node1 pings node2: node2 completes an inbound handshake, adds node1 to
+    # its routing table, and schedules a ping-back to node1.
+    check (await node1.ping(node2.localNode)).isOk()
+
+    # yield to the event loop to let the ping-back complete.
+    await sleepAsync(100.milliseconds)
+
+    # node1 should now be marked as seen in node2's routing table because the
+    # ping-back gave node2 a successful pong from node1.
+    let n = node2.getNode(node1.localNode.id)
+    check:
+      n.isSome()
+      n.get().seen
+
+    await node1.closeWait()
+    await node2.closeWait()


### PR DESCRIPTION
When a node completes an inbound handshake and is newly inserted into the routing table, schedule an outbound ping within a random 0 to pingBackMax ms delay to mark it quicker as "seen" for FINDNODE responses


This should improve routing table filling / removing unreachable nodes quicker.

It should also help with a discv5 hive test that is a bit flaky currently.