### PR TITLE
Speed up the RLP length tracker

### DIFF
--- a/eth/rlp/hash_writer.nim
+++ b/eth/rlp/hash_writer.nim
@@ -1,5 +1,5 @@
 # eth
-# Copyright (c) 2019-2025 Status Research & Development GmbH
+# Copyright (c) 2019-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -29,8 +29,9 @@ func writeLength(writer: var RlpHashWriter, dataLen: int, baseMarker: byte) =
   if dataLen < THRESHOLD_LEN:
     writer.update(baseMarker + byte(dataLen))
   else:
-    writer.update(baseMarker + (THRESHOLD_LEN - 1) + byte(uint64(dataLen).bytesNeeded))
-    writer.updateBigEndian(uint64(dataLen), uint64(dataLen).bytesNeeded)
+    let lenBytes = uint64(dataLen).bytesNeeded
+    writer.update(baseMarker + (THRESHOLD_LEN - 1) + byte(lenBytes))
+    writer.updateBigEndian(uint64(dataLen), lenBytes)
 
 func writeInt*(writer: var RlpHashWriter, i: SomeUnsignedInt) =
   if i == typeof(i)(0):

--- a/eth/rlp/length_writer.nim
+++ b/eth/rlp/length_writer.nim
@@ -76,18 +76,10 @@ proc processListCounter(self: var RlpLengthTracker, item: Opt[PendingListItem]):
     return false
 
 proc decrementCounters(self: var RlpLengthTracker, isSelfEncoding: bool) =
-  # This runs after every encoded item. `wrapEncoding` is the only thing that
-  # puts a wrapped encoding in flight, so most encodings never have one and can
-  # take the loop below, which does the same work as the general case without
-  # the wrap bookkeeping. `isSelfEncoding` only ever feeds `processWrapCounter`,
-  # so it does not matter while there is no wrapped encoding to close.
   if self.wrappedEncodings.isEmpty():
-    # Items left in the innermost list - nothing to close, just count down
     if self.pendingLists.decrementTop():
       return
 
-    # The innermost list ran out of items; closing it may in turn use up the
-    # last item of the list enclosing it, and so on outwards
     while true:
       let item = self.pendingLists.pop(PendingListItem)
       if item.isNone():
@@ -148,9 +140,6 @@ proc startList*(self: var RlpLengthTracker, listSize: int) =
     # open a list = push a list on the stack with count value as the list size
     self.pendingLists.push((self.lengths.len, self.totalLength), listSize)
 
-    # `add` rather than `setLen` - the slot is filled in when the list is
-    # closed, and growing a seq one item at a time is markedly cheaper through
-    # `add`, which grows geometrically
     self.lengths.add(0)
 
 # next item encoded will not decrement list or wrap counters
@@ -199,8 +188,6 @@ proc appendDetached*(self: var RlpLengthTracker, data: byte) =
   # self.decrementCounters(false)
 
 func initLengthTracker*(self: var RlpLengthTracker) =
-  # reserve room for the list lengths up front so that the first few lists do
-  # not each have to grow the seq
   when self is DynamicRlpLengthTracker:
     self.pendingLists.init(STACK_LENGTH, PendingListItem)
   self.lengths = newSeqOfCap[int](LIST_LENGTH)

--- a/eth/rlp/length_writer.nim
+++ b/eth/rlp/length_writer.nim
@@ -1,5 +1,5 @@
 # eth
-# Copyright (c) 2019-2025 Status Research & Development GmbH
+# Copyright (c) 2019-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -76,6 +76,30 @@ proc processListCounter(self: var RlpLengthTracker, item: Opt[PendingListItem]):
     return false
 
 proc decrementCounters(self: var RlpLengthTracker, isSelfEncoding: bool) =
