### PR TITLE
discv5: reject ENRs with udp = 0 at Node.fromRecord

### DIFF
--- a/eth/p2p/discoveryv5/node.nim
+++ b/eth/p2p/discoveryv5/node.nim
@@ -41,7 +41,10 @@ func toNodeId*(pk: PublicKey): NodeId =
 func fromRecord*(T: type Node, r: Record): T =
   ## Create a new `Node` from a `Record`.
   let tr = TypedRecord.fromRecord(r)
-  if tr.ip.isSome() and tr.udp.isSome():
+  if tr.ip.isSome() and tr.udp.isSome() and tr.udp.get() != 0:
+    # Port 0 is reserved (RFC 6335) and not routable as a destination.
+    # Reject it here so peers with udp = 0 cannot enter the routing table
+    # nor be returned in NODES responses.
     let a = Address(ip: ipv4(tr.ip.get()), port: Port(tr.udp.get()))
 
     Node(id: r.publicKey.toNodeId(), pubkey: r.publicKey, record: r,

--- a/tests/fuzzing/discoveryv5/fuzz_decode_packet.nim
+++ b/tests/fuzzing/discoveryv5/fuzz_decode_packet.nim
@@ -34,4 +34,4 @@ test:
 
   let decoded = decodePacket(codecB, nodeA.address.get(), @iv & maskedHeader)
   if decoded.isErr():
-    debug "Error occurred", error = decoded.error
+    echo "Error occurred: " & $decoded.error

--- a/tests/fuzzing/enr/fuzz_enr.nim
+++ b/tests/fuzzing/enr/fuzz_enr.nim
@@ -11,15 +11,15 @@ test:
     # parsing will still be fuzzed.
     let decoded = try: rlp.decode(payload, enr.Record)
                   except RlpError as e:
-                        debug "decode failed", err = e.msg
+                        echo "decode failed: " & e.msg
                         break testBlock
                   except ValueError as e:
-                        debug "decode failed", err = e.msg
+                        echo "decode failed: " & e.msg
                         break testBlock
 
     let encoded = try: rlp.encode(decoded)
                   except RlpError as e:
-                    debug "decode failed", err = e.msg
+                    echo "decode failed: " & e.msg
                     doAssert(false, "decoding worked but encoding failed")
                     break testBlock
     if encoded != payload.toOpenArray(0, encoded.len - 1):

--- a/tests/fuzzing/rlp/rlp_decode.nim
+++ b/tests/fuzzing/rlp/rlp_decode.nim
@@ -1,5 +1,5 @@
 import
-  testutils/fuzzing, chronicles,
+  testutils/fuzzing,
   ../../../eth/rlp
 
 type
@@ -14,7 +14,7 @@ template testDecode(payload: openArray, T: type) =
   try:
     discard rlp.decode(payload, T)
   except RlpError as e:
-    debug "Decode failed", err = e.msg
+    echo "Decode failed: " & e.msg
 
 test:
   testDecode(payload, string)

--- a/tests/fuzzing/rlp/rlp_inspect.nim
+++ b/tests/fuzzing/rlp/rlp_inspect.nim
@@ -1,5 +1,5 @@
 import
-  testutils/fuzzing, chronicles,
+  testutils/fuzzing,
   ../../../eth/rlp
 
 test:
@@ -7,4 +7,4 @@ test:
     var rlp = rlpFromBytes(payload)
     discard rlp.inspect()
   except RlpError as e:
-    debug "Inspect failed", err = e.msg
+    echo "Inspect failed: " & e.msg

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -1132,3 +1132,52 @@ suite "Discovery v5.1 Tests":
 
     await node1.closeWait()
     await node2.closeWait()
+
+  test "verifyNodesRecords rejects ENRs with udp = 0":
+    let
+      port = Port(9000)
+      srcRecord = enr.Record.init(1, PrivateKey.random(rng[]),
+        Opt.some(parseIpAddress("127.0.0.1")),
+        Opt.some(port), Opt.some(port))[]
+      srcNode = Node.fromRecord(srcRecord)
+      pk = PrivateKey.random(rng[])
+      badRecord = enr.Record.init(1, pk,
+        Opt.some(parseIpAddress("127.0.0.1")),
+        Opt.some(Port(0)), Opt.some(Port(0)))[]
+      accepted = verifyNodesRecords([badRecord], srcNode, 16)
+    check accepted.len == 0
+
+  asyncTest "addNode rejects ENRs with udp = 0":
+    let
+      node = initDiscoveryNode(
+        rng, PrivateKey.random(rng[]), localAddress(20401))
+      badRecord = enr.Record.init(1, PrivateKey.random(rng[]),
+        Opt.some(parseIpAddress("127.0.0.1")),
+        Opt.some(Port(0)), Opt.some(Port(0)))[]
+    check not node.addNode(badRecord)
+    await node.closeWait()
+
+  asyncTest "FindNode does not return peers with udp = 0":
+    let
+      mainNode = initDiscoveryNode(
+        rng, PrivateKey.random(rng[]), localAddress(20404))
+      testNode = initDiscoveryNode(
+        rng, PrivateKey.random(rng[]), localAddress(20405))
+
+      badRecord = enr.Record.init(1, PrivateKey.random(rng[]),
+        Opt.some(parseIpAddress("127.0.0.1")),
+        Opt.some(Port(0)), Opt.some(Port(0)))[]
+      badNode = Node.fromRecord(badRecord)
+
+    discard mainNode.addSeenNode(badNode)
+
+    check (await testNode.ping(mainNode.localNode)).isOk()
+    check (await mainNode.ping(testNode.localNode)).isOk()
+
+    let dist = uint16(logDistance(mainNode.localNode.id, badNode.id))
+    let discovered = await testNode.findNode(mainNode.localNode, @[dist])
+    check discovered.isOk()
+    check badNode notin discovered.get()
+
+    await mainNode.closeWait()
+    await testNode.closeWait()


### PR DESCRIPTION
Port 0 is not routable as a UDP destination, but was being accepted by addNode, NODES responses, and during lookup.

Note that this will still allow nodes/ENRs to be provided via lookup / query with tcp/tcp6 (and udp6) fields set to 0. As will ENRs still be decoded fine with all those fields (including udp == 0).

For now it is up to the application to validate these, just like discv5 does here.

We could eventually decide to make ENR decoding step to fail on this, but the spec currently does not state this.