### PR TITLE
Use rapidhash for Address and FixedBytes hashes

### DIFF
--- a/eth/common/addresses.nim
+++ b/eth/common/addresses.nim
@@ -10,7 +10,7 @@
 ## 20-byte ethereum account address, as derived from the keypair controlling it
 ## https://ethereum.org/en/developers/docs/accounts/#account-creation
 
-import std/[typetraits, hashes as std_hashes], "."/[base, hashes], stew/assign2
+import std/[typetraits, hashes as std_hashes], ../keccak/rapidhash,  ./[base, hashes], stew/assign2
 
 export hashes
 
@@ -58,16 +58,7 @@ template default*(_: type Address): Address =
 func `==`*(a, b: Address): bool {.borrow.}
 
 func hash*(a: Address): Hash {.inline.} =
-  # Addresses are more or less random so we should not need a fancy mixing
-  # function
-  var a0 {.noinit.}, a1 {.noinit.}: uint64
-  var a2 {.noinit.}: uint32
-
-  copyMem(addr a0, unsafeAddr a.data[0], sizeof(a0))
-  copyMem(addr a1, unsafeAddr a.data[8], sizeof(a1))
-  copyMem(addr a2, unsafeAddr a.data[16], sizeof(a2))
-
-  cast[Hash](a0 + a1 + uint64(a2))
+  cast[Hash](rapidhashNano(a.data)) 
 
 func toHex*(a: Address): string {.borrow.}
 func to0xHex*(a: Address): string {.borrow.}

--- a/eth/common/base.nim
+++ b/eth/common/base.nim
@@ -21,7 +21,8 @@ import
   std/[hashes, macros, typetraits],
   stint,
   results,
-  stew/[assign2, byteutils, endians2, staticfor]
+  stew/[assign2, byteutils, endians2],
+  ../keccak/rapidhash
 
 export stint, hashes, results
 
@@ -85,17 +86,12 @@ func `==`*(a, b: FixedBytes): bool {.inline.} =
   equalMem(addr a.data[0], addr b.data[0], a.N)
 
 func hash*[N: static int](v: FixedBytes[N]): Hash {.inline.} =
-  copyMem(addr result, addr v.data[0], min(N, sizeof(Hash)))
-
-  when N > sizeof(Hash):
-    var tmp: Hash
-    staticFor i, 1 ..< N div sizeof(Hash):
-      copyMem(addr tmp, addr v.data[i * sizeof(Hash)], sizeof(Hash))
-      result = result !& tmp
-    const last = N mod sizeof(Hash)
-    when last > 0:
-      copyMem(addr tmp, addr v.data[N - last], last)
-      result !& tmp
+  when N <= 48:
+    cast[Hash](rapidhashNano(v.data))
+  elif N <= 512:
+    cast[Hash](rapidhashMicro(v.data))
+  else:
+    cast[Hash](rapidhash(v.data))
 
 func toHex*(v: FixedBytes): string =
   ## Convert to lowercase hex without 0x prefix


### PR DESCRIPTION
Addresses are not always uniformly distributed. For example the EVM BALANCE opcode allows fetching the balance for any given address which may or may not exist. This means Tables can hit a worst case performance of 0(n) for lookups under certain conditions if the addresses are not uniform.