+  # This runs after every encoded item. `wrapEncoding` is the only thing that
+  # puts a wrapped encoding in flight, so most encodings never have one and can
+  # take the loop below, which does the same work as the general case without
+  # the wrap bookkeeping. `isSelfEncoding` only ever feeds `processWrapCounter`,
+  # so it does not matter while there is no wrapped encoding to close.
+  if self.wrappedEncodings.isEmpty():
+    # Items left in the innermost list - nothing to close, just count down
+    if self.pendingLists.decrementTop():
+      return
+
+    # The innermost list ran out of items; closing it may in turn use up the
+    # last item of the list enclosing it, and so on outwards
+    while true:
+      let item = self.pendingLists.pop(PendingListItem)
+      if item.isNone():
+        return
+
+      let
+        i = item.unsafeGet()
+        listLen = self.totalLength - i.startLen
+
+      self.lengths[i.idx] = listLen
+      self.totalLength += prefixLength(listLen)
+
   var
     wrapStatus = true
     listStatus = true
@@ -124,7 +148,10 @@ proc startList*(self: var RlpLengthTracker, listSize: int) =
     # open a list = push a list on the stack with count value as the list size
     self.pendingLists.push((self.lengths.len, self.totalLength), listSize)
 
-    self.lengths.setLen(self.lengths.len + 1)
+    # `add` rather than `setLen` - the slot is filled in when the list is
+    # closed, and growing a seq one item at a time is markedly cheaper through
+    # `add`, which grows geometrically
+    self.lengths.add(0)
 
 # next item encoded will not decrement list or wrap counters
 
@@ -132,7 +159,7 @@ proc wrapEncoding*(self: var RlpLengthTracker, numOfEncodings: int) =
   self.wrappedEncodings.push(
     (self.wrapLengths.len, self.lengths.len, self.totalLength), numOfEncodings
   )
-  self.wrapLengths.setLen(self.wrapLengths.len + 1)
+  self.wrapLengths.add(0)
 
 func writeBlob*(self: var RlpLengthTracker, data: openArray[byte]) =
   let isSelfEncoding = data.len == 1 and byte(data[0]) < BLOB_START_MARKER
@@ -152,7 +179,8 @@ func writeInt*(self: var RlpLengthTracker, i: SomeUnsignedInt) =
   elif i == typeof(i)(0):
     self.totalLength += 1
   else:
-    self.totalLength += prefixLength(i.bytesNeeded) + i.bytesNeeded
+    let lenBytes = i.bytesNeeded
+    self.totalLength += prefixLength(lenBytes) + lenBytes
 
   self.decrementCounters(isSelfEncoding)
 
@@ -171,8 +199,8 @@ proc appendDetached*(self: var RlpLengthTracker, data: byte) =
   # self.decrementCounters(false)
 
 func initLengthTracker*(self: var RlpLengthTracker) =
-  # we preset the lengths since we want to skip using add method for
-  # these lists
+  # reserve room for the list lengths up front so that the first few lists do
+  # not each have to grow the seq
   when self is DynamicRlpLengthTracker:
     self.pendingLists.init(STACK_LENGTH, PendingListItem)
   self.lengths = newSeqOfCap[int](LIST_LENGTH)

--- a/eth/rlp/stacked_counters.nim
+++ b/eth/rlp/stacked_counters.nim
@@ -15,6 +15,34 @@ proc push*[T](self: var StaticStackedCounters, item: T, count: int) =
 proc push*[T](self: var DynamicStackedCounters, item: T, count: int) =
   self.stack.add((item, count))
 
+func isEmpty*(self: StaticStackedCounters): bool {.inline.} =
+  self.top == 0
+
+func isEmpty*(self: DynamicStackedCounters): bool {.inline.} =
+  self.stack.len == 0
+
+func decrementTop*(self: var StaticStackedCounters): bool {.inline.} =
+  ## Decrement the innermost counter, returning true when it is left non-zero.
+  ## Returns false without touching anything when there is no counter or when
+  ## the counter is about to reach zero, leaving those cases - which have to
+  ## close the item and update the enclosing counters - to `pop`.
+  if self.top > 0:
+    let count = addr self.stack[self.top - 1].count
+    if count[] > 1:
+      count[] -= 1
+      return true
+  false
+
+func decrementTop*(self: var DynamicStackedCounters): bool {.inline.} =
+  ## See `decrementTop` for `StaticStackedCounters`.
+  let top = self.stack.len
+  if top > 0:
+    let count = addr self.stack[top - 1].count
+    if count[] > 1:
+      count[] -= 1
+      return true
+  false
+
 proc peek*(self: var StaticStackedCounters, T: type): Opt[T] =
   if self.top > 0:
     return Opt.some(self.stack[self.top - 1].item)

