### PR TITLE
fix 32-bit int overflows based on threadId()

### DIFF
--- a/eth/db/kvstore.nim
+++ b/eth/db/kvstore.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -8,7 +8,7 @@
 ## Simple Key-Value store database interface that allows creating multiple
 ## tables within each store
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 {.pragma: callback, gcsafe, raises: [].}
 
 import
@@ -154,32 +154,32 @@ proc find*(
 
   ok(total)
 
-proc del*(db: MemStoreRef, key: openArray[byte]): KvResult[bool] =
+func del*(db: MemStoreRef, key: openArray[byte]): KvResult[bool] =
   if @key in db.records:
     db.records.del(@key)
     ok(true)
   else:
     ok(false)
 
-proc clear*(db: MemStoreRef): KvResult[bool] =
+func clear*(db: MemStoreRef): KvResult[bool] =
   if db.records.len > 0:
     db.records.clear()
     ok(true)
   else:
     ok(false)
 
-proc contains*(db: MemStoreRef, key: openArray[byte]): KvResult[bool] =
+func contains*(db: MemStoreRef, key: openArray[byte]): KvResult[bool] =
   ok(db.records.contains(@key))
 
-proc put*(db: MemStoreRef, key, val: openArray[byte]): KvResult[void] =
+func put*(db: MemStoreRef, key, val: openArray[byte]): KvResult[void] =
   db.records[@key] = @val
   ok()
 
-proc close*(db: MemStoreRef): KvResult[void] =
+func close*(db: MemStoreRef): KvResult[void] =
   db.records.clear()
   ok()
 
-proc init*(T: type MemStoreRef): T =
+func init*(T: type MemStoreRef): T =
   T(
-    records: initTable[seq[byte], seq[byte]]()
+    records: Table[seq[byte], seq[byte]]()
   )

--- a/eth/net/nat.nim
+++ b/eth/net/nat.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Copyright (c) 2019-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -45,7 +45,7 @@ var
   upnp {.threadvar.}: Miniupnp
   npmp {.threadvar.}: NatPmp
   strategy = NatNone
-  portMapping = initTable[PortSpec, PortSpec]()
+  portMapping: Table[PortSpec, PortSpec]
 
 logScope:
   topics = "eth net nat"
@@ -512,10 +512,10 @@ func `==`*(a, b: NatConfig): bool =
   of true: a.extIp == b.extIp
   of false: a.nat == b.nat
 
-proc toPort*(p: PortSpec): Port =
+func toPort*(p: PortSpec): Port =
   p.port
 
-proc toPort*(p: Opt[PortSpec]): Opt[Port] =
+func toPort*(p: Opt[PortSpec]): Opt[Port] =
   if p.isSome:
     Opt.some(p.get().port)
   else:

--- a/eth/p2p/discoveryv5/routing_table.nim
+++ b/eth/p2p/discoveryv5/routing_table.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   std/[algorithm, times, sequtils, bitops, sets, tables],
@@ -201,7 +201,7 @@ func ipLimitDec(r: var RoutingTable, b: KBucket, n: Node) =
   r.ipLimits.dec(ip)
 
 func getNode*(r: RoutingTable, id: NodeId): Opt[Node]
-proc replaceNode*(r: var RoutingTable, n: Node) {.gcsafe.}
+proc replaceNode*(r: var RoutingTable, n: Node)
 
 proc banNode*(r: var RoutingTable, nodeId: NodeId, period: chronos.Duration) =
   ## Ban a node from the routing table for the given period. The node is removed
@@ -334,7 +334,7 @@ func init*(T: type RoutingTable, localNode: Node, bitsPerHop = DefaultBitsPerHop
     ipLimits: IpLimits(limit: ipLimits.tableIpLimit),
     distanceCalculator: distanceCalculator,
     rng: rng,
-    bannedNodes: initTable[NodeId, chronos.Moment]())
+    bannedNodes: Table[NodeId, chronos.Moment]())
 
 func splitBucket(r: var RoutingTable, index: int) =
   let bucket = r.buckets[index]
