### PR TITLE
enr: support encode ENR field values based on their type

### DIFF
--- a/eth/enr/enr.nim
+++ b/eth/enr/enr.nim
@@ -84,12 +84,19 @@ type
 template toField[T](v: T): Field =
   when T is string:
     Field(kind: kString, str: v)
-  elif T is array:
-    Field(kind: kBytes, bytes: @v)
-  elif T is seq[byte]:
-    Field(kind: kBytes, bytes: v)
   elif T is SomeUnsignedInt:
     Field(kind: kNum, num: BiggestUInt(v))
+  elif T is seq[byte]:
+    Field(kind: kBytes, bytes: @v)
+  elif T is array:
+    when type(default(T)[low(T)]) is byte:
+      Field(kind: kBytes, bytes: @v)
+    else:
+      # A non-byte sequence is an RLP list
+      Field(kind: kList, listRaw: rlp.encode(v))
+  elif T is seq:
+    # A non-byte sequence is an RLP list
+    Field(kind: kList, listRaw: rlp.encode(v))
   elif T is object|tuple:
     Field(kind: kList, listRaw: rlp.encode(v))
   else:
@@ -111,6 +118,14 @@ func `==`(a, b: Field): bool =
 
 template toFieldPair*(key: string, value: auto): FieldPair =
   (key, toField(value))
+
+macro enrFields*(pairs: untyped{nkTableConstr}): untyped =
+  ## Build a list of `FieldPair`s from a `{key: value}` table constructor.
+  var res = nnkBracket.newTree()
+  for c in pairs:
+    c.expectKind(nnkExprColonExpr)
+    res.add newCall(bindSym"toFieldPair", c[0], c[1])
+  res
 
 func cmp(a, b: FieldPair): int = cmp(a[0], b[0])
 
@@ -373,6 +388,22 @@ func tryGet*(r: Record, key: string, T: type): Opt[T] =
   ## Return `none` if the key does not exist or if the value is invalid
   ## according to type `T`.
   get(r, key, T).optValue()
+
+func rawFieldValue*(r: Record, key: string): Opt[seq[byte]] =
+  ## Get the value of the field with the given `key` as its raw (as encoded on
+  ## the wire) RLP bytes. Returns `none` if the key does not exist.
+  try:
+    var rlp = rlpFromBytes(r.raw)
+    doAssert rlp.enterList()
+    rlp.skipElem() # signature
+    rlp.skipElem() # seqNum
+    while rlp.hasData:
+      if rlp.read(string) == key:
+        return Opt.some(@(rlp.rawData()))
+      rlp.skipElem() # value of a non matching field
+    Opt.none(seq[byte])
+  except RlpError as e:
+    raiseAssert "Record.raw must be valid RLP: " & e.msg
 
 func fromRecord*(T: type TypedRecord, r: Record): T =
   TypedRecord(

--- a/eth/p2p/discoveryv5/protocol.nim
+++ b/eth/p2p/discoveryv5/protocol.nim
@@ -273,12 +273,22 @@ func getRecord*(d: Protocol): Record =
   d.localNode.record
 
 func updateRecord*(
-    d: Protocol, enrFields: openArray[(string, seq[byte])]): DiscResult[void] =
-  ## Update the ENR of the local node with provided `enrFields` k:v pairs.
-  let fields = mapIt(enrFields, toFieldPair(it[0], it[1]))
+    d: Protocol, fields: openArray[FieldPair]): DiscResult[void] =
+  ## Update the ENR of the local node with provided `fields` k:v pairs.
+  ##
+  ## Build the `fields` with `enr.enrFields` (or `toFieldPair`) so each field's
+  ## RLP encoding is chosen based on its value type (e.g. list vs byte string).
   d.localNode.record.update(d.privateKey, extraFields = fields)
   # TODO: Would it make sense to actively ping ("broadcast") to all the peers
   # we stored a handshake with in order to get that ENR updated?
+
+func updateRecord*(
+    d: Protocol, fields: openArray[(string, seq[byte])]): DiscResult[void] =
+  ## Update the ENR of the local node with provided k:v pairs.
+  ##
+  ## Convenience overload where every value is a `seq[byte]`, stored as an RLP
+  ## byte string. For other encodings use the `openArray[FieldPair]` overload.
+  d.updateRecord(mapIt(fields, toFieldPair(it[0], it[1])))
 
 func getEnr*(d: Protocol, id: NodeId, address: Address): Opt[enr.Record] =
   d.codec.sessions.getEnr(id, address)

--- a/tests/p2p/test_discoveryv5.nim
+++ b/tests/p2p/test_discoveryv5.nim
@@ -380,7 +380,7 @@ suite "Discovery v5.1 Tests":
 
       targetSeqNum.inc()
       # need to add something to get the enr sequence number incremented
-      let update = targetNode.updateRecord({"addsomefield": @[byte 1]})
+      let update = targetNode.updateRecord(enrFields({"addsomefield": @[byte 1]}))
       check update.isOk()
 
       var n = mainNode.getNode(targetId)

--- a/tests/test_enr.nim
+++ b/tests/test_enr.nim
@@ -115,6 +115,19 @@ suite "ENR encoding tests":
       $enr.value == """(123, id: "v4", ip: 5.6.7.8, secp256k1: 0x02E51EFA66628CE09F689BC2B82F165A75A9DDECBB6A804BE15AC3FDF41F3B34E7, some_list: (Raw RLP list) 0xCE4883000102884869207468657265, udp: 1234)"""
       testRlpEncodingLoop(enr.value)
 
+  test "enrFields encodes values based on their type":
+    let
+      pk = KeyPair.random(rng[]).seckey
+      fields = enrFields({
+        "a_bytes": @[byte 0xAA, 0xBB],
+        "a_list": [1'u16, 2'u16, 3'u16],
+      })
+      record = Record.init(1, pk, extraFields = fields).expect("valid record")
+
+    check:
+      record.rawFieldValue("a_list").get() == hexToSeqByte("c3010203")
+      record.rawFieldValue("a_bytes").get() == hexToSeqByte("82aabb")
+
   test "Base64 encode loop":
     const encodedBase64 = "-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8"
     let res = Record.fromBase64(encodedBase64)


### PR DESCRIPTION
Add `enrFields` to build ENR fields whose RLP encoding follows the value type (byte string vs list).
And add an `updateRecord` `FieldPair` overload to set them.