### PR TITLE
enr: reject records with unsorted or duplicate keys

### DIFF
--- a/eth/enr/enr.nim
+++ b/eth/enr/enr.nim
@@ -492,9 +492,23 @@ func fromBytesAux(T: type Record, s: openArray[byte]): EnrResult[T] =
     pairs = newSeqOfCap[FieldPair](numPairs)
     id: string = ""
     pkRaw = Opt.none(seq[byte])
+    prevKey = ""
 
   for i in 0 ..< numPairs:
     let k = rlpResult rlp.read(string)
+    # The key:value pairs must be sorted by key and must be unique. `pairs` is
+    # documented to hold them that way and `insert` relies on it, so a record
+    # that breaks the ordering cannot be stored as it arrived. Reading on would
+    # also leave the record disagreeing with itself: the identity scheme and
+    # the public key below are taken from the last occurrence of a repeated
+    # key, while every `getField` lookup returns the first.
+    if i > 0:
+      if k == prevKey:
+        return err("Duplicate key in the ENR")
+      if k < prevKey:
+        return err("Key:value pairs in the ENR are not sorted")
+    prevKey = k
+
     case k
     of "id":
       id = rlpResult rlp.read(string)

--- a/tests/test_enr.nim
+++ b/tests/test_enr.nim
@@ -451,3 +451,26 @@ suite "ENR update tests":
         typedEnr.quic.get() == 9001
 
         r.seqNum == 5
+
+suite "ENR decode validation tests":
+  # EIP-778: "The key/value pairs must be sorted by key and must be unique."
+  # `initRecord` is deprecated because it neither sorts nor deduplicates its
+  # pairs, which is exactly what is needed here: a correctly signed record
+  # whose wire encoding breaks the ordering rules.
+  {.push warning[Deprecated]: off.}
+
+  test "Decode: unsorted key/value pairs":
+    let
+      pk = PrivateKey.random(rng[])
+      r = initRecord(1, pk, {"zzz": 1'u, "aaa": 2'u}).expect("valid record")
+
+    check Record.fromBytes(r.raw).isErr()
+
+  test "Decode: duplicate keys":
+    let
+      pk = PrivateKey.random(rng[])
+      r = initRecord(1, pk, {"aaa": 1'u, "aaa": 2'u}).expect("valid record")
+
+    check Record.fromBytes(r.raw).isErr()
+
+  {.pop.}


### PR DESCRIPTION
## Problem

[EIP-778](https://github.com/ethereum/devp2p/blob/master/enr.md#rlp-encoding) requires the key:value pairs of a record to be sorted by key and to be unique. `fromBytesAux` appends them in the order they arrive and checks neither rule, so a correctly signed record that breaks either one decodes successfully.

That leaves the decoded record contradicting itself, because the two halves of the parse disagree on which occurrence of a repeated key wins:

- the decode loop reads `id` and `secp256k1` as it goes, so it keeps the **last** occurrence — and that is what selects the identity scheme, gets signature-verified, and becomes `record.publicKey`, and so the node id;
- `getField` scans from the front and returns the **first** — and that is what `get`, `tryGet`, `get(PublicKey)` and `TypedRecord.fromRecord` all use.

A record carrying `secp256k1` twice is therefore signature-verified against, and takes its node id from, one key while `get(PublicKey)` hands out a different one that was never verified.

It also breaks the invariant `Record.pairs` documents for itself — "must remain sorted and without duplicate keys. Use the insert func to ensure this." Records arriving off the wire never go through `insert`, so that no longer holds, and `insert` in turn relies on it for its `lowerBound` call: a later `update` of such a record inserts at the wrong position.

## Fix

Reject both cases while decoding. go-ethereum enforces the same two rules in the equivalent loop in [`p2p/enr/enr.go`](https://github.com/ethereum/go-ethereum/blob/master/p2p/enr/enr.go), returning `errNotSorted` and `errDuplicateKey`. Without this, nim-eth accepts — and, because it re-broadcasts records by their raw bytes, propagates — records that spec-conformant clients drop.

## Compatibility

Records built here are unaffected: `Record.init` reaches `pairs` only through `insert`, which keeps them sorted and unique. The EIP-778 test vector and the discv5 packet/ENR test vectors all still decode.

## Tests

Two tests that fail without the change. They build their input with `initRecord`, which is deprecated precisely because it neither sorts nor deduplicates — exactly what is needed to produce a correctly signed record with a non-conformant encoding.

Locally, with the change: `tests/test_enr` 27 OK, `tests/p2p/all_tests` 98 OK, `tests/rlp/all_tests` 104 OK, `tests/test_enode` 2 OK — 0 failed.

Related to the decoding rework mentioned in #706, though that issue tracks duplicates arriving through the `extraFields` construction API rather than off the wire.