@@ -499,7 +499,7 @@ func bucketsByDistanceTo(r: RoutingTable, id: NodeId): seq[KBucket] =
 func nodesByDistanceTo(r: RoutingTable, k: KBucket, id: NodeId): seq[Node] =
   sortedByIt(k.nodes, r.distance(it.id, id))
 
-proc neighbours*(
+func neighbours*(
     r: RoutingTable,
     id: NodeId,
     k: int = BUCKET_SIZE,

--- a/eth/trie/db.nim
+++ b/eth/trie/db.nim
@@ -1,16 +1,15 @@
 # nim-eth
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   std/[tables, hashes, sets],
-  "."/[trie_defs, db_tracing]
+  ./[trie_defs, db_tracing]
 
 type
   MemDBRec = object
@@ -56,16 +55,16 @@ type
 
   TransactionID* = distinct DbTransaction
 
-proc put*(db: TrieDatabaseRef, key, val: openArray[byte]) {.gcsafe.}
-proc get*(db: TrieDatabaseRef, key: openArray[byte]): seq[byte] {.gcsafe.}
-proc del*(db: TrieDatabaseRef, key: openArray[byte]) {.gcsafe.}
-proc beginTransaction*(db: TrieDatabaseRef): DbTransaction {.gcsafe.}
+proc put*(db: TrieDatabaseRef, key, val: openArray[byte])
+proc get*(db: TrieDatabaseRef, key: openArray[byte]): seq[byte]
+proc del*(db: TrieDatabaseRef, key: openArray[byte])
+func beginTransaction*(db: TrieDatabaseRef): DbTransaction
 
-proc get*(db: MemoryLayer, key: openArray[byte]): seq[byte] =
+func get*(db: MemoryLayer, key: openArray[byte]): seq[byte] =
   result = db.records.getOrDefault(@key).value
   traceGet key, result
 
-proc del*(db: MemoryLayer, key: openArray[byte]) =
+func del*(db: MemoryLayer, key: openArray[byte]) =
   traceDel key
 
   # The database should ensure that the empty key is always active:
@@ -80,10 +79,10 @@ proc del*(db: MemoryLayer, key: openArray[byte]) =
         db.records.del(key)
         db.deleted.incl(key)
 
-proc contains*(db: MemoryLayer, key: openArray[byte]): bool =
+func contains*(db: MemoryLayer, key: openArray[byte]): bool =
   db.records.hasKey(@key)
 
-proc put*(db: MemoryLayer, key, val: openArray[byte]) =
+func put*(db: MemoryLayer, key, val: openArray[byte]) =
   tracePut key, val
 
   # TODO: This is quite inefficient and it won't be necessary once
@@ -103,10 +102,10 @@ proc put*(db: MemoryLayer, key, val: openArray[byte]) =
     do:
       db.records[key] = MemDBRec(refCount: 1, value: @val)
 
-proc newMemoryLayer: MemoryLayer =
+func newMemoryLayer: MemoryLayer =
   result.new
-  result.records = initTable[seq[byte], MemDBRec]()
-  result.deleted = initHashSet[seq[byte]]()
+  result.records = Table[seq[byte], MemDBRec]()
+  result.deleted = HashSet[seq[byte]]()
 
 proc commit(memDb: MemoryLayer, db: TrieDatabaseRef, applyDeletes: bool = true) =
   if applyDeletes:
@@ -116,7 +115,7 @@ proc commit(memDb: MemoryLayer, db: TrieDatabaseRef, applyDeletes: bool = true) 
   for k, v in memDb.records:
     db.put(k, v.value)
 
-proc init(db: var MemoryLayer) =
+func init(db: var MemoryLayer) =
   db = newMemoryLayer()
 
 proc newMemoryDB*: TrieDatabaseRef =
@@ -130,7 +129,7 @@ template isMemoryDB(db: TrieDatabaseRef): bool =
     db.mostInnerTransaction != nil and
     db.mostInnerTransaction.parentTransaction == nil
 
-proc totalRecordsInMemoryDB*(db: TrieDatabaseRef): int =
+func totalRecordsInMemoryDB*(db: TrieDatabaseRef): int =
   doAssert isMemoryDB(db)
   return db.mostInnerTransaction.modifications.records.len
 
@@ -139,7 +138,7 @@ iterator pairsInMemoryDB*(db: TrieDatabaseRef): (seq[byte], seq[byte]) =
   for k, v in db.mostInnerTransaction.modifications.records:
     yield (k, v.value)
 
-proc beginTransaction*(db: TrieDatabaseRef): DbTransaction =
+func beginTransaction*(db: TrieDatabaseRef): DbTransaction =
   new result
   result.db = db
   init result.modifications
@@ -147,7 +146,7 @@ proc beginTransaction*(db: TrieDatabaseRef): DbTransaction =
   result.parentTransaction = db.mostInnerTransaction
   db.mostInnerTransaction = result
 
-proc rollback*(t: DbTransaction) =
+func rollback*(t: DbTransaction) =
   # Transactions should be handled in a strictly nested fashion.
   # Any child transaction must be committed or rolled-back before
   # its parent transactions:
@@ -164,11 +163,11 @@ proc commit*(t: DbTransaction, applyDeletes: bool = true) =
   t.modifications.commit(t.db, applyDeletes)
   t.state = Committed
 
-proc dispose*(t: DbTransaction) {.inline.} =
+func dispose*(t: DbTransaction) {.inline.} =
   if t.state == Pending:
     t.rollback()
 
-proc safeDispose*(t: DbTransaction) {.inline.} =
+func safeDispose*(t: DbTransaction) {.inline.} =
   if (not isNil(t)) and (t.state == Pending):
     t.rollback()
 
@@ -188,7 +187,7 @@ proc containsImpl[T](db: RootRef, key: openArray[byte]): bool =
   mixin contains
   return contains(T(db), key)
 
-proc trieDB*[T: RootRef](x: T): TrieDatabaseRef =
+func trieDB*[T: RootRef](x: T): TrieDatabaseRef =
   mixin del, get, put
 
   new result
@@ -248,10 +247,10 @@ proc contains*(db: TrieDatabaseRef, key: openArray[byte]): bool =
 # this is useful when we need to jump back to specific point
 # in history where the database still in 'original' state
 # and retrieve data from that point
-proc getTransactionID*(db: TrieDatabaseRef): TransactionID =
+func getTransactionID*(db: TrieDatabaseRef): TransactionID =
   TransactionID(db.mostInnerTransaction)
 
-proc setTransactionID*(db: TrieDatabaseRef, id: TransactionID) =
+func setTransactionID*(db: TrieDatabaseRef, id: TransactionID) =
   db.mostInnerTransaction = DbTransaction(id)
 
 template shortTimeReadOnly*(db: TrieDatabaseRef, id: TransactionID, body: untyped) =

--- a/tests/keccak/test_fixed_cache.nim
+++ b/tests/keccak/test_fixed_cache.nim
@@ -229,7 +229,7 @@ when compileOption("threads"):
     discard s.wrong.fetchAdd(localWrong, moRelaxed)
 
   proc writerLoop(s: ptr Shared) {.thread.} =
-    var rng = initRand(getThreadId() * 7919)
+    var rng = initRand(int64(getThreadId()) * 7919)
     for _ in 0 ..< OpsPerThread:
       let k = keyFor(rng.rand(0 ..< HotKeys))
       s.cache[].put(k, valueFor(k))
@@ -237,7 +237,7 @@ when compileOption("threads"):
   proc wideWriterLoop(s: ptr Shared) {.thread.} =
     ## Writes over a key space several times larger than the cache, so writers
     ## constantly evict each other's entries as well as their own.
-    var rng = initRand(getThreadId() * 104729)
+    var rng = initRand(int64(getThreadId()) * 104729)
     for _ in 0 ..< OpsPerThread:
       let k = keyFor(rng.rand(0 ..< 4 * TestEntries))
       s.cache[].put(k, valueFor(k))
@@ -247,7 +247,7 @@ when compileOption("threads"):
     ## `getBySlot` with the same view - as the keccak cache does, rather than
     ## through the owned-key `get`.
     var
-      rng = initRand(getThreadId() * 31 + 1)
+      rng = initRand(int64(getThreadId()) * 31 + 1)
       localHits = 0
       localMisses = 0
       localWrong = 0

--- a/tests/keccak/test_fixed_cache_fuzz.nim
+++ b/tests/keccak/test_fixed_cache_fuzz.nim
@@ -82,7 +82,7 @@ func wideKey(n: int): Key =
   ## always inside the compared prefix.
   keyFor(n, 8 + (n mod 80))
 
-proc randomVal(rng: var Rand): Val =
+func randomVal(rng: var Rand): Val =
   var v: Val
   for i in 0 ..< v.len:
     v[i] = byte(rng.rand(0 .. 255))
@@ -99,7 +99,7 @@ proc modelFuzz(capacity, rounds: int, seed: int64,
   ## Returns (hits, wrongs); every hit was checked against the model.
   var
     cache: FixedCache[Key, Val]
-    model = initTable[Key, Val]()
+    model: Table[Key, Val]
     rng = initRand(seed)
     hits = 0
     wrongs = 0
@@ -167,7 +167,7 @@ suite "FixedCache fuzz, single-threaded":
     # only in tag bits.
     var
       cache: FixedCache[uint64, uint64]
-      model = initTable[uint64, uint64]()
+      model: Table[uint64, uint64]
       rng = initRand(fcFuzzSeed + 3)
       hits = 0
     cache.init(ProdEntries)
@@ -260,7 +260,7 @@ when compileOption("threads"):
     ## Every thread both reads and writes, so the same bucket sees read/read,
     ## read/write and write/write races rather than fixed roles.
     var
-      rng = initRand(getThreadId() * 2654435761)
+      rng = initRand(int64(getThreadId()) * 2654435761)
       localHits = 0
       localMisses = 0
       localWrong = 0
@@ -343,7 +343,7 @@ when compileOption("threads"):
 
   proc narrowLoop(s: ptr SharedN) {.thread.} =
     var
-      rng = initRand(getThreadId() * 48271)
+      rng = initRand(int64(getThreadId()) * 48271)
       localHits = 0
       localWrong = 0
     for _ in 0 ..< fcFuzzThreadOps:

--- a/tests/keccak/test_keccak.nim
+++ b/tests/keccak/test_keccak.nim
@@ -59,7 +59,7 @@ func hashNimcrypto(data: openArray[byte]): array[32, byte] =
   c.update(data)
   c.finish().data
 
-proc hashStream(data: openArray[byte], chunks: openArray[int]): array[32, byte] =
+func hashStream(data: openArray[byte], chunks: openArray[int]): array[32, byte] =
   ## Feed `data` through the incremental context in the given chunk sizes.
   var
     ctx: keccak.Keccak256
@@ -74,7 +74,7 @@ proc hashStream(data: openArray[byte], chunks: openArray[int]): array[32, byte] 
     ctx.update(data.toOpenArray(pos, data.high))
   ctx.finish().data
 
-proc randomChunks(rng: var Rand, total: int): seq[int] =
+func randomChunks(rng: var Rand, total: int): seq[int] =
   ## A random partition of `total`, with zero-length updates mixed in - those
   ## must be no-ops.
   var remaining = total

--- a/tests/trie/testutils.nim
+++ b/tests/trie/testutils.nim
@@ -10,12 +10,12 @@ type
     key*: seq[byte]
     value*: seq[byte]
 
-proc randGen*[T](minVal, maxVal: T): RandGen[T] =
+func randGen*[T](minVal, maxVal: T): RandGen[T] =
   doAssert(minVal <= maxVal)
   result.minVal = minVal
   result.maxVal = maxVal
 
-proc randGen*[T](minMax: T): RandGen[T] =
+func randGen*[T](minMax: T): RandGen[T] =
   randGen(minMax, minMax)
 
 proc getVal*[T](x: RandGen[T]): T =
@@ -31,7 +31,7 @@ proc randBytes*(len: int): seq[byte] =
   result = newSeq[byte](len)
   discard randomBytes(result[0].addr, len)
 
-proc toBytesRange*(str: string): seq[byte] =
+func toBytesRange*(str: string): seq[byte] =
   var s: seq[byte]
   if str[0] == '0' and str[1] == 'x':
     s = fromHex(str.substr(2))
@@ -55,7 +55,7 @@ proc randList*(T: typedesc, strGen, listGen: RandGen, unique: bool = true): seq[
   let listLen = listGen.getVal()
   result = newSeqOfCap[T](listLen)
   if unique:
-    var set = initHashSet[T]()
+    var set: HashSet[T]
     for len in 0..<listLen:
       while true:
         let x = randPrimitives[T](strGen.getVal())

--- a/tools/dcli.nim
+++ b/tools/dcli.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025 Status Research & Development GmbH
+# Copyright (c) 2020-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -6,7 +6,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   std/[strutils, sets, sugar],
@@ -128,17 +128,17 @@ type
         desc: "Number of evenly distributed keys to generate"
         name: "n" .}: uint16
 
-proc parseCmdArg*(T: type enr.Record, p: string): T {.raises: [ValueError].} =
+func parseCmdArg*(T: type enr.Record, p: string): T {.raises: [ValueError].} =
   let res = enr.Record.fromURI(p)
   if res.isErr:
     raise newException(ValueError, "Invalid ENR:" & $res.error)
 
   res.value
 
-proc completeCmdArg*(T: type enr.Record, val: string): seq[string] =
-  return @[]
+func completeCmdArg*(T: type enr.Record, val: string): seq[string] =
+  @[]
 
-proc parseCmdArg*(T: type Node, p: string): T {.raises: [ValueError].} =
+func parseCmdArg*(T: type Node, p: string): T {.raises: [ValueError].} =
   let res = enr.Record.fromURI(p)
   if res.isErr:
     raise newException(ValueError, "Invalid ENR:" & $res.error)
@@ -149,17 +149,17 @@ proc parseCmdArg*(T: type Node, p: string): T {.raises: [ValueError].} =
 
   n
 
-proc completeCmdArg*(T: type Node, val: string): seq[string] =
-  return @[]
+func completeCmdArg*(T: type Node, val: string): seq[string] =
+  @[]
 
-proc parseCmdArg*(T: type PrivateKey, p: string): T {.raises: [ValueError].} =
+func parseCmdArg*(T: type PrivateKey, p: string): T {.raises: [ValueError].} =
   try:
     result = PrivateKey.fromHex(p).tryGet()
   except CatchableError:
     raise newException(ValueError, "Invalid private key")
 
-proc completeCmdArg*(T: type PrivateKey, val: string): seq[string] =
-  return @[]
+func completeCmdArg*(T: type PrivateKey, val: string): seq[string] =
+  @[]
 
 proc generateDistributedNetKeys(
     rng: var HmacDrbgContext, n: uint16
@@ -200,7 +200,7 @@ proc discover(
 ) {.async: (raises: [CancelledError]).} =
   info "Starting node discovery - storing nodes at: ", psFile
 
-  var seenNodes = initHashSet[NodeId]()
+  var seenNodes: HashSet[NodeId]
 
   let f =
     try:
@@ -437,7 +437,7 @@ proc run(config: DiscoveryConf) {.raises: [CatchableError].} =
 when isMainModule:
   {.pop.}
   let config = DiscoveryConf.load()
-  {.push raises: [].}
+  {.push raises: [], gcsafe.}
 
   setLogLevel(config.logLevel)
 


### PR DESCRIPTION
In addition:
- [`initTable()`](https://nim-lang.org/docs/tables.html#initTable) and [`initHashSet()`](https://nim-lang.org/docs/sets.html#initHashSet) are effectively deprecated when the initial sizes aren't overridden 
- `import "."/foo` isn't necessary in more modern Nim