--- a/eth/rlp/stacked_counters.nim
+++ b/eth/rlp/stacked_counters.nim
@@ -22,10 +22,6 @@ func isEmpty*(self: DynamicStackedCounters): bool {.inline.} =
   self.stack.len == 0
 
 func decrementTop*(self: var StaticStackedCounters): bool {.inline.} =
-  ## Decrement the innermost counter, returning true when it is left non-zero.
-  ## Returns false without touching anything when there is no counter or when
-  ## the counter is about to reach zero, leaving those cases - which have to
-  ## close the item and update the enclosing counters - to `pop`.
   if self.top > 0:
     let count = addr self.stack[self.top - 1].count
     if count[] > 1:
@@ -34,7 +30,6 @@ func decrementTop*(self: var StaticStackedCounters): bool {.inline.} =
   false
 
 func decrementTop*(self: var DynamicStackedCounters): bool {.inline.} =
-  ## See `decrementTop` for `StaticStackedCounters`.
   let top = self.stack.len
   if top > 0:
     let count = addr self.stack[top - 1].count

--- a/eth/rlp/two_pass_writer.nim
+++ b/eth/rlp/two_pass_writer.nim
@@ -1,5 +1,5 @@
 # eth
-# Copyright (c) 2019-2025 Status Research & Development GmbH
+# Copyright (c) 2019-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -31,8 +31,9 @@ func writeLength(writer: var RlpTwoPassWriter, dataLen: int, baseMarker: byte) =
   if dataLen < THRESHOLD_LEN:
     writer.update(baseMarker + byte(dataLen))
   else:
-    writer.update(baseMarker + (THRESHOLD_LEN - 1) + byte(uint64(dataLen).bytesNeeded))
-    writer.updateBigEndian(uint64(dataLen), uint64(dataLen).bytesNeeded)
+    let lenBytes = uint64(dataLen).bytesNeeded
+    writer.update(baseMarker + (THRESHOLD_LEN - 1) + byte(lenBytes))
+    writer.updateBigEndian(uint64(dataLen), lenBytes)
 
 func writeInt*(writer: var RlpTwoPassWriter, i: SomeUnsignedInt) =
   if i == typeof(i)(0):

--- a/eth/rlp/utils.nim
+++ b/eth/rlp/utils.nim
@@ -9,10 +9,6 @@ import std/bitops, ./priv/defs
 
 func bytesNeeded*(num: SomeUnsignedInt): int {.inline.} =
   # Number of non-zero bytes in the big endian encoding
-  #
-  # `countLeadingZeroBits` is undefined for zero, hence the branch - going
-  # through a leading-zero count that encodes zero as a sentinel instead costs
-  # several times as much because it cannot fold into a single instruction
   if num == typeof(num)(0):
     0
   else:

--- a/eth/rlp/utils.nim
+++ b/eth/rlp/utils.nim
@@ -1,15 +1,22 @@
 # eth
-# Copyright (c) 2019-2025 Status Research & Development GmbH
+# Copyright (c) 2019-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import stew/[bitops2], ./priv/defs
+import std/bitops, ./priv/defs
 
-func bytesNeeded*(num: SomeUnsignedInt): int =
+func bytesNeeded*(num: SomeUnsignedInt): int {.inline.} =
   # Number of non-zero bytes in the big endian encoding
-  sizeof(num) - (num.leadingZeros() shr 3)
+  #
+  # `countLeadingZeroBits` is undefined for zero, hence the branch - going
+  # through a leading-zero count that encodes zero as a sentinel instead costs
+  # several times as much because it cannot fold into a single instruction
+  if num == typeof(num)(0):
+    0
+  else:
+    sizeof(num) - (countLeadingZeroBits(num) shr 3)
 
 func writeBigEndian*(
     outStream: var auto, number: SomeUnsignedInt, lastByteIdx: int, numberOfBytes: int

--- a/tests/rlp/all_tests.nim
+++ b/tests/rlp/all_tests.nim
@@ -5,4 +5,5 @@ import
   ./test_object_serialization,
   ./test_optional_fields,
   ./test_hashes,
+  ./test_length_tracker,
   ./test_rlp_profiler

--- a/tests/rlp/test_length_tracker.nim
+++ b/tests/rlp/test_length_tracker.nim
@@ -1,0 +1,122 @@
+# eth
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  std/random,
+  ../../eth/[rlp, common],
+  unittest2
+
+# `encode`, `getEncodedLength` and `computeRlpHash` all measure the encoding
+# with `RlpLengthTracker` before writing it. `RlpDefaultWriter` instead writes
+# the payload first and shifts it to make room for the prefix, so it never
+# consults the tracker - which makes it an independent oracle for everything
+# the tracker produces.
+
+proc encodeDirect[T](v: T): seq[byte] =
+  var writer = initRlpWriter()
+  writer.append(v)
+  move(writer.finish)
+
+template checkAgainstDirect(v: untyped) =
+  let expected = encodeDirect(v)
+  check:
+    rlp.encode(v) == expected
+    getEncodedLength(v) == expected.len
+    computeRlpHash(v) == keccak256(expected)
+
+suite "RLP length tracker":
+  test "integers":
+    for i in [0'u64, 1, 2, 55, 56, 57, 127, 128, 129, 255, 256, 257, 65535,
+              65536, 1'u64 shl 32, 1'u64 shl 56, high(uint64)]:
+      checkAgainstDirect(i)
+      checkAgainstDirect(@[i])
+      checkAgainstDirect(@[i, i, i])
+
+  test "blobs across the length prefix boundaries":
+    for n in [0, 1, 2, 54, 55, 56, 57, 254, 255, 256, 257, 65534, 65535,
+              65536, 65537]:
+      var blob = newSeq[byte](n)
+      for i in 0 ..< n:
+        blob[i] = byte(i)
+      checkAgainstDirect(blob)
+      checkAgainstDirect(@[blob])
+
+  test "single byte blobs are their own encoding below the blob marker":
+    for b in [0'u8, 1, 126, 127, 128, 129, 255]:
+      checkAgainstDirect(@[b])
+      checkAgainstDirect(@[@[b]])
+      checkAgainstDirect(@[@[@[b]]])
+
+  test "empty and nested lists":
+    checkAgainstDirect(newSeq[uint64]())
+    checkAgainstDirect(@[newSeq[uint64]()])
+    checkAgainstDirect(@[newSeq[uint64](), newSeq[uint64]()])
+    checkAgainstDirect(@[@[newSeq[uint64]()]])
+    checkAgainstDirect(@[@[@[newSeq[byte]()]]])
+
+  test "deep nesting closes the enclosing lists in order":
+    # a list whose last element is itself a list cascades the closing outwards,
+    # which is the path the tracker takes when a counter reaches zero
+    checkAgainstDirect(@[@[@[@[@[@[@[1'u64]]]]]]])
+    checkAgainstDirect(@[@[@[1'u64, 2], @[3'u64]], @[@[4'u64]]])
+    checkAgainstDirect(@[@[@[newSeq[uint64]()]], @[newSeq[seq[uint64]]()]])
+
+  test "lists long enough to need a multi byte length prefix":
+    var many: seq[uint64]
+    for i in 0 ..< 200:
+      many.add uint64(i) * 1_000_000
+    checkAgainstDirect(many)
+
+    var nested: seq[seq[uint64]]
+    for i in 0 ..< 200:
+      nested.add @[uint64(i), uint64(i) * 1_000_000]
+    checkAgainstDirect(nested)
+
+  test "randomised nested structures":
+    var rng = initRand(0x1234)
+    for _ in 0 ..< 2000:
+      var outer: seq[seq[seq[uint64]]]
+      for a in 0 ..< rng.rand(4):
+        var mid: seq[seq[uint64]]
+        for b in 0 ..< rng.rand(4):
+          var inner: seq[uint64]
+          for c in 0 ..< rng.rand(5):
+            # cover self encoding, single byte and multi byte integers
+            inner.add(
+              case rng.rand(2)
+              of 0: uint64(rng.rand(127))
+              of 1: uint64(rng.rand(255))
+              else: uint64(rng.rand(int.high))
+            )
+          mid.add inner
+        outer.add mid
+      checkAgainstDirect(outer)
+
+  test "randomised blobs":
+    var rng = initRand(0x5678)
+    for _ in 0 ..< 2000:
+      var outer: seq[seq[byte]]
+      for a in 0 ..< rng.rand(5):
+        var blob = newSeq[byte](rng.rand(80))
+        for i in 0 ..< blob.len:
+          blob[i] = byte(rng.rand(255))
+        outer.add blob
+      checkAgainstDirect(outer)
+
+  test "objects":
+    checkAgainstDirect(Header(number: 21_000_000'u64, gasLimit: 30_000_000'u64))
+    checkAgainstDirect(
+      Account(nonce: 42, balance: high(UInt256))
+    )
+    checkAgainstDirect(
+      @[
+        Header(number: 1'u64, extraData: newSeq[byte](64)),
+        Header(number: high(uint64), extraData: newSeq[byte](0)),
+      ]
+    )

--- a/tests/rlp/test_length_tracker.nim
+++ b/tests/rlp/test_length_tracker.nim
@@ -12,12 +12,6 @@ import
   ../../eth/[rlp, common],
   unittest2
 
-# `encode`, `getEncodedLength` and `computeRlpHash` all measure the encoding
-# with `RlpLengthTracker` before writing it. `RlpDefaultWriter` instead writes
-# the payload first and shifts it to make room for the prefix, so it never
-# consults the tracker - which makes it an independent oracle for everything
-# the tracker produces.
-
 proc encodeDirect[T](v: T): seq[byte] =
   var writer = initRlpWriter()
   writer.append(v)
@@ -61,8 +55,6 @@ suite "RLP length tracker":
     checkAgainstDirect(@[@[@[newSeq[byte]()]]])
 
   test "deep nesting closes the enclosing lists in order":
-    # a list whose last element is itself a list cascades the closing outwards,
-    # which is the path the tracker takes when a counter reaches zero
     checkAgainstDirect(@[@[@[@[@[@[@[1'u64]]]]]]])
     checkAgainstDirect(@[@[@[1'u64, 2], @[3'u64]], @[@[4'u64]]])
     checkAgainstDirect(@[@[@[newSeq[uint64]()]], @[newSeq[seq[uint64]]()]])
@@ -87,7 +79,6 @@ suite "RLP length tracker":
         for b in 0 ..< rng.rand(4):
           var inner: seq[uint64]
           for c in 0 ..< rng.rand(5):
-            # cover self encoding, single byte and multi byte integers
             inner.add(
               case rng.rand(2)
               of 0: uint64(rng.rand(127))


### PR DESCRIPTION
This change results in approx ~2.4x speedup at the length-tracker level and approx ~1.7x speedup for full RLP encoding.

| mode | workload | master | branch | speedup |
|---|---|---:|---:|---:|
| tracker | header | 189.8 ns | 79.0 ns | 2.40x |
| tracker | tx-legacy | 123.1 ns | 66.6 ns | 1.85x |
| tracker | tx-1559 + access list | 312.1 ns | 134.5 ns | 2.32x |
| tracker | block, 8 txs | 1.22 µs | 539 ns | 2.25x |
| tracker | block, 320 txs | 38.27 µs | 15.97 µs | 2.40x |
| tracker | block, 320 1559-txs | 162.29 µs | 93.28 µs | 1.74x |
| tracker | 256 real mainnet blocks | 380.88 µs | 126.04 µs | 3.02x |
| tracker | nested lists (64×4×4) | 16.86 µs | 5.19 µs | 3.25x |
| tracker | **geomean** | | | **2.36x** |
| encode | header | 324.2 ns | 211.0 ns | 1.54x |
| encode | tx-legacy | 208.4 ns | 155.8 ns | 1.34x |
| encode | tx-1559 + access list | 492.1 ns | 289.4 ns | 1.70x |
| encode | block, 8 txs | 1.99 µs | 1.18 µs | 1.68x |
| encode | block, 320 txs | 62.09 µs | 35.31 µs | 1.76x |
| encode | block, 320 1559-txs | 327.10 µs | 191.38 µs | 1.71x |
| encode | 256 real mainnet blocks | 597.02 µs | 305.16 µs | 1.96x |
| encode | nested lists | 25.19 µs | 11.01 µs | 2.29x |
| encode | **geomean** | | | **1.73x** |